### PR TITLE
CC-1497. Added logic for passing a subset of configs down to configurable credentials provider

### DIFF
--- a/kafka-connect-s3/docs/README.md
+++ b/kafka-connect-s3/docs/README.md
@@ -21,3 +21,5 @@ Then run the monitoring script in the background:
 
 If you install the [browser extensions](http://livereload.com/) then everything should update every time any files are
 saved without any manual steps on your part.
+
+You can navigate docs in your browser [here](http://127.0.0.1:5500/_build/html/).

--- a/kafka-connect-s3/docs/configuration_options.rst
+++ b/kafka-connect-s3/docs/configuration_options.rst
@@ -109,6 +109,14 @@ S3
   * Valid Values: Any class implementing: interface com.amazonaws.auth.AWSCredentialsProvider
   * Importance: low
 
+``s3.credentials.provider.configs.``
+  The properties that begin with this prefix will be used to configure a class, specified by
+  ``s3.credentials.provider.class`` if it implements org.apache.kafka.common.Configurable.
+
+  * Type: set<object>
+  * Importance: low
+
+
 ``s3.ssea.name``
   The S3 Server Side Encryption Algorithm.
 

--- a/kafka-connect-s3/docs/configuration_options.rst
+++ b/kafka-connect-s3/docs/configuration_options.rst
@@ -109,14 +109,6 @@ S3
   * Valid Values: Any class implementing: interface com.amazonaws.auth.AWSCredentialsProvider
   * Importance: low
 
-``s3.credentials.provider.configs.``
-  The properties that begin with this prefix will be used to configure a class, specified by
-  ``s3.credentials.provider.class`` if it implements org.apache.kafka.common.Configurable.
-
-  * Type: set<object>
-  * Importance: low
-
-
 ``s3.ssea.name``
   The S3 Server Side Encryption Algorithm.
 

--- a/kafka-connect-s3/docs/s3_connector.rst
+++ b/kafka-connect-s3/docs/s3_connector.rst
@@ -122,6 +122,8 @@ Every service will start in order, printing a message with its status:
 .. note:: You need to make sure the connector user has write access to the S3 bucket
    specified in ``s3.bucket.name`` and has deployed credentials
    `appropriately <http://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html>`_.
+   You can also pass additional properties to credential provider, please refer to the
+   `Configurable credential provider`_ section.
 
 To import a few records with a simple schema in Kafka, start the Avro console producer as follows:
 
@@ -251,15 +253,16 @@ Configuration
 This section gives example configurations that cover common scenarios. For detailed description of all the
 available configuration options of the S3 connector go to :ref:`Configuration Options<s3_configuration_options>`
 
-Custom credential provider
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+Configurable credential provider
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Some use cases require more fine-grained credentials configuration for AWS so that each connector
 could have its own credentials.
 
-To use configurable credential provider, `s3.credentials.provider.class` should be a class which
-implements both `com.amazonaws.auth.AWSCredentialsProvider` and `org.apache.kafka.common.Configurable` interfaces.
+To use configurable credential provider, ``s3.credentials.provider.class`` should be a class which
+implements both ``com.amazonaws.auth.AWSCredentialsProvider`` and ``org.apache.kafka.common
+.Configurable`` interfaces.
 
-A subset of properties, starting from `s3.credentials.provider.` (with stripped out prefix)
+A subset of properties, starting from ``s3.credentials.provider.`` (with stripped out prefix)
 will be passed to an instance of a credential provider.
 
 Here is a non-thread safe reference implementation of configurable credential provider:

--- a/kafka-connect-s3/docs/s3_connector.rst
+++ b/kafka-connect-s3/docs/s3_connector.rst
@@ -263,10 +263,6 @@ to the name of a class that implements both the ``com.amazonaws.auth.AWSCredenti
 and ``org.apache.kafka.common.Configurable`` interfaces.
 Then as needed, supply additional properties required by that provider by prefixing them
 with ``s3.credentials.provider.``. These will all be passed to the credentials provider during configuration.
-As an example, you can refer to the class, used in unit-tests:
-`DummyAssertiveCredentialsProvider <https://github.com/
-confluentinc/kafka-connect-storage-cloud/blob/master/kafka-connect-s3/src/test/java/io/confluent
-/connect/s3/DummyAssertiveCredentialsProvider.java>`_.
 
 Basic Example
 ~~~~~~~~~~~~~

--- a/kafka-connect-s3/docs/s3_connector.rst
+++ b/kafka-connect-s3/docs/s3_connector.rst
@@ -263,6 +263,10 @@ to the name of a class that implements both the ``com.amazonaws.auth.AWSCredenti
 and ``org.apache.kafka.common.Configurable`` interfaces.
 Then as needed, supply additional properties required by that provider by prefixing them
 with ``s3.credentials.provider.``. These will all be passed to the credentials provider during configuration.
+As an example, you can refer to the class, used in unit-tests:
+`DummyAssertiveCredentialsProvider <https://github.com/
+confluentinc/kafka-connect-storage-cloud/blob/master/kafka-connect-s3/src/test/java/io/confluent
+/connect/s3/DummyAssertiveCredentialsProvider.java>`_.
 
 Example
 ~~~~~~~

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -83,7 +83,11 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
    * The properties that begin with this prefix will be used to configure a class, specified by
    * {@code s3.credentials.provider.class} if it implements {@link Configurable}.
    */
-  public static final String CREDENTIALS_PROVIDER_CONFIG_PREFIX = "s3.credentials.provider.";
+  public static final String CREDENTIALS_PROVIDER_CONFIG_PREFIX =
+      CREDENTIALS_PROVIDER_CLASS_CONFIG.substring(
+          0,
+          CREDENTIALS_PROVIDER_CLASS_CONFIG.lastIndexOf(".") + 1
+      );
 
   public static final String REGION_CONFIG = "s3.region";
   public static final String REGION_DEFAULT = Regions.DEFAULT_REGION.getName();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DummyAssertiveCredentialsProvider.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DummyAssertiveCredentialsProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.config.ConfigException;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+class DummyAssertiveCredentialsProvider implements AWSCredentialsProvider, Configurable {
+
+  public static final String ACCESS_KEY_NAME = "access.key";
+  public static final String SECRET_KEY_NAME = "secret.key";
+  public static final String CONFIGS_NUM_KEY_NAME = "configs.num";
+
+  private AWSCredentials credentials;
+
+  @Override
+  public AWSCredentials getCredentials() {
+    return credentials;
+  }
+
+  @Override
+  public void refresh() {
+    throw new UnsupportedOperationException(
+        "Refresh is not supported for this credentials provider"
+    );
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs) {
+
+    final String accessKeyId = (String) configs.get(ACCESS_KEY_NAME);
+    final String secretKey = (String) configs.get(SECRET_KEY_NAME);
+    final Integer configsNum = Integer.valueOf((String) configs.get(CONFIGS_NUM_KEY_NAME));
+
+    validateConfigs(configs);
+
+    assertEquals(configsNum.intValue(), configs.size());
+
+    credentials = new BasicAWSCredentials(accessKeyId, secretKey);
+  }
+
+  private void validateConfigs(Map<String, ?> configs) {
+
+    if (!configs.containsKey(ACCESS_KEY_NAME) ||
+        !configs.containsKey(SECRET_KEY_NAME)) {
+      throw new ConfigException(String.format("%s and %s are mandatory configuration properties",
+          ACCESS_KEY_NAME, SECRET_KEY_NAME
+      ));
+    }
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -16,11 +16,8 @@
 
 package io.confluent.connect.s3;
 
-import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
-import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -52,10 +49,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
-
-  private static final String ACCESS_KEY_NAME = "access.key";
-  private static final String SECRET_KEY_NAME = "secret.key";
-  private static final String CONFIGS_NUM_KEY_NAME = "configs.num";
 
   @Rule
   public ExpectedException thrown = ExpectedException.none();
@@ -187,9 +180,18 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
         DummyAssertiveCredentialsProvider.class.getName()
     );
     String configPrefix = S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CONFIG_PREFIX;
-    properties.put(configPrefix.concat(ACCESS_KEY_NAME), ACCESS_KEY_VALUE);
-    properties.put(configPrefix.concat(SECRET_KEY_NAME), SECRET_KEY_VALUE);
-    properties.put(configPrefix.concat(CONFIGS_NUM_KEY_NAME), "3");
+    properties.put(
+        configPrefix.concat(DummyAssertiveCredentialsProvider.ACCESS_KEY_NAME),
+        ACCESS_KEY_VALUE
+    );
+    properties.put(
+        configPrefix.concat(DummyAssertiveCredentialsProvider.SECRET_KEY_NAME),
+        SECRET_KEY_VALUE
+    );
+    properties.put(
+        configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME),
+        "3"
+    );
     connectorConfig = new S3SinkConnectorConfig(properties);
 
     AWSCredentialsProvider credentialsProvider = connectorConfig.getCredentialsProvider();
@@ -209,7 +211,10 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
         S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
         DummyAssertiveCredentialsProvider.class.getName()
     );
-    properties.put(configPrefix.concat(CONFIGS_NUM_KEY_NAME), "2");
+    properties.put(
+        configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME),
+        "2"
+    );
 
     connectorConfig = new S3SinkConnectorConfig(properties);
     connectorConfig.getCredentialsProvider();
@@ -276,45 +281,5 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     }
   }
 
-  static class DummyAssertiveCredentialsProvider implements AWSCredentialsProvider, Configurable {
-
-    private AWSCredentials credentials;
-
-    @Override
-    public AWSCredentials getCredentials() {
-      return credentials;
-    }
-
-    @Override
-    public void refresh() {
-      throw new UnsupportedOperationException(
-          "Refresh is not supported for this credentials provider"
-      );
-    }
-
-    @Override
-    public void configure(final Map<String, ?> configs) {
-
-      final String accessKeyId = (String) configs.get(ACCESS_KEY_NAME);
-      final String secretKey = (String) configs.get(SECRET_KEY_NAME);
-      final Integer configsNum = Integer.valueOf((String) configs.get(CONFIGS_NUM_KEY_NAME));
-
-      validateConfigs(configs);
-
-      assertEquals(configsNum.intValue(), configs.size());
-
-      credentials = new BasicAWSCredentials(accessKeyId, secretKey);
-    }
-
-    private void validateConfigs(Map<String, ?> configs) {
-
-      if (!configs.containsKey(ACCESS_KEY_NAME) ||
-          !configs.containsKey(SECRET_KEY_NAME)) {
-        throw new ConfigException(String.format("%s and %s are mandatory configuration properties",
-            ACCESS_KEY_NAME, SECRET_KEY_NAME
-        ));
-      }
-    }
-  }
 }
 


### PR DESCRIPTION
Changes in this PR:
* Logic which checks whether class specified in `s3.credentials.provider.class` implements `Configurable` and passes all properties prefixed by `s3.credentials.provider.configs.` to that class if it does;
* Unit test to exercise positive scenario of a configurable credential provider;
* Doc changes.