### PR TITLE
Allow to write records at the root of the bucket

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.s3;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
@@ -434,7 +435,11 @@ public class TopicPartitionWriter {
   }
 
   private String fileKey(String topicsPrefix, String keyPrefix, String name) {
-    return topicsPrefix + dirDelim + keyPrefix + dirDelim + name;
+    String base = "";
+    if (StringUtils.isNotBlank(topicsPrefix) && !topicsPrefix.equals("/")) {
+      base = topicsPrefix + dirDelim;
+    }
+    return base + keyPrefix + dirDelim + name;
   }
 
   private String fileKeyToCommit(String dirPrefix, long startOffset) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -437,8 +437,8 @@ public class TopicPartitionWriter {
   private String fileKey(String topicsPrefix, String keyPrefix, String name) {
     String suffix = keyPrefix + dirDelim + name;
     return StringUtils.isNotBlank(topicsPrefix)
-            ? topicsPrefix + dirDelim + suffix
-            : suffix;
+           ? topicsPrefix + dirDelim + suffix
+           : suffix;
   }
 
   private String fileKeyToCommit(String dirPrefix, long startOffset) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.s3;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
@@ -40,6 +39,7 @@ import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.common.StorageCommonConfig;
+import io.confluent.connect.storage.common.util.StringUtils;
 import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
 import io.confluent.connect.storage.hive.HiveConfig;
@@ -435,11 +435,10 @@ public class TopicPartitionWriter {
   }
 
   private String fileKey(String topicsPrefix, String keyPrefix, String name) {
-    String base = "";
-    if (StringUtils.isNotBlank(topicsPrefix) && !topicsPrefix.equals("/")) {
-      base = topicsPrefix + dirDelim;
-    }
-    return base + keyPrefix + dirDelim + name;
+    String suffix = keyPrefix + dirDelim + name;
+    return StringUtils.isNotBlank(topicsPrefix)
+            ? topicsPrefix + dirDelim + suffix
+            : suffix;
   }
 
   private String fileKeyToCommit(String dirPrefix, long startOffset) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileUtils.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileUtils.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.s3.util;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.TopicPartition;
 
 public class FileUtils {
@@ -23,7 +24,11 @@ public class FileUtils {
   public static final String TEST_DIRECTORY_DELIM = "_";
 
   public static String fileKey(String topicsPrefix, String keyPrefix, String name) {
-    return topicsPrefix + TEST_DIRECTORY_DELIM + keyPrefix + TEST_DIRECTORY_DELIM + name;
+    String base = "";
+    if (StringUtils.isNotBlank(topicsPrefix) && !topicsPrefix.equals("/")) {
+      base = topicsPrefix + TEST_DIRECTORY_DELIM;
+    }
+    return base + keyPrefix + TEST_DIRECTORY_DELIM + name;
   }
 
   public static String fileKeyToCommit(String topicsPrefix, String dirPrefix, TopicPartition tp, long startOffset,

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileUtils.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileUtils.java
@@ -27,8 +27,8 @@ public class FileUtils {
   public static String fileKey(String topicsPrefix, String keyPrefix, String name) {
     String suffix = keyPrefix + TEST_DIRECTORY_DELIM + name;
     return StringUtils.isNotBlank(topicsPrefix)
-            ? topicsPrefix + TEST_DIRECTORY_DELIM + suffix
-            : suffix;
+           ? topicsPrefix + TEST_DIRECTORY_DELIM + suffix
+           : suffix;
   }
 
   public static String fileKeyToCommit(String topicsPrefix, String dirPrefix, TopicPartition tp, long startOffset,

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileUtils.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileUtils.java
@@ -16,19 +16,19 @@
 
 package io.confluent.connect.s3.util;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.common.TopicPartition;
+
+import io.confluent.connect.storage.common.util.StringUtils;
 
 public class FileUtils {
   public static final String TEST_FILE_DELIM = "#";
   public static final String TEST_DIRECTORY_DELIM = "_";
 
   public static String fileKey(String topicsPrefix, String keyPrefix, String name) {
-    String base = "";
-    if (StringUtils.isNotBlank(topicsPrefix) && !topicsPrefix.equals("/")) {
-      base = topicsPrefix + TEST_DIRECTORY_DELIM;
-    }
-    return base + keyPrefix + TEST_DIRECTORY_DELIM + name;
+    String suffix = keyPrefix + TEST_DIRECTORY_DELIM + name;
+    return StringUtils.isNotBlank(topicsPrefix)
+            ? topicsPrefix + TEST_DIRECTORY_DELIM + suffix
+            : suffix;
   }
 
   public static String fileKeyToCommit(String topicsPrefix, String dirPrefix, TopicPartition tp, long startOffset,


### PR DESCRIPTION
Hi,

It would be useful to allow the s3 connector to write at the root of the bucket. It's fairly straightforward to implement this with the existing configs.

If topic.dir is either set with a blank value or a slash the connector should write at the root of the bucket