### PR TITLE
Added SafeByteArrayFormat to avoid using separator in S3SinkConnector

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/SafeByteArrayFormat.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/SafeByteArrayFormat.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.format.bytearray;
+
+import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.storage.format.Format;
+import io.confluent.connect.storage.format.RecordWriterProvider;
+import io.confluent.connect.storage.format.SchemaFileReader;
+import io.confluent.connect.storage.hive.HiveFactory;
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SafeByteArrayFormat implements Format<S3SinkConnectorConfig, String> {
+  private final S3Storage storage;
+  private final ByteArrayConverter converter;
+
+  public SafeByteArrayFormat(S3Storage storage) {
+    this.storage = storage;
+    this.converter = new ByteArrayConverter();
+    Map<String, Object> converterConfig = new HashMap<>();
+    this.converter.configure(converterConfig, false);
+  }
+
+  @Override
+  public RecordWriterProvider<S3SinkConnectorConfig> getRecordWriterProvider() {
+    return new SafeByteArrayRecordWriterProvider(storage, converter);
+  }
+
+  @Override
+  public SchemaFileReader<S3SinkConnectorConfig, String> getSchemaFileReader() {
+    throw new UnsupportedOperationException("Reading schemas from S3 is not currently supported");
+  }
+
+  @Override
+  public HiveFactory getHiveFactory() {
+    throw new UnsupportedOperationException(
+            "Hive integration is not currently supported in S3 Connector");
+  }
+
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/SafeByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/SafeByteArrayRecordWriterProvider.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.format.bytearray;
+
+import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.s3.storage.S3OutputStream;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.storage.format.RecordWriter;
+import io.confluent.connect.storage.format.RecordWriterProvider;
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Every entry start with the length of the record byte size (4 byte)
+ */
+public class SafeByteArrayRecordWriterProvider
+        implements RecordWriterProvider<S3SinkConnectorConfig> {
+
+  private static final Logger log = LoggerFactory.getLogger(ByteArrayRecordWriterProvider.class);
+  private final S3Storage storage;
+  private final ByteArrayConverter converter;
+  private final String extension;
+
+  SafeByteArrayRecordWriterProvider(S3Storage storage, ByteArrayConverter converter) {
+    this.storage = storage;
+    this.converter = converter;
+    this.extension = storage.conf().getByteArrayExtension();
+  }
+
+  @Override
+  public String getExtension() {
+    return extension + storage.conf().getCompressionType().extension;
+  }
+
+  @Override
+  public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
+    return new RecordWriter() {
+      final S3OutputStream s3out = storage.create(filename, true);
+      final OutputStream s3outWrapper = s3out.wrapForCompression();
+
+      @Override
+      public void write(SinkRecord record) {
+        log.trace("Sink record: {}", record);
+        try {
+          byte[] bytes = converter.fromConnectData(record.topic(),
+                  record.valueSchema(), record.value());
+
+          ByteBuffer bb = ByteBuffer.allocate(4);
+          bb.putInt(bytes.length);
+
+          s3outWrapper.write(bb.array());
+          s3outWrapper.write(bytes);
+        } catch (IOException | DataException e) {
+          throw new ConnectException(e);
+        }
+      }
+
+      @Override
+      public void commit() {
+        try {
+          s3out.commit();
+          s3outWrapper.close();
+        } catch (IOException e) {
+          throw new ConnectException(e);
+        }
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterSafeByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterSafeByteArrayTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+import io.confluent.connect.s3.format.bytearray.SafeByteArrayFormat;
+import io.confluent.connect.s3.storage.CompressionType;
+import io.confluent.connect.s3.storage.S3OutputStream;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.s3.util.FileUtils;
+import io.confluent.connect.storage.partitioner.DefaultPartitioner;
+import io.confluent.connect.storage.partitioner.Partitioner;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.converters.ByteArrayConverter;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.junit.Test;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.io.IOException;
+import java.util.*;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.*;
+
+public class DataWriterSafeByteArrayTest extends TestWithMockedS3 {
+
+  private static final String ZERO_PAD_FMT = "%010d";
+  private ByteArrayConverter converter;
+
+  protected S3Storage storage;
+  protected AmazonS3 s3;
+  protected Partitioner<FieldSchema> partitioner;
+  protected SafeByteArrayFormat format;
+  protected S3SinkTask task;
+  protected Map<String, String> localProps = new HashMap<>();
+
+  @Override
+  protected Map<String, String> createProps() {
+    Map<String, String> props = super.createProps();
+    props.putAll(localProps);
+    return props;
+  }
+
+  //@Before should be omitted in order to be able to add properties per test.
+  public void setUp() throws Exception {
+    super.setUp();
+    converter = new ByteArrayConverter();
+
+    s3 = newS3Client(connectorConfig);
+    storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3);
+
+    partitioner = new DefaultPartitioner<>();
+    partitioner.configure(parsedConfig);
+    format = new SafeByteArrayFormat(storage);
+    s3.createBucket(S3_TEST_BUCKET_NAME);
+    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+  }
+
+  @After
+  @Override
+  public void tearDown() throws Exception {
+    super.tearDown();
+    localProps.clear();
+  }
+
+  @Test
+  public void testBufferOverflowFix() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, SafeByteArrayFormat.class.getName());
+    localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_EXTENSION_CONFIG, ".sbin");
+    setUp();
+    PowerMockito.doReturn(5).when(connectorConfig).getPartSize();
+    S3OutputStream out = new S3OutputStream(S3_TEST_BUCKET_NAME, connectorConfig, s3);
+    out.write(new byte[]{65,66,67,68,69});
+    out.write(70);
+  }
+
+  @Test
+  public void testNoSchema() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, SafeByteArrayFormat.class.getName());
+    localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_EXTENSION_CONFIG, ".sbin");
+    setUp();
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+
+    List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
+    task.put(sinkRecords);
+    task.close(context.assignment());
+    task.stop();
+
+    long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets, context.assignment(), ".sbin");
+  }
+
+  @Test
+  public void testGzipCompression() throws Exception {
+    CompressionType compressionType = CompressionType.GZIP;
+    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, SafeByteArrayFormat.class.getName());
+    localProps.put(S3SinkConnectorConfig.COMPRESSION_TYPE_CONFIG, compressionType.name);
+    localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_EXTENSION_CONFIG, ".sbin");
+
+    setUp();
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+
+    List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
+    task.put(sinkRecords);
+    task.close(context.assignment());
+    task.stop();
+
+    long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets, context.assignment(), ".sbin.gz");
+  }
+
+  protected List<SinkRecord> createByteArrayRecordsWithoutSchema(int size, long startOffset, Set<TopicPartition> partitions) {
+    String key = "key";
+    int ibase = 12;
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (long offset = startOffset, total = 0; total < size; ++offset) {
+      for (TopicPartition tp : partitions) {
+        byte[] record = ("{\"schema\":{\"type\":\"struct\",\"fields\":[ " +
+                            "{\"type\":\"boolean\",\"optional\":true,\"field\":\"booleanField\"}," +
+                            "{\"type\":\"int32\",\"optional\":true,\"field\":\"intField\"}," +
+                            "{\"type\":\"int64\",\"optional\":true,\"field\":\"longField\"}," +
+                            "{\"type\":\"string\",\"optional\":false,\"field\":\"stringField\"}]," +
+                            "\"payload\":" +
+                            "{\"booleanField\":\"true\"," +
+                            "\"intField\":" + String.valueOf(ibase) + "," +
+                            "\"longField\":" + String.valueOf((long) ibase) + "," +
+                            "\"stringField\":str" + String.valueOf(ibase) +
+                            "}}").getBytes();
+        sinkRecords.add(new SinkRecord(TOPIC, tp.partition(), null, key, null, record, offset));
+        if (++total >= size) {
+          break;
+        }
+      }
+    }
+    return sinkRecords;
+  }
+
+  protected String getDirectory(String topic, int partition) {
+    String encodedPartition = "partition=" + String.valueOf(partition);
+    return partitioner.generatePartitionedPath(topic, encodedPartition);
+  }
+
+  protected List<String> getExpectedFiles(long[] validOffsets, TopicPartition tp, String extension) {
+    List<String> expectedFiles = new ArrayList<>();
+    for (int i = 1; i < validOffsets.length; ++i) {
+      long startOffset = validOffsets[i - 1];
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset,
+                                                  extension, ZERO_PAD_FMT));
+    }
+    return expectedFiles;
+  }
+
+  protected void verifyFileListing(long[] validOffsets, Set<TopicPartition> partitions, String extension) throws IOException {
+    List<String> expectedFiles = new ArrayList<>();
+    for (TopicPartition tp : partitions) {
+      expectedFiles.addAll(getExpectedFiles(validOffsets, tp, extension));
+    }
+    verifyFileListing(expectedFiles);
+  }
+
+  protected void verifyFileListing(List<String> expectedFiles) throws IOException {
+    List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
+    List<String> actualFiles = new ArrayList<>();
+    for (S3ObjectSummary summary : summaries) {
+      String fileKey = summary.getKey();
+      actualFiles.add(fileKey);
+    }
+
+    Collections.sort(actualFiles);
+    Collections.sort(expectedFiles);
+    assertThat(actualFiles, is(expectedFiles));
+  }
+
+  protected void verifyContents(List<SinkRecord> expectedRecords, int startIndex, Collection<Object> records)
+      throws IOException{
+    for (Object record : records) {
+      byte[] bytes = (byte[]) record;
+      SinkRecord expectedRecord = expectedRecords.get(startIndex++);
+      byte[] expectedBytes = (byte[]) expectedRecord.value();
+      assertArrayEquals(expectedBytes, bytes);
+    }
+  }
+
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,
+                        String extension) throws IOException {
+    verify(sinkRecords, validOffsets, partitions, extension, false);
+  }
+
+  /**
+   * Verify files and records are uploaded appropriately.
+   * @param sinkRecords a flat list of the records that need to appear in potentially several files in S3.
+   * @param validOffsets an array containing the offsets that map to uploaded files for a topic-partition.
+   *                     Offsets appear in ascending order, the difference between two consecutive offsets
+   *                     equals the expected size of the file, and last offset in exclusive.
+   * @throws IOException
+   */
+  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,
+                        String extension, boolean skipFileListing)
+      throws IOException {
+    if (!skipFileListing) {
+      verifyFileListing(validOffsets, partitions, extension);
+    }
+
+    for (TopicPartition tp : partitions) {
+      for (int i = 1, j = 0; i < validOffsets.length; ++i) {
+        long startOffset = validOffsets[i - 1];
+        long size = validOffsets[i] - startOffset;
+
+        FileUtils.fileKeyToCommit(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset, extension, ZERO_PAD_FMT);
+        Collection<Object> records = readRecords(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset,
+                                                 extension, ZERO_PAD_FMT, S3_TEST_BUCKET_NAME, s3);
+        // assertEquals(size, records.size());
+        verifyContents(sinkRecords, j, records);
+        j += size;
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Background:**
We are using protobuf as our message schema in kafka. Messages are saved in kafka in byte array format.
When we try to backup our message with S3SinkConnector, we found that the ByteArrayFormat separate messages with separator. We hardly find a suitable separator for our messages.

**Solution:**
Therefore we try to follow the suggestion provided by google and create the SafeByteArrayFormat.
https://developers.google.com/protocol-buffers/docs/techniques?hl=en

The SafeByteArrayFormat write the size of each message before it write the message itself.
When we need to read back the messages from file, we read the first 4 bytes for the length of the message and then read (length of the message) bytes for the message body, repeat til the end.

**Limitation:**
For message size that is larger than Int value, there will be a problem..