### PR TITLE
MINOR: Restore the complete hierarchy of exceptions during failures in part upload

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -133,7 +133,7 @@ public class S3OutputStream extends OutputStream {
         multiPartUpload.abort();
         log.debug("Multipart upload aborted for bucket '{}' key '{}'.", bucket, key);
       }
-      throw new IOException("Part upload failed: ", e.getCause());
+      throw new IOException("Part upload failed: ", e);
     }
   }
 


### PR DESCRIPTION
`e.getCause` returns the cause of `e` (or null), so we will lose `e` from the stack trace.
Here is a real example, we can't even know what `e` actually is:
```
Caused by: java.io.IOException: Part upload failed:
        at io.confluent.connect.s3.storage.S3OutputStream.uploadPart(S3OutputStream.java:135)
        at io.confluent.connect.s3.storage.S3OutputStream.uploadPart(S3OutputStream.java:119)
        at io.confluent.connect.s3.storage.S3OutputStream.write(S3OutputStream.java:107)
        at java.util.zip.DeflaterOutputStream.deflate(DeflaterOutputStream.java:253)
        at java.util.zip.DeflaterOutputStream.write(DeflaterOutputStream.java:211)
        at java.util.zip.GZIPOutputStream.write(GZIPOutputStream.java:145)
        at java.io.FilterOutputStream.write(FilterOutputStream.java:97)
        at io.confluent.connect.s3.format.bytearray.ByteArrayRecordWriterProvider$1.write(ByteArrayRecordWriterProvider.java:68)
        ... 16 more
(END)
```
 