### PR TITLE
S3 Object Level Tagging for Offsets & Record Counts

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -8,7 +8,7 @@
     <!-- Intentionally high coupling to pull together config classes -->
     <suppress
             checks="ClassDataAbstractionCoupling"
-            files="(S3OutputStream|S3SinkConnectorConfig).java"
+            files="(S3OutputStream|S3SinkConnectorConfig|S3Storage).java"
     />
 
     <suppress

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -227,7 +227,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Type.BOOLEAN,
           S3_OBJECT_TAGGING_DEFAULT,
           Importance.LOW,
-          "Tag S3 objects with offsets & record count.",
+          "Tag S3 objects with start and end offsets, as well as record count.",
           group,
           ++orderInGroup,
           Width.LONG,

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -66,6 +66,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   // S3 Group
   public static final String S3_BUCKET_CONFIG = "s3.bucket.name";
 
+  public static final String S3_OBJECT_TAGGING_CONFIG = "s3.object.tagging";
+  public static final boolean S3_OBJECT_TAGGING_DEFAULT = false;
+
   public static final String SSEA_CONFIG = "s3.ssea.name";
   public static final String SSEA_DEFAULT = "";
 
@@ -186,6 +189,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.LONG,
           "S3 Bucket"
+      );
+
+      configDef.define(
+          S3_OBJECT_TAGGING_CONFIG,
+          Type.BOOLEAN,
+          S3_OBJECT_TAGGING_DEFAULT,
+          Importance.LOW,
+          "Tag S3 objects with offsets & record count.",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "S3 Object Tagging"
       );
 
       configDef.define(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -132,6 +132,7 @@ public class S3SinkTask extends SinkTask {
     for (TopicPartition tp : assignment) {
       TopicPartitionWriter writer = new TopicPartitionWriter(
           tp,
+          storage,
           writerProvider,
           partitioner,
           connectorConfig,

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -90,16 +90,6 @@ public class TopicPartitionWriter {
   private final S3SinkConnectorConfig connectorConfig;
   private static final Time SYSTEM_TIME = new SystemTime();
 
-  @Deprecated
-  public TopicPartitionWriter(TopicPartition tp,
-                              S3Storage storage,
-                              RecordWriterProvider<S3SinkConnectorConfig> writerProvider,
-                              Partitioner<?> partitioner,
-                              S3SinkConnectorConfig connectorConfig,
-                              SinkTaskContext context) {
-    this(tp, storage, writerProvider, partitioner, connectorConfig, context);
-  }
-
   public TopicPartitionWriter(TopicPartition tp,
                               S3Storage storage,
                               RecordWriterProvider<S3SinkConnectorConfig> writerProvider,

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -569,9 +569,9 @@ public class TopicPartitionWriter {
         log.info("Tagged file {} with starting offset {}, ending offset {}, record count {}",
             s3ObjectPath, startOffsets, endOffsets, recordCount);
       } catch (SdkClientException e) {
-        log.warn("Unable to tag file {}. Ignoring.", s3ObjectPath);
+        log.warn("Unable to tag file {}. Ignoring.", s3ObjectPath, e);
       } catch (Exception e) {
-        log.warn("Unrecoverable exception while attempting to tag s3 object. Ignoring.");
+        log.warn("Unrecoverable exception while attempting to tag s3 object. Ignoring.", e);
       }
     }
   }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -34,8 +34,7 @@ import org.apache.avro.file.SeekableInput;
 
 import java.io.OutputStream;
 import java.util.Map;
-import java.util.List;
-import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.util.S3ProxyConfig;
@@ -225,15 +224,11 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
   @Override
   public void close() {}
 
-  public void addTags(String fileName, Map<String, String> tags)
-          throws SdkClientException {
+  public void addTags(String fileName, Map<String, String> tags) throws SdkClientException {
     ObjectTagging objectTagging = new ObjectTagging(tags.entrySet().stream()
         .map(e -> new Tag(e.getKey(), e.getValue()))
         .collect(Collectors.toList()));
-    s3.setObjectTagging(new SetObjectTaggingRequest(
-            this.bucketName,
-            fileName,
-            new ObjectTagging(newTagList)));
+    s3.setObjectTagging(new SetObjectTaggingRequest(this.bucketName, fileName, objectTagging));
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -227,10 +227,9 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
 
   public void addTags(String fileName, Map<String, String> tags)
           throws SdkClientException {
-    List<Tag> newTagList = new ArrayList<>();
-    for (Map.Entry<String, String> entry : tags.entrySet()) {
-      newTagList.add(new Tag(entry.getKey(), entry.getValue()));
-    }
+    ObjectTagging objectTagging = new ObjectTagging(tags.entrySet().stream()
+        .map(e -> new Tag(e.getKey(), e.getValue()))
+        .collect(Collectors.toList()));
     s3.setObjectTagging(new SetObjectTaggingRequest(
             this.bucketName,
             fileName,

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -25,9 +25,16 @@ import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectListing;
+import com.amazonaws.services.s3.model.ObjectTagging;
+import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
+import com.amazonaws.services.s3.model.Tag;
+import com.amazonaws.SdkClientException;
 import org.apache.avro.file.SeekableInput;
 
 import java.io.OutputStream;
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.util.S3ProxyConfig;
@@ -211,6 +218,18 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
 
   @Override
   public void close() {}
+
+  public void addTags(String fileName, Map<String, String> tags)
+          throws SdkClientException {
+    List<Tag> newTagList = new ArrayList<>();
+    for (Map.Entry<String, String> entry : tags.entrySet()) {
+      newTagList.add(new Tag(entry.getKey(), entry.getValue()));
+    }
+    s3.setObjectTagging(new SetObjectTaggingRequest(
+            this.bucketName,
+            fileName,
+            new ObjectTagging(newTagList)));
+  }
 
   @Override
   public ObjectListing list(String path) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -256,6 +256,20 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     connectorConfig.getCredentialsProvider();
   }
 
+  @Test
+  public void testConfigurableS3ObjectTaggingConfigs() {
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(false, connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG));
+
+    properties.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "true");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(true, connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG));
+
+    properties.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "false");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(false, connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG));
+  }
+
   private void assertDefaultPartitionerVisibility(List<ConfigValue> values) {
     for (ConfigValue val : values) {
       switch (val.name()) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -33,6 +33,7 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -666,7 +667,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Bring the clock to present.
     time.sleep(SYSTEM.milliseconds());
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context, time);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time);
 
     String key = "key";
     Schema schema = createSchema();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -17,6 +17,7 @@ package io.confluent.connect.s3;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
+import com.amazonaws.services.s3.model.Tag;
 import io.confluent.common.utils.SystemTime;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -513,7 +514,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Time systemTime = EasyMock.createMock(SystemTime.class);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context, systemTime);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, systemTime);
 
     // Freeze clock passed into topicPartitionWriter, so we know what time it will use for "now"
     long freezeTime = 3599000L;
@@ -564,7 +565,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Bring the clock to present.
     time.sleep(SYSTEM.milliseconds());
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context, time);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time);
 
     String key = "key";
     Schema schema = createSchema();
@@ -792,6 +793,44 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     verify(expectedFiles, 3, schema, records);
   }
 
+  @Test
+  public void testAddingS3ObjectTags() throws Exception{
+    // Setting size-based rollup to 10 but will produce fewer records. Commit should not happen.
+    localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "true");
+    setUp();
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new DefaultPartitioner<>();
+    partitioner.configure(parsedConfig);
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 3, 3);
+
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // Test actual write
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    // Check expected s3 object tags
+    String dirPrefix = partitioner.generatePartitionedPath(TOPIC, "partition=" + PARTITION);
+    Map<String, List<Tag>> expectedTaggedFiles = new HashMap<>();
+    expectedTaggedFiles.put(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 0, extension, ZERO_PAD_FMT),
+            Arrays.asList(new Tag("startOffset", "0"), new Tag("endOffset", "2"), new Tag("recordCount", "3")));
+    expectedTaggedFiles.put(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 3, extension, ZERO_PAD_FMT),
+            Arrays.asList(new Tag("startOffset", "3"), new Tag("endOffset", "5"), new Tag("recordCount", "3")));
+    expectedTaggedFiles.put(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 6, extension, ZERO_PAD_FMT),
+            Arrays.asList(new Tag("startOffset", "6"), new Tag("endOffset", "8"), new Tag("recordCount", "3")));
+    verifyTags(expectedTaggedFiles);
+  }
+
   private Struct createRecord(Schema schema, int ibase, float fbase) {
     return new Struct(schema)
                .put("boolean", true)
@@ -869,6 +908,27 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
         Object expectedRecord = format.getAvroData().fromConnectData(schema, records.get(index++));
         assertEquals(expectedRecord, avroRecord);
       }
+    }
+  }
+
+  private void verifyTags(Map<String, List<Tag>> expectedTaggedFiles)
+          throws IOException {
+    List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
+    List<String> actualFiles = new ArrayList<>();
+    for (S3ObjectSummary summary : summaries) {
+      String fileKey = summary.getKey();
+      actualFiles.add(fileKey);
+    }
+
+    List<String> expectedFileKeys = new ArrayList<>(expectedTaggedFiles.keySet());
+    Collections.sort(actualFiles);
+    Collections.sort(expectedFileKeys);
+    assertThat(actualFiles, is(expectedFileKeys));
+
+    for (String fileKey : actualFiles) {
+      List<Tag> actualTags = getS3ObjectTags(S3_TEST_BUCKET_NAME, fileKey, s3);
+      List<Tag> expectedTags = expectedTaggedFiles.get(fileKey);
+      assertTrue(actualTags.containsAll(expectedTags));
     }
   }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -115,7 +115,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -148,7 +148,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -182,7 +182,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -239,7 +239,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -297,7 +297,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
         PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockedWallclockTimestampExtractor.class.getName());
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -369,7 +369,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -426,7 +426,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -483,7 +483,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -634,7 +634,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchemaWithTimestampField();
@@ -706,7 +706,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -740,7 +740,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();
@@ -769,7 +769,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
 
     String key = "key";
     Schema schema = createSchema();


### PR DESCRIPTION
PR for https://github.com/confluentinc/kafka-connect-storage-cloud/issues/201

This PR gives the S3 Connector Plugin the option to add s3 object level tags for starting offset, ending offset, and total record count of a given file. This should provide users a greater ability to track and monitor records written to s3.