### PR TITLE
CC-2617: Accept timestamp for wallclock instances to assure consistency

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -196,13 +196,13 @@ public class TopicPartitionWriter {
       case WRITE_PARTITION_PAUSED:
         SinkRecord record = buffer.peek();
         if (timestampExtractor != null) {
-          currentTimestamp = timestampExtractor.extract(record);
+          currentTimestamp = timestampExtractor.extract(record, now);
           if (baseRecordTimestamp == null) {
             baseRecordTimestamp = currentTimestamp;
           }
         }
         Schema valueSchema = record.valueSchema();
-        String encodedPartition = partitioner.encodePartition(record);
+        String encodedPartition = partitioner.encodePartition(record, now);
         Schema currentValueSchema = currentSchemas.get(encodedPartition);
         if (currentValueSchema == null) {
           currentSchemas.put(encodedPartition, valueSchema);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -495,8 +495,8 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     topicPartitionWriter.write();
   }
 
-  /* Test will start writing before the hour, and write some records after the hour, and verify
-     there is still only one output file created.
+  /** Test will start writing before the hour, and write some records after the hour, and verify
+   *  there is still only one output file created.
    */
   @Test
   public void testWallclockAcrossPartitionBoundary() throws Exception {
@@ -531,8 +531,6 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     for (SinkRecord record : sinkRecords) {
       topicPartitionWriter.buffer(record);
     }
-
-    // Set system time to 1 second before the hour
 
     topicPartitionWriter.write();
     List<String> expectedFiles = new ArrayList<>();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -498,10 +498,6 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testWallclockUsesBatchTimePartitionBoundary() throws Exception {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "6");
-//    localProps.put(
-//        S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
-//        String.valueOf(TimeUnit.HOURS.toMillis(1))
-//    );
     setUp();
 
     // Define the partitioner


### PR DESCRIPTION
Extending Partitioner and Extractor to accept a timestamp gives flexibility
for the calling function to inject desired behavior in some cases.

This has been particularly useful in getting consistent timestamps
in a wallclock based partitioners to return the same encodedPartition
for the same batch of records, preventing small files being created
across partition boundaries

Depends on https://github.com/confluentinc/kafka-connect-storage-common/pull/88