### PR TITLE
Allow S3OutputStream to commit as part of close()

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -85,10 +85,7 @@ public class AvroRecordWriterProvider implements RecordWriterProvider<S3SinkConn
       @Override
       public void commit() {
         try {
-          // Flush is required here, because closing the writer will close the underlying S3
-          // output stream before committing any data to S3.
-          writer.flush();
-          s3out.commit();
+          s3out.enableCommitOnClose();
           writer.close();
         } catch (IOException e) {
           throw new ConnectException(e);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -89,10 +89,7 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConn
         @Override
         public void commit() {
           try {
-            // Flush is required here, because closing the writer will close the underlying S3
-            // output stream before committing any data to S3.
-            writer.flush();
-            s3out.commit();
+            s3out.enableCommitOnClose();
             writer.close();
           } catch (IOException e) {
             throw new ConnectException(e);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -40,6 +40,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Output stream enabling multi-part uploads of Kafka records.
@@ -58,6 +59,7 @@ public class S3OutputStream extends OutputStream {
   private ByteBuffer buffer;
   private MultipartUpload multiPartUpload;
   private final int retries;
+  private final AtomicBoolean commitOnCloseEnabled = new AtomicBoolean(false);
 
   public S3OutputStream(String key, S3SinkConnectorConfig conf, AmazonS3 s3) {
     this.s3 = s3;
@@ -131,29 +133,14 @@ public class S3OutputStream extends OutputStream {
     }
   }
 
-  public void commit() throws IOException {
-    if (closed) {
-      log.warn(
-          "Tried to commit data for bucket '{}' key '{}' on a closed stream. Ignoring.",
-          bucket,
-          key
-      );
-      return;
-    }
-
-    try {
-      if (buffer.hasRemaining()) {
-        uploadPart(buffer.position());
-      }
-      multiPartUpload.complete();
-      log.debug("Upload complete for bucket '{}' key '{}'", bucket, key);
-    } catch (Exception e) {
-      log.error("Multipart upload failed to complete for bucket '{}' key '{}'", bucket, key);
-      throw new DataException("Multipart upload failed to complete.", e);
-    } finally {
-      buffer.clear();
-      multiPartUpload = null;
-      close();
+  /**
+   * Until this method is called, the close() method will abort the multiplart upload.
+   * Should be called immediately before closing this stream and any wrappers.
+   */
+  public void enableCommitOnClose() {
+    boolean enabled = commitOnCloseEnabled.compareAndSet(false, true);
+    if (!enabled) {
+      log.warn("The stream was already enabled to commit on close(). Ignoring.");
     }
   }
 
@@ -163,9 +150,26 @@ public class S3OutputStream extends OutputStream {
       return;
     }
     closed = true;
-    if (multiPartUpload != null) {
-      multiPartUpload.abort();
-      log.debug("Multipart upload aborted for bucket '{}' key '{}'.", bucket, key);
+
+    if (commitOnCloseEnabled.get()) {
+      try {
+        if (buffer.hasRemaining()) {
+          uploadPart(buffer.position());
+        }
+        multiPartUpload.complete();
+        log.debug("Upload complete for bucket '{}' key '{}'", bucket, key);
+      } catch (Exception e) {
+        log.error("Multipart upload failed to complete for bucket '{}' key '{}'", bucket, key);
+        throw new DataException("Multipart upload failed to complete.", e);
+      } finally {
+        buffer.clear();
+        multiPartUpload = null;
+      }
+    } else {
+      if (multiPartUpload != null) {
+        multiPartUpload.abort();
+        log.debug("Multipart upload aborted for bucket '{}' key '{}'.", bucket, key);
+      }
     }
     super.close();
   }


### PR DESCRIPTION
The existing RecordWriterProvider classes in this project need to be
careful to flush their writers before calling commit() on the
S3OutputStream and include comments warning about this need.

This PR moves the commit logic directly into the close() method
so that closing a wrapper can more elegantly initiate the multipart
upload.

I'm particularly interested in this change as it paves the way
for an elegant implementation of compression in this project.
In particular, the current implementation makes it necessary to
call GZIPOutputStream.finish() before closing, which is a method
specific to DeflatorOutputStream. If commit can happen inside close(),
then we can handle compressors more generically via the OutputStream
interface.

For review, I'm looking for feedback about whether this approach actually seems like an improvement or if it could cause problems that I'm not anticipating. I will admit that I don't have deep experience with Java I/O streams and documentation on expected usage is a bit slim. I'm inferring, though, that it's generally expected that wrappers should allow flushing and closing to cascade down to the streams they wrap.