### PR TITLE
Update to PowerMock 2.0.x and Mockito 2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,8 @@
         </dependency>
         <dependency>
             <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
+            <artifactId>powermock-api-mockito2</artifactId>
+            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This fixes the build and allows the tests
to run with Java 9.