### PR TITLE
MINOR: Pin httpclient dependency to 4.5.9 to silence warning by the AWS SDK

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -38,6 +38,7 @@
     <properties>
         <aws.version>1.11.725</aws.version>
         <s3mock.version>0.1.5</s3mock.version>
+        <apache.httpclient.version>4.5.9</apache.httpclient.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
     </properties>
 
@@ -64,6 +65,11 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${apache.httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>


### PR DESCRIPTION
Adapting temporarily to https://github.com/aws/aws-sdk-java/issues/1919 until a newer version of httpclient is inherited by the imported hadoop or kafka-connect-storage-common dependencies. 

Without this PR a warning is issued every time `S3Storage` instantiates a new AWS S3 client

``WARN NoSuchMethodException was thrown when disabling normalizeUri. This indicates you are using an old version (< 4.5.8) of Apache http client. It is recommended to use http client version >= 4.5.9 to avoid the breaking change introduced in apache client 4.5.7 and the latency in exception handling. See https://github.com/aws/aws-sdk-java/issues/1919 for more information (com.amazonaws.http.apache.utils.ApacheUtils:246)``