### PR TITLE
MINOR: Add all parameters which decide the value of periodicRotation

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -309,10 +309,12 @@ public class TopicPartitionWriter {
 
     log.trace(
         "Should apply periodic time-based rotation (rotateIntervalMs: '{}', baseRecordTimestamp: "
-            + "'{}', timestamp: '{}')? {}",
+            + "'{}', timestamp: '{}', encodedPartition: '{}', currentEncodedPartition: '{}')? {}",
         rotateIntervalMs,
         baseRecordTimestamp,
         recordTimestamp,
+        encodedPartition,
+        currentEncodedPartition,
         periodicRotation
     );
 


### PR DESCRIPTION
This is how the log message will look like now: 

```
[2018-04-23 10:57:41,935] TRACE Should apply periodic time-based rotation (rotateIntervalMs: '60000', baseRecordTimestamp: 'null', timestamp: 'null', encodedPartition: 'partition=12', currentEncodedPartition: 'partition=12')? false (io.confluent.connect.s3.TopicPartitionWriter:310)
```

Signed-off-by: Arjun Satish <arjun@confluent.io>