### PR TITLE
CC-7892: Introduce configuration properties for key and secret to easily define credentials per connector instance

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -281,7 +281,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           new CredentialsProviderValidator(),
           Importance.LOW,
           "Credentials provider or provider chain to use for authentication to AWS. By default "
-              + "the connector uses ``DefaultAWSCredentialsProviderChain``.",
+              + "the connector uses ``"
+              + DefaultAWSCredentialsProviderChain.class.getSimpleName()
+              + "``.",
+
           group,
           ++orderInGroup,
           Width.LONG,
@@ -295,8 +298,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Importance.HIGH,
           "The AWS access key ID used to authenticate personal AWS credentials such as IAM "
               + "credentials. Use only if you do not wish to authenticate by using a credentials "
-              + "provider class via "
-              + CREDENTIALS_PROVIDER_CLASS_CONFIG,
+              + "provider class via ``"
+              + CREDENTIALS_PROVIDER_CLASS_CONFIG
+              + "``",
           group,
           ++orderInGroup,
           Width.LONG,
@@ -310,8 +314,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Importance.HIGH,
           "The secret access key used to authenticate personal AWS credentials such as IAM "
               + "credentials. Use only if you do not wish to authenticate by using a credentials "
-              + "provider class via "
-              + CREDENTIALS_PROVIDER_CLASS_CONFIG,
+              + "provider class via ``"
+              + CREDENTIALS_PROVIDER_CLASS_CONFIG
+              + "``",
           group,
           ++orderInGroup,
           Width.LONG,
@@ -631,8 +636,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       if (provider instanceof Configurable) {
         Map<String, Object> configs = originalsWithPrefix(CREDENTIALS_PROVIDER_CONFIG_PREFIX);
         configs.remove(CREDENTIALS_PROVIDER_CLASS_CONFIG.substring(
-            CREDENTIALS_PROVIDER_CONFIG_PREFIX.length(),
-            CREDENTIALS_PROVIDER_CLASS_CONFIG.length()
+            CREDENTIALS_PROVIDER_CONFIG_PREFIX.length()
         ));
         ((Configurable) provider).configure(configs);
       }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -106,6 +106,12 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           CREDENTIALS_PROVIDER_CLASS_CONFIG.lastIndexOf(".") + 1
       );
 
+  public static final String AWS_ACCESS_KEY_ID_CONFIG = "aws.access.key.id";
+  public static final String AWS_ACCESS_KEY_ID_DEFAULT = "";
+
+  public static final String AWS_SECRET_ACCESS_KEY_CONFIG = "aws.secret.access.key";
+  public static final Password AWS_SECRET_ACCESS_KEY_DEFAULT = new Password(null);
+
   public static final String REGION_CONFIG = "s3.region";
   public static final String REGION_DEFAULT = Regions.DEFAULT_REGION.getName();
 
@@ -280,6 +286,36 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.LONG,
           "AWS Credentials Provider Class"
+      );
+
+      configDef.define(
+          AWS_ACCESS_KEY_ID_CONFIG,
+          Type.STRING,
+          AWS_ACCESS_KEY_ID_DEFAULT,
+          Importance.HIGH,
+          "The AWS access key ID used to authenticate personal AWS credentials such as IAM "
+              + "credentials. Use only if you do not wish to authenticate by using a credentials "
+              + "provider class via "
+              + CREDENTIALS_PROVIDER_CLASS_CONFIG,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "AWS Access Key ID"
+      );
+
+      configDef.define(
+          AWS_SECRET_ACCESS_KEY_CONFIG,
+          Type.PASSWORD,
+          AWS_SECRET_ACCESS_KEY_DEFAULT,
+          Importance.HIGH,
+          "The secret access key used to authenticate personal AWS credentials such as IAM "
+              + "credentials. Use only if you do not wish to authenticate by using a credentials "
+              + "provider class via "
+              + CREDENTIALS_PROVIDER_CLASS_CONFIG,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "AWS Secret Access Key"
       );
 
       List<String> validSsea = new ArrayList<>(SSEAlgorithm.values().length + 1);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DummyAssertiveCredentialsProvider.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DummyAssertiveCredentialsProvider.java
@@ -25,7 +25,8 @@ import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
 
-class DummyAssertiveCredentialsProvider implements AWSCredentialsProvider, Configurable {
+public final class DummyAssertiveCredentialsProvider implements AWSCredentialsProvider,
+    Configurable {
 
   public static final String ACCESS_KEY_NAME = "access.key";
   public static final String SECRET_KEY_NAME = "secret.key";

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3StorageTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3StorageTest.java
@@ -17,16 +17,19 @@ package io.confluent.connect.s3.storage;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.retry.PredefinedBackoffStrategies;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
 import org.apache.http.HttpStatus;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.util.HashMap;
 import java.util.Map;
 
+import io.confluent.connect.s3.DummyAssertiveCredentialsProvider;
+import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.S3SinkConnectorTestBase;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_RETRY_BACKOFF_CONFIG;
@@ -53,7 +56,7 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
     return props;
   }
 
-  @Before
+  //@Before should be omitted in order to be able to add properties per test.
   public void setUp() throws Exception {
     super.setUp();
     storage = new S3Storage(connectorConfig, url);
@@ -62,6 +65,7 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
 
   @Test
   public void testRetryPolicy() throws Exception {
+    setUp();
     assertTrue(retryPolicy.getRetryCondition() instanceof PredefinedRetryPolicies
         .SDKDefaultRetryCondition);
     assertTrue(retryPolicy.getBackoffStrategy() instanceof PredefinedBackoffStrategies
@@ -70,12 +74,14 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
 
   @Test
   public void testRetryPolicyNonRetriable() throws Exception {
+    setUp();
     AmazonClientException e = new AmazonClientException("Non-retriable exception");
     assertFalse(retryPolicy.getRetryCondition().shouldRetry(null, e, 1));
   }
 
   @Test
   public void testRetryPolicyRetriableServiceException() throws Exception {
+    setUp();
     AmazonServiceException e = new AmazonServiceException("Retriable exception");
     e.setStatusCode(HttpStatus.SC_INTERNAL_SERVER_ERROR);
     assertTrue(retryPolicy.getRetryCondition().shouldRetry(null, e, 1));
@@ -83,6 +89,7 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
 
   @Test
   public void testRetryPolicyNonRetriableServiceException() throws Exception {
+    setUp();
     AmazonServiceException e = new AmazonServiceException("Non-retriable exception");
     e.setStatusCode(HttpStatus.SC_METHOD_NOT_ALLOWED);
     assertFalse(retryPolicy.getRetryCondition().shouldRetry(null, e, 1));
@@ -90,6 +97,7 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
 
   @Test
   public void testRetryPolicyRetriableThrottlingException() throws Exception {
+    setUp();
     AmazonServiceException e = new AmazonServiceException("Retriable exception");
     e.setErrorCode("TooManyRequestsException");
     assertTrue(retryPolicy.getRetryCondition().shouldRetry(null, e, 1));
@@ -97,6 +105,7 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
 
   @Test
   public void testRetryPolicyRetriableSkewException() throws Exception {
+    setUp();
     AmazonServiceException e = new AmazonServiceException("Retriable exception");
     e.setErrorCode("RequestExpired");
     assertTrue(retryPolicy.getRetryCondition().shouldRetry(null, e, 1));
@@ -104,12 +113,52 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
 
   @Test
   public void testRetryPolicyDelayRanges() throws Exception {
+    setUp();
     assertComputeRetryInRange(10, 10L);
     assertComputeRetryInRange(10, 100L);
     assertComputeRetryInRange(10, 1000L);
     assertComputeRetryInRange(MAX_RETRIES + 1, 1000L);
     assertComputeRetryInRange(100, S3_RETRY_MAX_BACKOFF_TIME_MS + 1);
     assertComputeRetryInRange(MAX_RETRIES + 1, S3_RETRY_MAX_BACKOFF_TIME_MS + 1);
+  }
+
+  @Test
+  public void testDefaultCredentialsProvider() throws Exception {
+    // default values
+    setUp();
+    AWSCredentialsProvider credentialsProvider = storage.newCredentialsProvider(connectorConfig);
+    assertTrue(S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_DEFAULT.isInstance(credentialsProvider));
+
+    // empty default values
+    localProps.put(S3SinkConnectorConfig.AWS_ACCESS_KEY_ID_CONFIG, "");
+    localProps.put(S3SinkConnectorConfig.AWS_SECRET_ACCESS_KEY_CONFIG, "");
+    setUp();
+    credentialsProvider = storage.newCredentialsProvider(connectorConfig);
+    assertTrue(S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_DEFAULT.isInstance(credentialsProvider));
+  }
+
+  @Test
+  public void testUserDefinedCredentialsProvider() throws Exception {
+    String configPrefix = S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CONFIG_PREFIX;
+    localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.ACCESS_KEY_NAME), "foo_key");
+    localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.SECRET_KEY_NAME), "bar_secret");
+    localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME), "3");
+    localProps.put(
+        S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
+        DummyAssertiveCredentialsProvider.class.getName()
+    );
+    setUp();
+    AWSCredentialsProvider credentialsProvider = storage.newCredentialsProvider(connectorConfig);
+    assertTrue(credentialsProvider instanceof DummyAssertiveCredentialsProvider);
+  }
+
+  @Test
+  public void testUserSuppliedCredentials() throws Exception {
+    localProps.put(S3SinkConnectorConfig.AWS_ACCESS_KEY_ID_CONFIG, "foo_key");
+    localProps.put(S3SinkConnectorConfig.AWS_SECRET_ACCESS_KEY_CONFIG, "bar_secret");
+    setUp();
+    AWSCredentialsProvider credentialsProvider = storage.newCredentialsProvider(connectorConfig);
+    assertTrue(credentialsProvider instanceof AWSStaticCredentialsProvider);
   }
 
   /**
@@ -134,7 +183,6 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
       int retryAttempts,
       long retryBackoffMs
   ) throws Exception {
-
     localProps.put(S3_RETRY_BACKOFF_CONFIG, String.valueOf(retryBackoffMs));
     setUp();
     RetryPolicy.BackoffStrategy backoffStrategy = retryPolicy.getBackoffStrategy();


### PR DESCRIPTION
Hello there, here is a functionality add that allows for secret/access key pairs to be defined for each connector instance in a connect cluster.  There are two new connector config settings and if they are not null the _AWSStaticCredentialsProvider_ is used and the credentials passed instead of using the provider chain that uses the environment variables or system properties that can't be set per connector.  Features like AssumeRole are the best practice in AWS itself but for devices that emulate the S3 API these kind of credential options are important.  Also, notice that this feature exposes this issue (https://github.com/aws/aws-sdk-java/issues/1256) but can be easily fixed when the AWS SDK version is increased.