### PR TITLE
CC-3035: Upgrade the S3Mock library so the module builds on Java 8 and Java 11

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -37,16 +37,9 @@
 
     <properties>
         <aws.version>1.11.86</aws.version>
-        <s3mock.version>0.1.5</s3mock.version>
+        <s3mock.version>0.2.5</s3mock.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
     </properties>
-
-    <repositories>
-        <repository>
-            <id>findify</id>
-            <url>https://dl.bintray.com/findify/maven/</url>
-        </repository>
-    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -67,7 +60,7 @@
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>
-            <artifactId>s3mock_2.11</artifactId>
+            <artifactId>s3mock_2.12</artifactId>
             <version>${s3mock.version}</version>
             <scope>test</scope>
         </dependency>

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.internal.SkipMd5CheckStrategy;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.confluent.common.utils.MockTime;
 import io.confluent.common.utils.Time;
@@ -110,6 +111,9 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
 
     s3.createBucket(S3_TEST_BUCKET_NAME);
     assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+
+    // Workaround to avoid AWS S3 client failing due to apparently incorrect S3Mock digest
+    System.setProperty(SkipMd5CheckStrategy.DISABLE_GET_OBJECT_MD5_VALIDATION_PROPERTY, "true");
   }
 
   @After

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -89,6 +89,7 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
   Partitioner<FieldSchema> partitioner;
   S3SinkTask task;
   Map<String, String> localProps = new HashMap<>();
+  private String prevMd5Prop = null;
 
   @Override
   protected Map<String, String> createProps() {
@@ -113,6 +114,9 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
     assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
 
     // Workaround to avoid AWS S3 client failing due to apparently incorrect S3Mock digest
+    prevMd5Prop = System.getProperty(
+        SkipMd5CheckStrategy.DISABLE_GET_OBJECT_MD5_VALIDATION_PROPERTY
+    );
     System.setProperty(SkipMd5CheckStrategy.DISABLE_GET_OBJECT_MD5_VALIDATION_PROPERTY, "true");
   }
 
@@ -121,6 +125,16 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
   public void tearDown() throws Exception {
     super.tearDown();
     localProps.clear();
+
+    // Unset the property to the previous value
+    if (prevMd5Prop != null) {
+      System.setProperty(
+          SkipMd5CheckStrategy.DISABLE_GET_OBJECT_MD5_VALIDATION_PROPERTY,
+          prevMd5Prop
+      );
+    } else {
+      System.clearProperty(SkipMd5CheckStrategy.DISABLE_GET_OBJECT_MD5_VALIDATION_PROPERTY);
+    }
   }
 
   @Test

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
@@ -81,7 +81,7 @@ public class TestWithMockedS3 extends S3SinkConnectorTestBase {
   @Override
   public void tearDown() throws Exception {
     super.tearDown();
-    s3mock.stop();
+    s3mock.shutdown(); // shutdown the Akka and HTTP frameworks to close all connections
   }
 
   public static List<S3ObjectSummary> listObjects(String bucket, String prefix, AmazonS3 s3) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -64,6 +64,7 @@ import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class TopicPartitionWriterTest extends TestWithMockedS3 {
   // The default
@@ -90,6 +91,9 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     s3 = newS3Client(connectorConfig);
     storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3);
     format = new AvroFormat(storage);
+
+    s3.createBucket(S3_TEST_BUCKET_NAME);
+    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
 
     Format<S3SinkConnectorConfig, String> format = new AvroFormat(storage);
     writerProvider = format.getRecordWriterProvider();

--- a/kafka-connect-s3/src/test/resources/log4j.properties
+++ b/kafka-connect-s3/src/test/resources/log4j.properties
@@ -21,3 +21,5 @@ log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n
 
 log4j.logger.org.apache.kafka=ERROR
+#log4j.logger.io.confluent.connect.s3=DEBUG
+#log4j.logger.io.findify.s3mock=DEBUG


### PR DESCRIPTION
Also upgrade the S3Mock library from 0.1.5 (on Scala 2.11) to 0.2.5 (on Scala 2.12), which incorporates a number of bug fixes. This is to take advantage of a new `S3Mock.shutdown()` method that properly closes the Akka framework and HTTP listener created in the S3Mock object. For some reason, these still-bound HTTP listeners are not a problem on Java 8, but with Java 11 they prevent the next test from binding to the address and cause the test to fail.

With these changes, the build passes on both Java 8 and Java 11.