### PR TITLE
Extend the existing SSE support to enable Customer (provided) Keys SSE-C

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -71,7 +71,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String SSEA_DEFAULT = "";
 
   public static final String SSE_CUSTOMER_KEY = "s3.sse.customer.key";
-  public static final String SSE_CUSTOMER_KEY_DEFAULT = "";
+  public static final Password SSE_CUSTOMER_KEY_DEFAULT = new Password(null);
 
   public static final String SSE_KMS_KEY_ID_CONFIG = "s3.sse.kms.key.id";
   public static final String SSE_KMS_KEY_ID_DEFAULT = "";
@@ -470,7 +470,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   }
 
   public String getSseCustomerKey() {
-    return getString(SSE_CUSTOMER_KEY);
+    return getPassword(SSE_CUSTOMER_KEY).value();
   }
 
   public String getSseKmsKeyId() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -70,8 +70,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String SSEA_CONFIG = "s3.ssea.name";
   public static final String SSEA_DEFAULT = "";
 
-  public static final String SSE_KEY = "s3.sse.key";
-  public static final String SSE_KEY_DEFAULT = "";
+  public static final String SSE_CUSTOMER_KEY = "s3.sse.customer.key";
+  public static final String SSE_CUSTOMER_KEY_DEFAULT = "";
 
   public static final String SSE_KMS_KEY_ID_CONFIG = "s3.sse.kms.key.id";
   public static final String SSE_KMS_KEY_ID_DEFAULT = "";
@@ -246,9 +246,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       );
 
       configDef.define(
-          SSE_KEY,
+          SSE_CUSTOMER_KEY,
           Type.PASSWORD,
-          SSE_KEY_DEFAULT,
+          SSE_CUSTOMER_KEY_DEFAULT,
           Importance.LOW,
           "The S3 Server Side Encryption Customer-Provided Key (SSE-C).",
           group,
@@ -469,8 +469,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     return getString(SSEA_CONFIG);
   }
 
-  public String getSseKey() {
-    return getString(SSE_KEY);
+  public String getSseCustomerKey() {
+    return getString(SSE_CUSTOMER_KEY);
   }
 
   public String getSseKmsKeyId() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -247,7 +247,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
       configDef.define(
           SSE_KEY,
-          Type.STRING,
+          Type.PASSWORD,
           SSE_KEY_DEFAULT,
           Importance.LOW,
           "The S3 Server Side Encryption Customer-Provided Key (SSE-C).",

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -250,11 +250,11 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Type.STRING,
           SSE_KEY_DEFAULT,
           Importance.LOW,
-          "The S3 Server Side Encryption Customer (provided) Key.",
+          "The S3 Server Side Encryption Customer-Provided Key (SSE-C).",
           group,
           ++orderInGroup,
           Width.LONG,
-          "S3 Server Side Encryption Customer (provided) Key"
+          "S3 Server Side Encryption Customer-Provided Key (SSE-C)"
       );
 
       configDef.define(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -250,11 +250,11 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Type.STRING,
           SSE_KEY_DEFAULT,
           Importance.LOW,
-          "The S3 Server Side Encryption Customer Key.",
+          "The S3 Server Side Encryption Customer (provided) Key.",
           group,
           ++orderInGroup,
           Width.LONG,
-          "S3 Server Side Encryption Customer Key"
+          "S3 Server Side Encryption Customer (provided) Key"
       );
 
       configDef.define(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -70,6 +70,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String SSEA_CONFIG = "s3.ssea.name";
   public static final String SSEA_DEFAULT = "";
 
+  public static final String SSE_KEY = "s3.sse.key";
+  public static final String SSE_KEY_DEFAULT = "";
+
   public static final String SSE_KMS_KEY_ID_CONFIG = "s3.sse.kms.key.id";
   public static final String SSE_KMS_KEY_ID_DEFAULT = "";
 
@@ -240,6 +243,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Width.LONG,
           "S3 Server Side Encryption Algorithm",
           new SseAlgorithmRecommender()
+      );
+
+      configDef.define(
+          SSE_KEY,
+          Type.STRING,
+          SSE_KEY_DEFAULT,
+          Importance.LOW,
+          "The S3 Server Side Encryption Customer Key.",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "S3 Server Side Encryption Customer Key"
       );
 
       configDef.define(
@@ -452,6 +467,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public String getSsea() {
     return getString(SSEA_CONFIG);
+  }
+
+  public String getSseKey() {
+    return getString(SSE_KEY);
   }
 
   public String getSseKmsKeyId() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -54,7 +54,7 @@ public class S3OutputStream extends OutputStream {
   private final String bucket;
   private final String key;
   private final String ssea;
-  private final String sseCustomerKeyConf;
+  private final String sseCustomerKeyConfig;
   private final SSECustomerKey sseCustomerKey;
   private final String sseKmsKeyId;
   private final ProgressListener progressListener;
@@ -71,10 +71,10 @@ public class S3OutputStream extends OutputStream {
     this.bucket = conf.getBucketName();
     this.key = key;
     this.ssea = conf.getSsea();
-    this.sseCustomerKeyConf = conf.getSseCustomerKey();
+    this.sseCustomerKeyConfig = conf.getSseCustomerKey();
     this.sseCustomerKey = (SSEAlgorithm.AES256.toString().equalsIgnoreCase(ssea)
-        && StringUtils.isNotBlank(sseCustomerKeyConf))
-      ? new SSECustomerKey(sseCustomerKeyConf) : null;
+        && StringUtils.isNotBlank(sseCustomerKeyConfig))
+      ? new SSECustomerKey(sseCustomerKeyConfig) : null;
     this.sseKmsKeyId = conf.getSseKmsKeyId();
     this.partSize = conf.getPartSize();
     this.cannedAcl = conf.getCannedAcl();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -192,7 +192,8 @@ public class S3OutputStream extends OutputStream {
         newObjectMetadata()
     ).withCannedACL(cannedAcl);
 
-    if (StringUtils.isNotBlank(ssea) && StringUtils.isNotBlank(sseKey)) {
+    if (SSEAlgorithm.AES256.toString().equalsIgnoreCase(ssea)
+        && StringUtils.isNotBlank(sseKey)) {
       sseCustomerKey = new SSECustomerKey(sseKey);
       initRequest.setSSECustomerKey(sseCustomerKey);
     } else if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -54,7 +54,7 @@ public class S3OutputStream extends OutputStream {
   private final String bucket;
   private final String key;
   private final String ssea;
-  private final String sseKey;
+  private final String sseCustomerKeyConf;
   private SSECustomerKey sseCustomerKey;
   private final String sseKmsKeyId;
   private final ProgressListener progressListener;
@@ -71,7 +71,7 @@ public class S3OutputStream extends OutputStream {
     this.bucket = conf.getBucketName();
     this.key = key;
     this.ssea = conf.getSsea();
-    this.sseKey = conf.getSseKey();
+    this.sseCustomerKeyConf = conf.getSseCustomerKey();
     this.sseCustomerKey = null;
     this.sseKmsKeyId = conf.getSseKmsKeyId();
     this.partSize = conf.getPartSize();
@@ -193,8 +193,8 @@ public class S3OutputStream extends OutputStream {
     ).withCannedACL(cannedAcl);
 
     if (SSEAlgorithm.AES256.toString().equalsIgnoreCase(ssea)
-        && StringUtils.isNotBlank(sseKey)) {
-      sseCustomerKey = new SSECustomerKey(sseKey);
+        && StringUtils.isNotBlank(sseCustomerKeyConf)) {
+      sseCustomerKey = new SSECustomerKey(sseCustomerKeyConf);
       initRequest.setSSECustomerKey(sseCustomerKey);
     } else if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)
         && StringUtils.isNotBlank(sseKmsKeyId)) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -27,6 +27,7 @@ import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.SSEAlgorithm;
+import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
@@ -53,6 +54,7 @@ public class S3OutputStream extends OutputStream {
   private final String bucket;
   private final String key;
   private final String ssea;
+  private final String sseKey;
   private final String sseKmsKeyId;
   private final ProgressListener progressListener;
   private final int partSize;
@@ -68,6 +70,7 @@ public class S3OutputStream extends OutputStream {
     this.bucket = conf.getBucketName();
     this.key = key;
     this.ssea = conf.getSsea();
+    this.sseKey = conf.getSseKey();
     this.sseKmsKeyId = conf.getSseKmsKeyId();
     this.partSize = conf.getPartSize();
     this.cannedAcl = conf.getCannedAcl();
@@ -187,7 +190,9 @@ public class S3OutputStream extends OutputStream {
         newObjectMetadata()
     ).withCannedACL(cannedAcl);
 
-    if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)
+    if (StringUtils.isNotBlank(ssea) && StringUtils.isNotBlank(sseKey)) {
+      initRequest.setSSECustomerKey(new SSECustomerKey(sseKey));
+    } else if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)
         && StringUtils.isNotBlank(sseKmsKeyId)) {
       initRequest.setSSEAwsKeyManagementParams(new SSEAwsKeyManagementParams(sseKmsKeyId));
     }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -54,7 +54,6 @@ public class S3OutputStream extends OutputStream {
   private final String bucket;
   private final String key;
   private final String ssea;
-  private final String sseCustomerKeyConfig;
   private final SSECustomerKey sseCustomerKey;
   private final String sseKmsKeyId;
   private final ProgressListener progressListener;
@@ -71,7 +70,7 @@ public class S3OutputStream extends OutputStream {
     this.bucket = conf.getBucketName();
     this.key = key;
     this.ssea = conf.getSsea();
-    this.sseCustomerKeyConfig = conf.getSseCustomerKey();
+    final String sseCustomerKeyConfig = conf.getSseCustomerKey();
     this.sseCustomerKey = (SSEAlgorithm.AES256.toString().equalsIgnoreCase(ssea)
         && StringUtils.isNotBlank(sseCustomerKeyConfig))
       ? new SSECustomerKey(sseCustomerKeyConfig) : null;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -55,6 +55,7 @@ public class S3OutputStream extends OutputStream {
   private final String key;
   private final String ssea;
   private final String sseKey;
+  private SSECustomerKey sseCustomerKey;
   private final String sseKmsKeyId;
   private final ProgressListener progressListener;
   private final int partSize;
@@ -71,6 +72,7 @@ public class S3OutputStream extends OutputStream {
     this.key = key;
     this.ssea = conf.getSsea();
     this.sseKey = conf.getSseKey();
+    this.sseCustomerKey = null;
     this.sseKmsKeyId = conf.getSseKmsKeyId();
     this.partSize = conf.getPartSize();
     this.cannedAcl = conf.getCannedAcl();
@@ -191,7 +193,8 @@ public class S3OutputStream extends OutputStream {
     ).withCannedACL(cannedAcl);
 
     if (StringUtils.isNotBlank(ssea) && StringUtils.isNotBlank(sseKey)) {
-      initRequest.setSSECustomerKey(new SSECustomerKey(sseKey));
+      sseCustomerKey = new SSECustomerKey(sseKey);
+      initRequest.setSSECustomerKey(sseCustomerKey);
     } else if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)
         && StringUtils.isNotBlank(sseKmsKeyId)) {
       initRequest.setSSEAwsKeyManagementParams(new SSEAwsKeyManagementParams(sseKmsKeyId));
@@ -227,6 +230,7 @@ public class S3OutputStream extends OutputStream {
                                             .withBucketName(bucket)
                                             .withKey(key)
                                             .withUploadId(uploadId)
+                                            .withSSECustomerKey(sseCustomerKey)
                                             .withInputStream(inputStream)
                                             .withPartNumber(currentPartNumber)
                                             .withPartSize(partSize)


### PR DESCRIPTION
This resolves issue #79 (Support AWS KMS and SSE-C). Example usage:
```
s3.ssea.name=AES256
# base64encode("32_byte_string_needed_for_AES256")
s3.sse.customer.key=MzJfYnl0ZV9zdHJpbmdfbmVlZGVkX2Zvcl9BRVMyNTY=
```