### PR TITLE
Fix new client creation to cater for URLs and region together

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -69,13 +69,15 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
                                                 .withUserAgentPrefix(
                                                     String.format(VERSION_FORMAT, Version.getVersion())));
 
+    String region = config.getString(REGION_CONFIG);
     if (StringUtils.isBlank(url)) {
-      String region = config.getString(REGION_CONFIG);
       builder = "us-east-1".equals(region) ?
                     builder.withRegion(Regions.US_EAST_1):
                     builder.withRegion(region);
     } else {
-      builder = builder.withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(url, ""));
+      builder = builder.withEndpointConfiguration(
+          new AwsClientBuilder.EndpointConfiguration(url, region)
+      );
     }
 
     return builder.build();


### PR DESCRIPTION
To connect to an S3 compatible service, connector should be able to accept both URL and region together.

Refer https://github.com/minio/minio/issues/3978 for example