### PR TITLE
Propagate exceptions thrown during time-based commits

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -298,6 +298,7 @@ public class TopicPartitionWriter {
           log.error("Exception on topic partition {}: ", tp, e);
           failureTime = time.milliseconds();
           setRetryTimeout(timeoutMs);
+          throw e; // #269 propagate exceptions from time-based commits
         }
       }
 


### PR DESCRIPTION
ConnectExceptions that were thrown during time-based commits
were being logged but did not get retried. This causes data
loss because the framework assumes that such records were
committed successfully, when they were not. This fix throws
the error upwards, triggering normal error handling.

Thanks @gharris1727 for the fix and the help with the test!

Fixes #269

Signed-off-by: Aakash Shah <ashah@confluent.io>