### PR TITLE
Fix for BufferOverflowException in S3OutputStream

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -94,7 +94,7 @@ public class S3OutputStream extends OutputStream {
       return;
     }
 
-    if (buffer.remaining() < len) {
+    if (buffer.remaining() <= len) {
       int firstPart = buffer.remaining();
       buffer.put(b, off, firstPart);
       uploadPart();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
@@ -19,6 +19,7 @@ package io.confluent.connect.s3;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
+import io.confluent.connect.s3.storage.S3OutputStream;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.s3.util.FileUtils;
 import io.confluent.connect.storage.partitioner.DefaultPartitioner;
@@ -29,6 +30,7 @@ import org.apache.kafka.connect.converters.ByteArrayConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -83,6 +85,16 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
   public void tearDown() throws Exception {
     super.tearDown();
     localProps.clear();
+  }
+
+  @Test
+  public void testBufferOverflowFix() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
+    setUp();
+    PowerMockito.doReturn(5).when(connectorConfig).getPartSize();
+    S3OutputStream out = new S3OutputStream(S3_TEST_BUCKET_NAME, connectorConfig, s3);
+    out.write(new byte[]{65,66,67,68,69});
+    out.write(70);
   }
 
   @Test


### PR DESCRIPTION
There is two overloaded versions of `write` method on S3OutputStream. In situation when stream `buffer` becomes full by calling `public void write(byte[] b, int off, int len)`, and then `public void write(int b)` called for some reason, we'll get BufferOverflowException. To avoid it, we do check `!buffer.hasRemaining()` in both methods before returning and flush buffer if it's full.

Just to provide more context, I got this exception when extending `kafka-connect-s3` with custom format that uses LZOP compression before sending data to S3. In this case LZOP API finalizes compression of the chunk of data by writing a byte at the end of the S3 stream. If buffer of the stream is full by that time, I get BufferOverflowException. To be consistent, both methods now check if buffer is full before returning.

There is test that supports given idea.