### PR TITLE
CC-8085: Allow setting compression level for gzip in Json and ByteArray formats

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -141,7 +141,7 @@
                             <goal>testCompile</goal>
                         </goals>
                         <configuration>
-                            <source>1.7</source>
+                            <source>1.8</source>
                             <target>1.8</target>
                         </configuration>
                     </execution>

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/CompressionType.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/CompressionType.java
@@ -20,6 +20,7 @@ import org.apache.kafka.connect.errors.ConnectException;
 
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.zip.Deflater;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
@@ -39,8 +40,18 @@ public enum CompressionType {
   GZIP("gzip", ".gz") {
     @Override
     public OutputStream wrapForOutput(OutputStream out) {
+      return wrapForOutput(out, Deflater.DEFAULT_COMPRESSION);
+    }
+
+    @Override
+    public OutputStream wrapForOutput(OutputStream out, int level) {
       try {
-        return new GZIPOutputStream(out, GZIP_BUFFER_SIZE_BYTES);
+        return new GZIPOutputStream(out, GZIP_BUFFER_SIZE_BYTES) {
+          public OutputStream setLevel(int level) {
+            def.setLevel(level);
+            return this;
+          }
+        }.setLevel(level);
       } catch (Exception e) {
         throw new ConnectException(e);
       }
@@ -64,7 +75,7 @@ public enum CompressionType {
           throw new ConnectException(e);
         }
       } else {
-        throw new ConnectException("Expected compressionFilter to be a DeflatorOutputStream, "
+        throw new ConnectException("Expected compressionFilter to be a DeflaterOutputStream, "
             + "but was passed an instance that does not match that type.");
       }
     }
@@ -104,6 +115,18 @@ public enum CompressionType {
    */
   public OutputStream wrapForOutput(OutputStream out) {
     return out;
+  }
+
+  /**
+   * Wrap {@code out} with a filter that will compress data with this CompressionType at the
+   * given compression level (optional operation).
+   *
+   * @param out the {@link OutputStream} to wrap
+   * @param level the compression level for this compression type
+   * @return a wrapped version of {@code out} that will apply compression at the given level
+   */
+  public OutputStream wrapForOutput(OutputStream out, int level) {
+    return wrapForOutput(out);
   }
 
   /**

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -63,6 +63,7 @@ public class S3OutputStream extends OutputStream {
   private ByteBuffer buffer;
   private MultipartUpload multiPartUpload;
   private final CompressionType compressionType;
+  private final int compressionLevel;
   private volatile OutputStream compressionFilter;
 
   public S3OutputStream(String key, S3SinkConnectorConfig conf, AmazonS3 s3) {
@@ -82,6 +83,7 @@ public class S3OutputStream extends OutputStream {
     this.progressListener = new ConnectProgressListener();
     this.multiPartUpload = null;
     this.compressionType = conf.getCompressionType();
+    this.compressionLevel = conf.getCompressionLevel();
     log.debug("Create S3OutputStream for bucket '{}' key '{}'", bucket, key);
   }
 
@@ -260,7 +262,7 @@ public class S3OutputStream extends OutputStream {
   public OutputStream wrapForCompression() {
     if (compressionFilter == null) {
       // Initialize compressionFilter the first time this method is called.
-      compressionFilter = compressionType.wrapForOutput(this);
+      compressionFilter = compressionType.wrapForOutput(this, compressionLevel);
     }
     return compressionFilter;
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -32,6 +32,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import io.confluent.connect.s3.format.avro.AvroFormat;
 import io.confluent.connect.s3.format.json.JsonFormat;
@@ -316,18 +318,39 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
       }
     }
   }
+
   @Test(expected = ConfigException.class)
   public void testS3PartRetriesNegative() {
     properties.put(S3SinkConnectorConfig.S3_PART_RETRIES_CONFIG, "-1");
     connectorConfig = new S3SinkConnectorConfig(properties);
-    connectorConfig.getInt(S3SinkConnectorConfig.S3_PART_RETRIES_CONFIG);
   }
 
   @Test(expected = ConfigException.class)
   public void testS3RetryBackoffNegative() {
     properties.put(S3SinkConnectorConfig.S3_RETRY_BACKOFF_CONFIG, "-1");
     connectorConfig = new S3SinkConnectorConfig(properties);
-    connectorConfig.getLong(S3SinkConnectorConfig.S3_RETRY_BACKOFF_CONFIG);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testInvalidHighCompressionLevel() {
+    properties.put(S3SinkConnectorConfig.COMPRESSION_LEVEL_CONFIG, "10");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testInvalidLowCompressionLevel() {
+    properties.put(S3SinkConnectorConfig.COMPRESSION_LEVEL_CONFIG, "-2");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+  }
+
+  @Test
+  public void testValidCompressionLevels() {
+    IntStream.range(-1, 9).boxed().forEach(i -> {
+          properties.put(S3SinkConnectorConfig.COMPRESSION_LEVEL_CONFIG, String.valueOf(i));
+          connectorConfig = new S3SinkConnectorConfig(properties);
+          assertEquals((int) i, connectorConfig.getCompressionLevel());
+        }
+    );
   }
 }
 


### PR DESCRIPTION
This change will allow users to specify a specific level of compression when using the gzip compression type with Json or ByteArray formats. 