### PR TITLE
Add gzip compression support for json and byte array formats

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -41,6 +41,7 @@ import java.util.Set;
 
 import io.confluent.connect.s3.format.avro.AvroFormat;
 import io.confluent.connect.s3.format.json.JsonFormat;
+import io.confluent.connect.s3.storage.CompressionType;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.StorageSinkConnectorConfig;
 import io.confluent.connect.storage.common.ComposableConfig;
@@ -78,6 +79,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String ACL_CANNED_CONFIG = "s3.acl.canned";
   public static final String ACL_CANNED_DEFAULT = null;
+
+  public static final String COMPRESSION_TYPE_CONFIG = "s3.compression.type";
+  public static final String COMPRESSION_TYPE_DEFAULT = "none";
 
   public static final String S3_PART_RETRIES_CONFIG = "s3.part.retries";
   public static final int S3_PART_RETRIES_DEFAULT = 3;
@@ -228,6 +232,21 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.LONG,
           "S3 accelerated endpoint enabled"
+      );
+
+      configDef.define(
+          COMPRESSION_TYPE_CONFIG,
+          Type.STRING,
+          COMPRESSION_TYPE_DEFAULT,
+          new CompressionTypeValidator(),
+          Importance.LOW,
+          "Compression type for file written to S3. "
+          + "Applied when using JsonFormat or ByteArrayFormat. "
+          + "Available values: none, gzip.",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "Compression type"
       );
 
       configDef.define(
@@ -385,6 +404,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     }
   }
 
+  public CompressionType getCompressionType() {
+    return CompressionType.forName(getString(COMPRESSION_TYPE_CONFIG));
+  }
+
   public int getS3PartRetries() {
     return getInt(S3_PART_RETRIES_CONFIG);
   }
@@ -489,6 +512,33 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     @Override
     public String toString() {
       return "[" + Utils.join(RegionUtils.getRegions(), ", ") + "]";
+    }
+  }
+
+  private static class CompressionTypeValidator implements ConfigDef.Validator {
+    public static final Map<String, CompressionType> TYPES_BY_NAME = new HashMap<>();
+    public static final String ALLOWED_VALUES;
+
+    static {
+      List<String> names = new ArrayList<>();
+      for (CompressionType compressionType : CompressionType.values()) {
+        TYPES_BY_NAME.put(compressionType.name, compressionType);
+        names.add(compressionType.name);
+      }
+      ALLOWED_VALUES = Utils.join(names, ", ");
+    }
+
+    @Override
+    public void ensureValid(String name, Object compressionType) {
+      String compressionTypeString = ((String) compressionType).trim();
+      if (!TYPES_BY_NAME.containsKey(compressionTypeString)) {
+        throw new ConfigException(name, compressionType, "Value must be one of: " + ALLOWED_VALUES);
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "[" + ALLOWED_VALUES + "]";
     }
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
@@ -53,7 +54,7 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConn
 
   @Override
   public String getExtension() {
-    return EXTENSION;
+    return EXTENSION + storage.conf().getCompressionType().extension;
   }
 
   @Override
@@ -61,8 +62,9 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConn
     try {
       return new RecordWriter() {
         final S3OutputStream s3out = storage.create(filename, true);
+        final OutputStream s3outWrapper = s3out.wrapForCompression();
         final JsonGenerator writer = mapper.getFactory()
-                                         .createGenerator(s3out)
+                                         .createGenerator(s3outWrapper)
                                          .setRootValueSeparator(null);
 
         @Override
@@ -76,8 +78,8 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConn
                   record.valueSchema(),
                   value
               );
-              s3out.write(rawJson);
-              s3out.write(LINE_SEPARATOR_BYTES);
+              s3outWrapper.write(rawJson);
+              s3outWrapper.write(LINE_SEPARATOR_BYTES);
             } else {
               writer.writeObject(value);
               writer.writeRaw(LINE_SEPARATOR);
@@ -94,7 +96,7 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConn
             // output stream before committing any data to S3.
             writer.flush();
             s3out.commit();
-            writer.close();
+            s3outWrapper.close();
           } catch (IOException e) {
             throw new ConnectException(e);
           }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/CompressionType.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/CompressionType.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3.storage;
+
+import org.apache.kafka.connect.errors.ConnectException;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.DeflaterOutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+/**
+ * Supported compression types for formats lacking built-in compression.
+ *
+ * <p>In particular, the compression here is not used for Avro since the
+ * Avro libraries have compression codecs built in.
+ *
+ * <p>Closely modeled on {@link org.apache.kafka.common.record.CompressionType}.</p>
+ */
+public enum CompressionType {
+
+  NONE("none", ""),
+
+  GZIP("gzip", ".gz") {
+    @Override
+    public OutputStream wrapForOutput(OutputStream out) {
+      try {
+        return new GZIPOutputStream(out, GZIP_BUFFER_SIZE_BYTES);
+      } catch (Exception e) {
+        throw new ConnectException(e);
+      }
+    }
+
+    @Override
+    public InputStream wrapForInput(InputStream in) {
+      try {
+        return new GZIPInputStream(in);
+      } catch (Exception e) {
+        throw new ConnectException(e);
+      }
+    }
+
+    @Override
+    public void finalize(OutputStream compressionFilter) {
+      if (compressionFilter instanceof DeflaterOutputStream) {
+        try {
+          ((DeflaterOutputStream) compressionFilter).finish();
+        } catch (Exception e) {
+          throw new ConnectException(e);
+        }
+      } else {
+        throw new ConnectException("Expected compressionFilter to be a DeflatorOutputStream, "
+            + "but was passed an instance that does not match that type.");
+      }
+    }
+  };
+
+  private static final int GZIP_BUFFER_SIZE_BYTES = 8 * 1024;
+
+  public final String name;
+  public final String extension;
+
+  CompressionType(String name, String extension) {
+    this.name = name;
+    this.extension = extension;
+  }
+
+  /**
+   * Return the {@link CompressionType} with given {@code name}.
+   *
+   * @param name a lowercase compression type name
+   * @return a {@link CompressionType} with the given name
+   */
+  public static CompressionType forName(String name) {
+    if (NONE.name.equals(name)) {
+      return NONE;
+    } else if (GZIP.name.equals(name)) {
+      return GZIP;
+    } else {
+      throw new IllegalArgumentException("Unknown compression name: " + name);
+    }
+  }
+
+  /**
+   * Wrap {@code out} with a filter that will compress data with this CompressionType.
+   *
+   * @param out the {@link OutputStream} to wrap
+   * @return a wrapped version of {@code out} that will apply compression
+   */
+  public OutputStream wrapForOutput(OutputStream out) {
+    return out;
+  }
+
+  /**
+   * Wrap {@code in} with a filter that will decompress data with this CompressionType.
+   *
+   * @param in the {@link InputStream} to wrap
+   * @return a wrapped version of {@code in} that will apply decompression
+   */
+  public InputStream wrapForInput(InputStream in) {
+    return in;
+  }
+
+  /**
+   * Take any action necessary to finalize filter before the underlying
+   * S3OutputStream is committed.
+   *
+   * <p>Implementations of this method should make sure to handle the case
+   * where {@code compressionFilter} is null.
+   *
+   * @param compressionFilter a wrapped {@link OutputStream}
+   */
+  public void finalize(OutputStream compressionFilter) {}
+
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -60,6 +60,8 @@ public class S3OutputStream extends OutputStream {
   private ByteBuffer buffer;
   private MultipartUpload multiPartUpload;
   private final int retries;
+  private final CompressionType compressionType;
+  private volatile OutputStream compressionFilter;
 
   public S3OutputStream(String key, S3SinkConnectorConfig conf, AmazonS3 s3) {
     this.s3 = s3;
@@ -73,6 +75,7 @@ public class S3OutputStream extends OutputStream {
     this.buffer = ByteBuffer.allocate(this.partSize);
     this.progressListener = new ConnectProgressListener();
     this.multiPartUpload = null;
+    this.compressionType = conf.getCompressionType();
     log.debug("Create S3OutputStream for bucket '{}' key '{}'", bucket, key);
   }
 
@@ -145,6 +148,7 @@ public class S3OutputStream extends OutputStream {
     }
 
     try {
+      compressionType.finalize(compressionFilter);
       if (buffer.hasRemaining()) {
         uploadPart(buffer.position());
       }
@@ -278,6 +282,14 @@ public class S3OutputStream extends OutputStream {
         log.warn("Unable to abort multipart upload, you may need to purge uploaded parts: ", e);
       }
     }
+  }
+
+  public OutputStream wrapForCompression() {
+    if (compressionFilter == null) {
+      // Initialize compressionFilter the first time this method is called.
+      compressionFilter = compressionType.wrapForOutput(this);
+    }
+    return compressionFilter;
   }
 
   // Dummy listener for now, just logs the event progress.

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
@@ -19,6 +19,7 @@ package io.confluent.connect.s3;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
+import io.confluent.connect.s3.storage.CompressionType;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.s3.util.FileUtils;
 import io.confluent.connect.storage.partitioner.DefaultPartitioner;
@@ -101,8 +102,25 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
   }
 
   @Test
+  public void testGzipCompression() throws Exception {
+    CompressionType compressionType = CompressionType.GZIP;
+    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
+    localProps.put(S3SinkConnectorConfig.COMPRESSION_TYPE_CONFIG, compressionType.name);
+    setUp();
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+
+    List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
+    task.put(sinkRecords);
+    task.close(context.assignment());
+    task.stop();
+
+    long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets, context.assignment(), ".bin.gz");
+  }
+
+  @Test
   public void testCustomExtensionAndLineSeparator() throws Exception {
-    String extension = ".SEPARATORjson";
+    String extension = ".customExtensionForTest";
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
     localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_LINE_SEPARATOR_CONFIG, "SEPARATOR");
     localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_EXTENSION_CONFIG, extension);


### PR DESCRIPTION
Addresses the final piece of https://github.com/confluentinc/kafka-connect-storage-cloud/issues/22
