### PR TITLE
Add ByteArrayFormat

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -188,14 +188,15 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
                         "S3 Part Upload Retries");
 
       CONFIG_DEF.define(FORMAT_BYTEARRAY_EXTENSION_CONFIG,
-          Type.STRING,
-          FORMAT_BYTEARRAY_EXTENSION_DEFAULT,
-          Importance.LOW,
-          "Output file extension for ByteArrayFormat. Defaults to '.bin'",
-          group,
-          ++orderInGroup,
-          Width.LONG,
-          "Output file extension for ByteArrayFormat");
+                        Type.STRING,
+                        FORMAT_BYTEARRAY_EXTENSION_DEFAULT,
+                        Importance.LOW,
+                        String.format("Output file extension for ByteArrayFormat. Defaults to '%s'",
+                            FORMAT_BYTEARRAY_EXTENSION_DEFAULT),
+                        group,
+                        ++orderInGroup,
+                        Width.LONG,
+                        "Output file extension for ByteArrayFormat");
     }
   }
 
@@ -263,7 +264,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     return getInt(S3_PART_RETRIES_CONFIG);
   }
 
-  public String getFormatBytearrayExtension() {
+  public String getByteArrayExtension() {
     return getString(FORMAT_BYTEARRAY_EXTENSION_CONFIG);
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -74,6 +74,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String S3_PART_RETRIES_CONFIG = "s3.part.retries";
   public static final int S3_PART_RETRIES_DEFAULT = 3;
 
+  public static final String FORMAT_BYTEARRAY_EXTENSION_CONFIG = "format.bytearray.extension";
+  public static final String FORMAT_BYTEARRAY_EXTENSION_DEFAULT = ".bin";
+
   private final String name;
 
   private final StorageCommonConfig commonConfig;
@@ -183,6 +186,16 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
                         ++orderInGroup,
                         Width.LONG,
                         "S3 Part Upload Retries");
+
+      CONFIG_DEF.define(FORMAT_BYTEARRAY_EXTENSION_CONFIG,
+          Type.STRING,
+          FORMAT_BYTEARRAY_EXTENSION_DEFAULT,
+          Importance.LOW,
+          "Output file extension for ByteArrayFormat. Defaults to '.bin'",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "Output file extension for ByteArrayFormat");
     }
   }
 
@@ -248,6 +261,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public int getS3PartRetries() {
     return getInt(S3_PART_RETRIES_CONFIG);
+  }
+
+  public String getFormatBytearrayExtension() {
+    return getString(FORMAT_BYTEARRAY_EXTENSION_CONFIG);
   }
 
   protected static String parseName(Map<String, String> props) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -21,6 +21,7 @@ import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.ConfigDef.Importance;
@@ -76,6 +77,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String FORMAT_BYTEARRAY_EXTENSION_CONFIG = "format.bytearray.extension";
   public static final String FORMAT_BYTEARRAY_EXTENSION_DEFAULT = ".bin";
+
+  public static final String FORMAT_BYTEARRAY_LINE_SEPARATOR_CONFIG = "format.bytearray.separator";
+  public static final String FORMAT_BYTEARRAY_LINE_SEPARATOR_DEFAULT =
+      StringEscapeUtils.escapeJava(System.lineSeparator());
 
   private final String name;
 
@@ -197,6 +202,20 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
                         ++orderInGroup,
                         Width.LONG,
                         "Output file extension for ByteArrayFormat");
+
+      CONFIG_DEF.define(FORMAT_BYTEARRAY_LINE_SEPARATOR_CONFIG,
+                        Type.STRING,
+                        FORMAT_BYTEARRAY_LINE_SEPARATOR_DEFAULT,
+                        Importance.LOW,
+                        "String inserted between records for ByteArrayFormat. "
+                        + "Defaults to 'System.lineSeparator()' "
+                        + "and may contain escape sequences like '\\n'. "
+                        + "An input record that contains the line separator will look like "
+                        + "multiple records in the output S3 object.",
+                        group,
+                        ++orderInGroup,
+                        Width.LONG,
+                        "Line separator ByteArrayFormat");
     }
   }
 
@@ -266,6 +285,11 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public String getByteArrayExtension() {
     return getString(FORMAT_BYTEARRAY_EXTENSION_CONFIG);
+  }
+
+  public String getFormatByteArrayLineSeparator() {
+    String raw = getString(FORMAT_BYTEARRAY_LINE_SEPARATOR_CONFIG);
+    return StringEscapeUtils.unescapeJava(raw);
   }
 
   protected static String parseName(Map<String, String> props) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayFormat.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayFormat.java
@@ -50,7 +50,8 @@ public class ByteArrayFormat implements Format<S3SinkConnectorConfig, String> {
 
   @Override
   public HiveFactory getHiveFactory() {
-    throw new UnsupportedOperationException("Hive integration is not currently supported in S3 Connector");
+    throw new UnsupportedOperationException(
+        "Hive integration is not currently supported in S3 Connector");
   }
 
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayFormat.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayFormat.java
@@ -35,9 +35,6 @@ public class ByteArrayFormat implements Format<S3SinkConnectorConfig, String> {
     this.storage = storage;
     this.converter = new ByteArrayConverter();
     Map<String, Object> converterConfig = new HashMap<>();
-    converterConfig.put("schemas.enable", "false");
-    converterConfig.put("schemas.cache.size",
-        String.valueOf(storage.conf().get(S3SinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG)));
     this.converter.configure(converterConfig, false);
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayFormat.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayFormat.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3.format.bytearray;
+
+import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.storage.format.Format;
+import io.confluent.connect.storage.format.RecordWriterProvider;
+import io.confluent.connect.storage.format.SchemaFileReader;
+import io.confluent.connect.storage.hive.HiveFactory;
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ByteArrayFormat implements Format<S3SinkConnectorConfig, String> {
+  private final S3Storage storage;
+  private final ByteArrayConverter converter;
+
+  public ByteArrayFormat(S3Storage storage) {
+    this.storage = storage;
+    this.converter = new ByteArrayConverter();
+    Map<String, Object> converterConfig = new HashMap<>();
+    converterConfig.put("schemas.enable", "false");
+    converterConfig.put("schemas.cache.size",
+        String.valueOf(storage.conf().get(S3SinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG)));
+    this.converter.configure(converterConfig, false);
+  }
+
+  @Override
+  public RecordWriterProvider<S3SinkConnectorConfig> getRecordWriterProvider() {
+    return new ByteArrayRecordWriterProvider(storage, converter);
+  }
+
+  @Override
+  public SchemaFileReader<S3SinkConnectorConfig, String> getSchemaFileReader() {
+    throw new UnsupportedOperationException("Reading schemas from S3 is not currently supported");
+  }
+
+  @Override
+  public HiveFactory getHiveFactory() {
+    throw new UnsupportedOperationException("Hive integration is not currently supported in S3 Connector");
+  }
+
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -29,23 +29,26 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3SinkConnectorConfig> {
 
   private static final Logger log = LoggerFactory.getLogger(ByteArrayRecordWriterProvider.class);
-  private static final String EXTENSION = ".out";
-  private static final byte[] LINE_SEPARATOR_BYTES = System.lineSeparator().getBytes();
   private final S3Storage storage;
   private final ByteArrayConverter converter;
+  private final String extension;
+  private final byte[] lineSeparatorBytes;
 
   ByteArrayRecordWriterProvider(S3Storage storage, ByteArrayConverter converter) {
     this.storage = storage;
     this.converter = converter;
+    this.extension = storage.conf().getByteArrayExtension();
+    this.lineSeparatorBytes = storage.conf().getFormatByteArrayLineSeparator().getBytes();
   }
 
   @Override
   public String getExtension() {
-    return storage.conf().getByteArrayExtension();
+    return extension;
   }
 
   @Override
@@ -60,7 +63,7 @@ public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3Sin
           byte[] bytes = converter.fromConnectData(
               record.topic(), record.valueSchema(), record.value());
           s3out.write(bytes);
-          s3out.write(LINE_SEPARATOR_BYTES);
+          s3out.write(lineSeparatorBytes);
         } catch (IOException | DataException e) {
           throw new ConnectException(e);
         }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -34,8 +34,7 @@ public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3Sin
 
   private static final Logger log = LoggerFactory.getLogger(ByteArrayRecordWriterProvider.class);
   private static final String EXTENSION = ".out";
-  private static final String LINE_SEPARATOR = System.lineSeparator();
-  private static final byte[] LINE_SEPARATOR_BYTES = LINE_SEPARATOR.getBytes();
+  private static final byte[] LINE_SEPARATOR_BYTES = System.lineSeparator().getBytes();
   private final S3Storage storage;
   private final ByteArrayConverter converter;
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -45,7 +45,7 @@ public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3Sin
 
   @Override
   public String getExtension() {
-    return EXTENSION;
+    return storage.conf().getByteArrayExtension();
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3.format.bytearray;
+
+import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.s3.storage.S3OutputStream;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.storage.format.RecordWriter;
+import io.confluent.connect.storage.format.RecordWriterProvider;
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3SinkConnectorConfig> {
+
+  private static final Logger log = LoggerFactory.getLogger(ByteArrayRecordWriterProvider.class);
+  private static final String EXTENSION = ".out";
+  private static final String LINE_SEPARATOR = System.lineSeparator();
+  private static final byte[] LINE_SEPARATOR_BYTES = LINE_SEPARATOR.getBytes();
+  private final S3Storage storage;
+  private final ByteArrayConverter converter;
+
+  ByteArrayRecordWriterProvider(S3Storage storage, ByteArrayConverter converter) {
+    this.storage = storage;
+    this.converter = converter;
+  }
+
+  @Override
+  public String getExtension() {
+    return EXTENSION;
+  }
+
+  @Override
+  public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
+    return new RecordWriter() {
+      final S3OutputStream s3out = storage.create(filename, true);
+
+      @Override
+      public void write(SinkRecord record) {
+        log.trace("Sink record: {}", record);
+        try {
+          byte[] bytes = converter.fromConnectData(
+              record.topic(), record.valueSchema(), record.value());
+          s3out.write(bytes);
+          s3out.write(LINE_SEPARATOR_BYTES);
+        } catch (IOException | DataException e) {
+          throw new ConnectException(e);
+        }
+      }
+
+      @Override
+      public void commit() {
+        try {
+          s3out.commit();
+        } catch (IOException e) {
+          throw new ConnectException(e);
+        }
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.s3.util.FileUtils;
+import io.confluent.connect.storage.partitioner.DefaultPartitioner;
+import io.confluent.connect.storage.partitioner.Partitioner;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class DataWriterByteArrayTest extends TestWithMockedS3 {
+
+  private static final String ZERO_PAD_FMT = "%010d";
+  private ByteArrayConverter converter;
+
+  protected S3Storage storage;
+  protected AmazonS3 s3;
+  protected Partitioner<FieldSchema> partitioner;
+  protected ByteArrayFormat format;
+  protected S3SinkTask task;
+  protected Map<String, String> localProps = new HashMap<>();
+
+  @Override
+  protected Map<String, String> createProps() {
+    Map<String, String> props = super.createProps();
+    props.putAll(localProps);
+    return props;
+  }
+
+  //@Before should be omitted in order to be able to add properties per test.
+  public void setUp() throws Exception {
+    super.setUp();
+    converter = new ByteArrayConverter();
+
+    s3 = newS3Client(connectorConfig);
+    storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3);
+
+    partitioner = new DefaultPartitioner<>();
+    partitioner.configure(parsedConfig);
+    format = new ByteArrayFormat(storage);
+    s3.createBucket(S3_TEST_BUCKET_NAME);
+    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+    localProps.clear();
+  }
+
+  @Test
+  public void testNoSchema() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
+    setUp();
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+
+    List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
+    task.put(sinkRecords);
+    task.close(context.assignment());
+    task.stop();
+
+    long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets, context.assignment(), ".bin");
+  }
+
+  @Test
+  public void testCustomExtensionAndLineSeparator() throws Exception {
+    String extension = ".SEPARATORjson";
+    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
+    localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_LINE_SEPARATOR_CONFIG, "SEPARATOR");
+    localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_EXTENSION_CONFIG, extension);
+    setUp();
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+
+    List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
+    task.put(sinkRecords);
+    task.close(context.assignment());
+    task.stop();
+
+    long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets, context.assignment(), extension);
+  }
+
+  protected List<SinkRecord> createByteArrayRecordsWithoutSchema(int size, long startOffset, Set<TopicPartition> partitions) {
+    String key = "key";
+    int ibase = 12;
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = startOffset, total = 0; total < size; ++offset) {
+      for (TopicPartition tp : partitions) {
+        byte[] record = ("{\"schema\":{\"type\":\"struct\",\"fields\":[ " +
+                            "{\"type\":\"boolean\",\"optional\":true,\"field\":\"booleanField\"}," +
+                            "{\"type\":\"int32\",\"optional\":true,\"field\":\"intField\"}," +
+                            "{\"type\":\"int64\",\"optional\":true,\"field\":\"longField\"}," +
+                            "{\"type\":\"string\",\"optional\":false,\"field\":\"stringField\"}]," +
+                            "\"payload\":" +
+                            "{\"booleanField\":\"true\"," +
+                            "\"intField\":" + String.valueOf(ibase) + "," +
+                            "\"longField\":" + String.valueOf((long) ibase) + "," +
+                            "\"stringField\":str" + String.valueOf(ibase) +
+                            "}}").getBytes();
+        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), null, key, null, record, offset));
+        if (++total >= size) {
+          break;
+        }
+      }
+    }
+    return sinkRecords;
+  }
+
+  protected String getDirectory(String topic, int partition) {
+    String encodedPartition = "partition=" + String.valueOf(partition);
+    return partitioner.generatePartitionedPath(topic, encodedPartition);
+  }
+
+  protected List<String> getExpectedFiles(long[] validOffsets, TopicPartition tp, String extension) {
+    List<String> expectedFiles = new ArrayList<>();
+    for (int i = 1; i < validOffsets.length; ++i) {
+      long startOffset = validOffsets[i - 1];
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset,
+                                                  extension, ZERO_PAD_FMT));
+    }
+    return expectedFiles;
+  }
+
+  protected void verifyFileListing(long[] validOffsets, Set<TopicPartition> partitions, String extension) throws IOException {
+    List<String> expectedFiles = new ArrayList<>();
+    for (TopicPartition tp : partitions) {
+      expectedFiles.addAll(getExpectedFiles(validOffsets, tp, extension));
+    }
+    verifyFileListing(expectedFiles);
+  }
+
+  protected void verifyFileListing(List<String> expectedFiles) throws IOException {
+    List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
+    List<String> actualFiles = new ArrayList<>();
+    for (S3ObjectSummary summary : summaries) {
+      String fileKey = summary.getKey();
+      actualFiles.add(fileKey);
+    }
+
+    Collections.sort(actualFiles);
+    Collections.sort(expectedFiles);
+    assertThat(actualFiles, is(expectedFiles));
+  }
+
+  protected void verifyContents(List<SinkRecord> expectedRecords, int startIndex, Collection<Object> records)
+      throws IOException{
+    for (Object record : records) {
+      byte[] bytes = (byte[]) record;
+      SinkRecord expectedRecord = expectedRecords.get(startIndex++);
+      byte[] expectedBytes = (byte[]) expectedRecord.value();
+      assertArrayEquals(expectedBytes, bytes);
+    }
+  }
+
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,
+                        String extension) throws IOException {
+    verify(sinkRecords, validOffsets, partitions, extension, false);
+  }
+
+  /**
+   * Verify files and records are uploaded appropriately.
+   * @param sinkRecords a flat list of the records that need to appear in potentially several files in S3.
+   * @param validOffsets an array containing the offsets that map to uploaded files for a topic-partition.
+   *                     Offsets appear in ascending order, the difference between two consecutive offsets
+   *                     equals the expected size of the file, and last offset in exclusive.
+   * @throws IOException
+   */
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,
+                        String extension, boolean skipFileListing)
+      throws IOException {
+    if (!skipFileListing) {
+      verifyFileListing(validOffsets, partitions, extension);
+    }
+
+    for (TopicPartition tp : partitions) {
+      for (int i = 1, j = 0; i < validOffsets.length; ++i) {
+        long startOffset = validOffsets[i - 1];
+        long size = validOffsets[i] - startOffset;
+
+        FileUtils.fileKeyToCommit(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset, extension, ZERO_PAD_FMT);
+        Collection<Object> records = readRecords(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset,
+                                                 extension, ZERO_PAD_FMT, S3_TEST_BUCKET_NAME, s3);
+        // assertEquals(size, records.size());
+        verifyContents(sinkRecords, j, records);
+        j += size;
+      }
+    }
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
@@ -26,7 +26,6 @@ import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.findify.s3mock.S3Mock;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.After;
 import org.junit.Rule;
@@ -117,7 +116,7 @@ public class TestWithMockedS3 extends S3SinkConnectorTestBase {
         return readRecordsJson(bucketName, fileKey, s3);
       } else if (".bin".equals(extension)) {
         return readRecordsByteArray(bucketName, fileKey, s3,
-            StringEscapeUtils.unescapeJava(S3SinkConnectorConfig.FORMAT_BYTEARRAY_LINE_SEPARATOR_DEFAULT).getBytes());
+            S3SinkConnectorConfig.FORMAT_BYTEARRAY_LINE_SEPARATOR_DEFAULT.getBytes());
       } else if (".SEPARATORjson".equals(extension)) {
         return readRecordsByteArray(bucketName, fileKey, s3, "SEPARATOR".getBytes());
       } else {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/bytearray/ByteArrayUtils.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/bytearray/ByteArrayUtils.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package  io.confluent.connect.s3.format.bytearray;
+
+import org.apache.commons.io.IOUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+public class ByteArrayUtils {
+  public static Collection<Object> getRecords(InputStream in, byte[] lineSeparatorBytes) throws IOException {
+    byte[] bytes = IOUtils.toByteArray(in);
+    return splitLines(lineSeparatorBytes, bytes);
+  }
+
+  private static boolean isMatch(byte[] lineSeparatorBytes, byte[] input, int pos) {
+    for (int i = 0; i < lineSeparatorBytes.length; i++) {
+      if (lineSeparatorBytes[i] != input[pos+i]) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Collection<Object> splitLines(byte[] lineSeparatorBytes, byte[] input) {
+    List<Object> records = new ArrayList<>();
+    int lineStart = 0;
+    for (int i = 0; i < input.length; i++) {
+      if (isMatch(lineSeparatorBytes, input, i)) {
+        records.add(Arrays.copyOfRange(input, lineStart, i));
+        lineStart = i + lineSeparatorBytes.length;
+        i = lineStart;
+      }
+    }
+    if (lineStart != input.length) {
+      records.add(Arrays.copyOfRange(input, lineStart, input.length));
+    }
+    return records;
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
+            <artifactId>connect-runtime</artifactId>
+            <version>${kafka.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
             <artifactId>connect-json</artifactId>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
As @kkonstantine suggested in https://github.com/confluentinc/kafka-connect-storage-cloud/issues/22#issuecomment-287885581, availability of `ByteArrayConverter` since 0.11.0.0 allows us to skip parsing of message values completely and write them as is.

This PR adds a `ByteArrayFormat` and `ByteArrayRecordWriterProvider` to wrap the new converter.

I've marked this WIP as I'd like to gather some feedback about whether there are other potential approaches and whether there are additional options we'd need to see for this to be mergeable.