### PR TITLE
Add s3.canned.acl config

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -22,6 +22,7 @@ import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressListener;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -54,6 +55,7 @@ public class S3OutputStream extends OutputStream {
   private final String ssea;
   private final ProgressListener progressListener;
   private final int partSize;
+  private final CannedAccessControlList cannedAcl;
   private boolean closed;
   private ByteBuffer buffer;
   private MultipartUpload multiPartUpload;
@@ -65,6 +67,7 @@ public class S3OutputStream extends OutputStream {
     this.key = key;
     this.ssea = conf.getSsea();
     this.partSize = conf.getPartSize();
+    this.cannedAcl = conf.getCannedAcl();
     this.closed = false;
     this.retries = conf.getS3PartRetries();
     this.buffer = ByteBuffer.allocate(this.partSize);
@@ -183,7 +186,8 @@ public class S3OutputStream extends OutputStream {
         bucket,
         key,
         newObjectMetadata()
-    );
+    ).withCannedACL(cannedAcl);
+
     try {
       return new MultipartUpload(s3.initiateMultipartUpload(initRequest).getUploadId());
     } catch (AmazonClientException e) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.s3;
 
 import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import com.amazonaws.services.s3.model.UploadPartResult;
 import io.confluent.connect.avro.AvroData;
@@ -229,5 +230,16 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
           map.containsKey("custom.partitioner.config"));
     }
   }
+
+  @Test
+  public void testAclCannedConfig() throws Exception {
+    localProps.put(S3SinkConnectorConfig.ACL_CANNED_CONFIG, CannedAccessControlList.BucketOwnerFullControl.toString());
+    setUp();
+    replayAll();
+    task = new S3SinkTask();
+    task.initialize(context);
+    task.start(properties);
+  }
+
 }
 


### PR DESCRIPTION
This option is helpful for writing cross account.

In our use case, our Kafka Connect instance runs in a separate account from where our destination S3 buckets live. We want to be able to specify `BucketOwnerFullControl` so that the destination account has read and write access to the objects Kafka Connect is writing. The default `Private` acl allows access only from the account that originally wrote the data.