### PR TITLE
HOTFIX: S3SinkConnector should extend SinkConnector

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnector.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnector.java
@@ -17,8 +17,8 @@
 package io.confluent.connect.s3;
 
 import org.apache.kafka.common.config.ConfigDef;
-import org.apache.kafka.connect.connector.Connector;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.sink.SinkConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +32,7 @@ import io.confluent.connect.s3.util.Version;
 /**
  * Connector class for Amazon Simple Storage Service (S3).
  */
-public class S3SinkConnector extends Connector {
+public class S3SinkConnector extends SinkConnector {
   private static final Logger log = LoggerFactory.getLogger(S3SinkConnector.class);
   private Map<String, String> configProps;
   private S3SinkConnectorConfig config;

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorTest.java
@@ -16,9 +16,12 @@
 
 package io.confluent.connect.s3;
 
+import org.apache.kafka.connect.connector.Connector;
+import org.apache.kafka.connect.sink.SinkConnector;
 import org.junit.Test;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 
 public class S3SinkConnectorTest {
@@ -30,5 +33,10 @@ public class S3SinkConnectorTest {
     assertFalse(version.isEmpty());
   }
 
+  @Test
+  public void connectorType() {
+    Connector connector = new S3SinkConnector();
+    assertTrue(SinkConnector.class.isAssignableFrom(connector.getClass()));
+  }
 }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.s3;
 
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTask;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -65,6 +66,14 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
   public void tearDown() throws Exception {
     super.tearDown();
     localProps.clear();
+  }
+
+  @Test
+  public void testTaskType() throws Exception {
+    setUp();
+    replayAll();
+    task = new S3SinkTask();
+    SinkTask.class.isAssignableFrom(task.getClass());
   }
 
   @Test


### PR DESCRIPTION
  * Needed by the framework for better management of the connector.
  * Fixes CC-537: S3SinkConnector needs to extend SinkConnector for runtime class resolution