### PR TITLE
Add AWS IAM Assume Role credentials provider

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -57,6 +57,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.amazonaws</groupId>
+                <artifactId>aws-java-sdk-sts</artifactId>
+                <version>${aws.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -64,6 +69,10 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk-sts</artifactId>
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -1,18 +1,17 @@
 /*
- * Copyright 2020 Confluent Inc., Nordstrom Inc.
+ * Copyright 2020 Confluent Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package io.confluent.connect.s3.auth;
@@ -73,7 +72,8 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
     return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
         .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
         .withExternalId(roleExternalId)
-        .build().getCredentials();
+        .build()
+        .getCredentials();
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -21,9 +21,9 @@ import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
-import io.confluent.common.config.AbstractConfig;
-import io.confluent.common.config.ConfigDef;
 import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
 
 import java.util.Map;
 
@@ -55,7 +55,7 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
           ConfigDef.Importance.HIGH,
           "Role session name to use when starting a session"
       );
-  
+
   private String roleArn;
   private String roleExternalId;
   private String roleSessionName;
@@ -70,15 +70,10 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
 
   @Override
   public AWSCredentials getCredentials() {
-    AWSSecurityTokenServiceClientBuilder clientBuilder =
-        AWSSecurityTokenServiceClientBuilder.standard();
-    AWSCredentialsProvider provider =
-        new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
-            .withStsClient(clientBuilder.defaultClient())
-            .withExternalId(roleExternalId)
-            .build();
-
-    return provider.getCredentials();
+    return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
+        .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
+        .withExternalId(roleExternalId)
+        .build().getCredentials();
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2020 Confluent Inc., Nordstrom Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package io.confluent.connect.s3.auth;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import io.confluent.common.config.AbstractConfig;
+import io.confluent.common.config.ConfigDef;
+import org.apache.kafka.common.Configurable;
+
+import java.util.Map;
+
+/**
+ * AWS credentials provider that uses the AWS Security Token Service to assume a Role and create a
+ * temporary, short-lived session to use for authentication.  This credentials provider does not
+ * support refreshing the credentials in a background thread.
+ */
+public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider, Configurable {
+
+  public static final String ROLE_EXTERNAL_ID_CONFIG = "sts.role.external.id";
+  public static final String ROLE_ARN_CONFIG = "sts.role.arn";
+  public static final String ROLE_SESSION_NAME_CONFIG = "sts.role.session.name";
+
+  private static final ConfigDef STS_CONFIG_DEF = new ConfigDef()
+      .define(
+          ROLE_EXTERNAL_ID_CONFIG,
+          ConfigDef.Type.STRING,
+          ConfigDef.Importance.MEDIUM,
+          "The role external ID used when retrieving session credentials under an assumed role."
+      ).define(
+          ROLE_ARN_CONFIG,
+          ConfigDef.Type.STRING,
+          ConfigDef.Importance.HIGH,
+          "Role ARN to use when starting a session."
+      ).define(
+          ROLE_SESSION_NAME_CONFIG,
+          ConfigDef.Type.STRING,
+          ConfigDef.Importance.HIGH,
+          "Role session name to use when starting a session"
+      );
+  
+  private String roleArn;
+  private String roleExternalId;
+  private String roleSessionName;
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    AbstractConfig config = new AbstractConfig(STS_CONFIG_DEF, configs);
+    roleArn = config.getString(ROLE_ARN_CONFIG);
+    roleExternalId = config.getString(ROLE_EXTERNAL_ID_CONFIG);
+    roleSessionName = config.getString(ROLE_SESSION_NAME_CONFIG);
+  }
+
+  @Override
+  public AWSCredentials getCredentials() {
+    AWSSecurityTokenServiceClientBuilder clientBuilder =
+        AWSSecurityTokenServiceClientBuilder.standard();
+    AWSCredentialsProvider provider =
+        new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
+            .withStsClient(clientBuilder.defaultClient())
+            .withExternalId(roleExternalId)
+            .build();
+
+    return provider.getCredentials();
+  }
+
+  @Override
+  public void refresh() {
+    // Nothing to do really, since we acquire a new session every getCredentials() call.
+  }
+
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -35,6 +35,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider;
 import io.confluent.connect.s3.format.avro.AvroFormat;
 import io.confluent.connect.s3.format.json.JsonFormat;
 import io.confluent.connect.s3.storage.S3Storage;
@@ -222,6 +223,31 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
   }
 
   @Test
+  public void testConfigurableAwsAssumeRoleCredentialsProvider() {
+    properties.put(
+        S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
+        AwsAssumeRoleCredentialsProvider.class.getName()
+    );
+    String configPrefix = S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CONFIG_PREFIX;
+    properties.put(
+        configPrefix.concat(AwsAssumeRoleCredentialsProvider.ROLE_ARN_CONFIG),
+        "arn:aws:iam::012345678901:role/my-restricted-role"
+    );
+    properties.put(
+        configPrefix.concat(AwsAssumeRoleCredentialsProvider.ROLE_SESSION_NAME_CONFIG),
+        "my-session-name"
+    );
+    properties.put(
+        configPrefix.concat(AwsAssumeRoleCredentialsProvider.ROLE_EXTERNAL_ID_CONFIG),
+        "my-external-id"
+    );
+    connectorConfig = new S3SinkConnectorConfig(properties);
+
+    AwsAssumeRoleCredentialsProvider credentialsProvider =
+        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider();
+  }
+
+  @Test
   public void testUseExpectContinueDefault() throws Exception {
     setUp();
     S3Storage storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, null);
@@ -256,6 +282,36 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
 
     connectorConfig = new S3SinkConnectorConfig(properties);
     connectorConfig.getCredentialsProvider();
+  }
+
+  @Test
+  public void testConfigurableAwsAssumeRoleCredentialsProviderMissingConfigs() {
+    thrown.expect(ConfigException.class);
+    thrown.expectMessage("Missing required configuration");
+
+    properties.put(
+        S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
+        AwsAssumeRoleCredentialsProvider.class.getName()
+    );
+    String configPrefix = S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CONFIG_PREFIX;
+    properties.put(
+        configPrefix.concat(AwsAssumeRoleCredentialsProvider.ROLE_ARN_CONFIG),
+        "arn:aws:iam::012345678901:role/my-restricted-role"
+    );
+    properties.put(
+        configPrefix.concat(AwsAssumeRoleCredentialsProvider.ROLE_SESSION_NAME_CONFIG),
+        "my-session-name"
+    );
+    properties.put(
+        configPrefix.concat(AwsAssumeRoleCredentialsProvider.ROLE_EXTERNAL_ID_CONFIG),
+        "my-external-id"
+    );
+    connectorConfig = new S3SinkConnectorConfig(properties);
+
+    AwsAssumeRoleCredentialsProvider credentialsProvider =
+        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider();
+
+    credentialsProvider.configure(properties);
   }
 
   private void assertDefaultPartitionerVisibility(List<ConfigValue> values) {


### PR DESCRIPTION
Add an AWSCredentialsProvider that uses STSAssumeRoleSessionCredentialsProvider to assume an IAM Role. This allows the worker to write S3 objects that are owned by the bucket owner and not the Kafka Connect worker AWS Account.