### PR TITLE
Bump Confluent to 3.3.0-SNAPSHOT, Kafka to 0.10.3.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-s3</artifactId>
     <packaging>jar</packaging>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.3.0-SNAPSHOT</version>
     <name>kafka-connect-s3</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -51,8 +51,8 @@
     </scm>
 
     <properties>
-        <confluent.version>3.2.0-SNAPSHOT</confluent.version>
-        <kafka.version>0.10.2.0-SNAPSHOT</kafka.version>
+        <confluent.version>3.3.0-SNAPSHOT</confluent.version>
+        <kafka.version>0.10.3.0-SNAPSHOT</kafka.version>
         <aws.version>1.11.68</aws.version>
         <junit.version>4.12</junit.version>
         <easymock.version>3.4</easymock.version>


### PR DESCRIPTION
Since 3.2.x existed, I'm first bumping up the version here, and then I'll merge 3.2.x to master to get a hold of the process. 