### PR TITLE
CC-6801: Retry effectively on retriable failures (backport to java 7 branches)

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -22,6 +22,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -51,6 +52,7 @@ public class S3SinkTask extends SinkTask {
 
   private S3SinkConnectorConfig connectorConfig;
   private String url;
+  private long timeoutMs;
   private S3Storage storage;
   private final Set<TopicPartition> assignment;
   private final Map<TopicPartition, TopicPartitionWriter> topicPartitionWriters;
@@ -93,6 +95,7 @@ public class S3SinkTask extends SinkTask {
     try {
       connectorConfig = new S3SinkConnectorConfig(props);
       url = connectorConfig.getString(StorageCommonConfig.STORE_URL_CONFIG);
+      timeoutMs = connectorConfig.getLong(S3SinkConnectorConfig.RETRY_BACKOFF_CONFIG);
 
       @SuppressWarnings("unchecked")
       Class<? extends S3Storage> storageClass =
@@ -123,12 +126,11 @@ public class S3SinkTask extends SinkTask {
 
   @Override
   public void open(Collection<TopicPartition> partitions) {
-    // assignment should be empty, either because this is the initial call or because it follows a call to "close".
+    // assignment should be empty, either because this is the initial call or because it follows
+    // a call to "close".
     assignment.addAll(partitions);
     for (TopicPartition tp : assignment) {
-      TopicPartitionWriter writer =
-          new TopicPartitionWriter(tp, writerProvider, partitioner, connectorConfig, context, time);
-      topicPartitionWriters.put(tp, writer);
+      topicPartitionWriters.put(tp, newTopicPartitionWriter(tp));
     }
   }
 
@@ -177,7 +179,20 @@ public class S3SinkTask extends SinkTask {
     }
 
     for (TopicPartition tp : assignment) {
-      topicPartitionWriters.get(tp).write();
+      TopicPartitionWriter writer = topicPartitionWriters.get(tp);
+      try {
+        writer.write();
+      } catch (RetriableException e) {
+        log.error("Exception on topic partition {}: ", tp, e);
+        Long currentStartOffset = writer.currentStartOffset();
+        if (currentStartOffset != null) {
+          context.offset(tp, currentStartOffset);
+        }
+        context.timeout(timeoutMs);
+        writer = newTopicPartitionWriter(tp);
+        writer.failureTime(time.milliseconds());
+        topicPartitionWriters.put(tp, writer);
+      }
     }
   }
 
@@ -226,6 +241,17 @@ public class S3SinkTask extends SinkTask {
   // Visible for testing
   TopicPartitionWriter getTopicPartitionWriter(TopicPartition tp) {
     return topicPartitionWriters.get(tp);
+  }
+
+  private TopicPartitionWriter newTopicPartitionWriter(TopicPartition tp) {
+    return new TopicPartitionWriter(
+        tp,
+        writerProvider,
+        partitioner,
+        connectorConfig,
+        context,
+        time
+    );
   }
 
   // Visible for testing

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -43,11 +43,13 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.confluent.common.utils.MockTime;
 import io.confluent.common.utils.Time;
 import io.confluent.connect.s3.format.avro.AvroFormat;
 import io.confluent.connect.s3.format.avro.AvroUtils;
+import io.confluent.connect.s3.storage.S3OutputStream;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.s3.util.FileUtils;
 import io.confluent.connect.storage.hive.HiveConfig;
@@ -91,6 +93,29 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
     s3 = newS3Client(connectorConfig);
 
     storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3);
+
+    partitioner = new DefaultPartitioner<>();
+    partitioner.configure(parsedConfig);
+    format = new AvroFormat(storage);
+
+    s3.createBucket(S3_TEST_BUCKET_NAME);
+    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+  }
+
+  //@Before should be omitted in order to be able to add properties per test.
+  public void setUpWithCommitException() throws Exception {
+    super.setUp();
+
+    s3 = newS3Client(connectorConfig);
+
+    storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3) {
+      private final AtomicInteger retries = new AtomicInteger(0);
+
+      @Override
+      public S3OutputStream create(String path, boolean overwrite) {
+        return new TopicPartitionWriterTest.S3OutputStreamFlaky(path, this.conf(), s3, retries);
+      }
+    };
 
     partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
@@ -393,6 +418,93 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
     offsetsToCommit = task.preCommit(null);
 
     verifyOffsets(offsetsToCommit, validOffsets2, context.assignment());
+
+    task.close(context.assignment());
+    task.stop();
+  }
+
+  @Test
+  public void testPreCommitOnRotateScheduleTimeWithException() throws Exception {
+    // Do not roll on size, only based on time.
+    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.HOURS.toMillis(1))
+    );
+    setUpWithCommitException();
+
+    // Define the partitioner
+    TimeBasedPartitioner<FieldSchema> partitioner = new TimeBasedPartitioner<>();
+    parsedConfig.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.DAYS.toMillis(1));
+    parsedConfig.put(
+        PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG,
+        TimeBasedSchemaGenerator.class
+    );
+    parsedConfig.put(
+        PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
+        TopicPartitionWriterTest.MockedWallclockTimestampExtractor.class.getName()
+    );
+    partitioner.configure(parsedConfig);
+
+    MockTime time = ((TopicPartitionWriterTest.MockedWallclockTimestampExtractor) partitioner
+        .getTimestampExtractor()).time;
+    // Bring the clock to present.
+    time.sleep(SYSTEM.milliseconds());
+
+    List<SinkRecord> sinkRecords = createRecordsWithTimestamp(
+        3,
+        0,
+        Collections.singleton(new TopicPartition(TOPIC, PARTITION)),
+        time
+    );
+
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time);
+
+    // Perform write
+    task.put(sinkRecords);
+    Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = task.preCommit(null);
+
+    long[] validOffsets1 = {-1, -1};
+    verifyOffsets(offsetsToCommit, validOffsets1, context.assignment());
+
+    // 1 hour + 10 minutes
+    time.sleep(TimeUnit.HOURS.toMillis(1) + TimeUnit.MINUTES.toMillis(10));
+
+    // Perform write with no records that will flush the outstanding records due to scheduled
+    // interval
+    task.put(Collections.<SinkRecord>emptyList());
+
+    // After the exception is caught the connector resets offsets for rewind to the start offset
+    long[] validOffsets2 = {0, -1};
+    verifyRawOffsets(context.offsets(), validOffsets2, context.assignment());
+
+    // Offsets get rewind and the consumer redelivers the records that failed to commit
+    task.put(sinkRecords);
+
+    // But a retry backoff is in effect so these records won't be written to the underlying
+    // output stream until the backoff expires. Of course no offset commits happen either
+    offsetsToCommit = task.preCommit(null);
+
+    long[] validOffsets3 = {-1, -1};
+    verifyOffsets(offsetsToCommit, validOffsets3, context.assignment());
+
+    time.sleep(TimeUnit.MINUTES.toMillis(
+        connectorConfig.getLong(S3SinkConnectorConfig.RETRY_BACKOFF_CONFIG)));
+
+    // The backoff expires, the records are written to the underlying output stream. No commits yet
+    task.put(Collections.<SinkRecord>emptyList());
+
+    long[] validOffsets4 = {-1, -1};
+    verifyOffsets(offsetsToCommit, validOffsets4, context.assignment());
+
+    // 1 hour + 10 minutes
+    time.sleep(TimeUnit.HOURS.toMillis(1) + TimeUnit.MINUTES.toMillis(10));
+
+    task.put(Collections.<SinkRecord>emptyList());
+    offsetsToCommit = task.preCommit(null);
+
+    long[] validOffsets5 = {3, -1};
+    verifyOffsets(offsetsToCommit, validOffsets5, context.assignment());
 
     task.close(context.assignment());
     task.stop();
@@ -768,6 +880,22 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
       long offset = validOffsets[i++];
       if (offset >= 0) {
         expectedOffsets.put(tp, new OffsetAndMetadata(offset, ""));
+      }
+    }
+    assertTrue(Objects.equals(actualOffsets, expectedOffsets));
+  }
+
+  protected void verifyRawOffsets(
+      Map<TopicPartition, Long> actualOffsets,
+      long[] validOffsets,
+      Set<TopicPartition> partitions
+  ) {
+    int i = 0;
+    Map<TopicPartition, Long> expectedOffsets = new HashMap<>();
+    for (TopicPartition tp : partitions) {
+      long offset = validOffsets[i++];
+      if (offset >= 0) {
+        expectedOffsets.put(tp, offset);
       }
     }
     assertTrue(Objects.equals(actualOffsets, expectedOffsets));

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
@@ -16,6 +16,7 @@
 
 package io.confluent.connect.s3;
 
+import akka.parboiled2.RuleTrace;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AnonymousAWSCredentials;
@@ -27,6 +28,7 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.findify.s3mock.S3Mock;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -41,9 +43,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.confluent.connect.s3.format.avro.AvroUtils;
 import io.confluent.connect.s3.format.json.JsonUtils;
+import io.confluent.connect.s3.storage.S3OutputStream;
 import io.confluent.connect.s3.util.FileUtils;
 import io.confluent.connect.storage.common.StorageCommonConfig;
 
@@ -158,4 +162,21 @@ public class TestWithMockedS3 extends S3SinkConnectorTestBase {
     return builder.build();
   }
 
+  class S3OutputStreamFlaky extends S3OutputStream {
+    private final AtomicInteger retries;
+
+    public S3OutputStreamFlaky(String key, S3SinkConnectorConfig conf, AmazonS3 s3, AtomicInteger retries) {
+      super(key, conf, s3);
+      this.retries = retries;
+    }
+
+    @Override
+    public void commit() throws IOException {
+      if (retries.getAndIncrement() == 0) {
+        close();
+        throw new ConnectException("Fake exception");
+      }
+      super.commit();
+    }
+  }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -24,6 +24,7 @@ import org.apache.kafka.connect.connector.ConnectRecord;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -38,9 +39,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import io.confluent.common.utils.MockTime;
 import io.confluent.connect.s3.format.avro.AvroFormat;
+import io.confluent.connect.s3.storage.S3OutputStream;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.s3.util.FileUtils;
 import io.confluent.connect.s3.util.TimeUtils;
@@ -85,6 +88,26 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
     s3 = newS3Client(connectorConfig);
     storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3);
+    format = new AvroFormat(storage);
+
+    Format<S3SinkConnectorConfig, String> format = new AvroFormat(storage);
+    writerProvider = format.getRecordWriterProvider();
+    extension = writerProvider.getExtension();
+  }
+
+  public void setUpWithCommitException() throws Exception {
+    super.setUp();
+
+    s3 = newS3Client(connectorConfig);
+    storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3) {
+      private final AtomicInteger retries = new AtomicInteger(0);
+
+      @Override
+      public S3OutputStream create(String path, boolean overwrite) {
+        return new S3OutputStreamFlaky(path, this.conf(), s3, retries);
+      }
+    };
+
     format = new AvroFormat(storage);
 
     Format<S3SinkConnectorConfig, String> format = new AvroFormat(storage);
@@ -572,6 +595,53 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
                                                   ZERO_PAD_FMT));
     }
     verify(expectedFiles, 3, schema, records);
+  }
+
+  @Test(expected = RetriableException.class)
+  public void testPropagateErrorsDuringTimeBasedCommits() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.HOURS.toMillis(1))
+    );
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.MINUTES.toMillis(10))
+    );
+    setUpWithCommitException();
+
+    // Define the partitioner
+    TimeBasedPartitioner<FieldSchema> partitioner = new TimeBasedPartitioner<>();
+    parsedConfig.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.DAYS.toMillis(1));
+    parsedConfig.put(PartitionerConfig.SCHEMA_GENERATOR_CLASS_CONFIG, TimeBasedSchemaGenerator.class);
+    parsedConfig.put(
+        PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockedWallclockTimestampExtractor.class.getName());
+    partitioner.configure(parsedConfig);
+
+    MockTime time = ((MockedWallclockTimestampExtractor) partitioner.getTimestampExtractor()).time;
+
+    // Bring the clock to present.
+    time.sleep(SYSTEM.milliseconds());
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context, time);
+
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 3, 6);
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records.subList(0, 3), key, schema);
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // No records written to S3
+    topicPartitionWriter.write();
+    long timestampFirst = time.milliseconds();
+
+    // 11 minutes
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+    // Records are written due to scheduled rotation
+    topicPartitionWriter.write();
   }
 
   @Test


### PR DESCRIPTION
The connector so far has treated failures that occur when the output stream is closed as retriable only when rotate.schedule.interval.ms is set and it needs to flush outstanding records due to inactivity.

However, offsets are not reset correctly, and retrying after the timeout expires might result in records being skipped as described in #269

This fix applies proper reset to the start offset that allows the consumer of a task to rewind correctly and considers any failure during file-commits (finalization of uploads) as a retriable exception.