### PR TITLE
Dynamically create TopicPartitionWriters

### DIFF
--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -616,7 +616,7 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
     List<SinkRecord> sinkRecords = new ArrayList<>();
     for (TopicPartition tp : partitions) {
       for (long offset = startOffset; offset < startOffset + size; ++offset) {
-        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset));
+        sinkRecords.add(new SinkRecord(tp.topic(), tp.partition(), Schema.STRING_SCHEMA, key, schema, record, offset));
       }
     }
     return sinkRecords;


### PR DESCRIPTION
Currently, this connector generates errors when configured with a
Transformer such as RegexRouter or TimestampRouter which changes the
topic name.

In order to support topic Router transforms, we need to dynamically
create TopicPartitionWriters as we see new topic names, since the
existing logic creates a static set of writers for only the specific
topic partitions in the connector's assignment.