### PR TITLE
CC-7901: dynamic buffer sizes for output streams

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -568,7 +568,46 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       );
 
     }
+
+    addInternalConfigs(configDef);
     return configDef;
+  }
+
+  protected static final String INITIAL_BUFFER_SIZE_CONFIG = "initial.buffer.size";
+  private static final String MOVING_AVERAGE_FORGETTING_FACTOR_CONFIG = "forgetting.factor";
+  private static final String BUFFER_SIZE_PADDING_MULTIPLIER_CONFIG =
+      "buffer.size.padding.multiplier";
+
+  private static void addInternalConfigs(ConfigDef configDef) {
+    configDef
+        .defineInternal(
+            INITIAL_BUFFER_SIZE_CONFIG,
+            Type.INT,
+            1024 * 512,
+            Importance.LOW
+        ).defineInternal(
+            MOVING_AVERAGE_FORGETTING_FACTOR_CONFIG,
+            Type.DOUBLE,
+            .9,
+            Importance.LOW
+        ).defineInternal(
+            BUFFER_SIZE_PADDING_MULTIPLIER_CONFIG,
+            Type.DOUBLE,
+            1.5,
+            Importance.LOW
+    );
+  }
+
+  public int getInitialBufferSize() {
+    return getInt(INITIAL_BUFFER_SIZE_CONFIG);
+  }
+
+  public double getForgettingFactor() {
+    return getDouble(MOVING_AVERAGE_FORGETTING_FACTOR_CONFIG);
+  }
+
+  public double getBufferSizePadding() {
+    return getDouble(BUFFER_SIZE_PADDING_MULTIPLIER_CONFIG);
   }
 
   public S3SinkConnectorConfig(Map<String, String> props) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -134,6 +134,7 @@ public class S3SinkTask extends SinkTask {
     assignment.addAll(partitions);
     for (TopicPartition tp : assignment) {
       topicPartitionWriters.put(tp, newTopicPartitionWriter(tp));
+      storage.setBufferSize(tp, connectorConfig.getInitialBufferSize());
     }
   }
 
@@ -230,6 +231,7 @@ public class S3SinkTask extends SinkTask {
       } catch (ConnectException e) {
         log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
       }
+      storage.closePartition(tp);
     }
     topicPartitionWriters.clear();
     assignment.clear();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3ParquetOutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3ParquetOutputStream.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.s3.storage;
 
-import com.amazonaws.services.s3.AmazonS3;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 
 import java.io.IOException;
@@ -25,8 +24,13 @@ public class S3ParquetOutputStream extends S3OutputStream {
 
   private volatile boolean commit;
 
-  public S3ParquetOutputStream(String key, S3SinkConnectorConfig conf, AmazonS3 s3) {
-    super(key, conf, s3);
+  public S3ParquetOutputStream(
+      String key,
+      S3SinkConnectorConfig conf,
+      S3Storage s3Storage,
+      int bufferSize
+  ) {
+    super(key, conf, s3Storage, bufferSize);
     commit = false;
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -17,6 +17,7 @@ package io.confluent.connect.s3.storage;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.PredefinedClientConfigurations;
+import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -28,24 +29,27 @@ import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectListing;
-import io.confluent.connect.s3.format.parquet.ParquetFormat;
 import com.amazonaws.services.s3.model.ObjectTagging;
 import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.Tag;
-import com.amazonaws.SdkClientException;
-import org.apache.avro.file.SeekableInput;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.OutputStream;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.s3.format.parquet.ParquetFormat;
 import io.confluent.connect.s3.util.S3ProxyConfig;
 import io.confluent.connect.s3.util.Version;
 import io.confluent.connect.storage.Storage;
+import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.common.util.StringUtils;
+
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.avro.file.SeekableInput;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_ACCESS_KEY_ID_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_SECRET_ACCESS_KEY_CONFIG;
@@ -65,6 +69,8 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
   private final String url;
   private final String bucketName;
   private final AmazonS3 s3;
+  private final Map<TopicPartition, WeightedMovingAverage> bufferSizes;
+  protected final Map<S3OutputStream, TopicPartition> openStreams;
   private final S3SinkConnectorConfig conf;
   private static final String VERSION_FORMAT = "APN/1.0 Confluent/1.0 KafkaS3Connector/%s";
 
@@ -78,6 +84,8 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
     this.url = url;
     this.conf = conf;
     this.bucketName = conf.getBucketName();
+    this.bufferSizes = new HashMap<>();
+    this.openStreams = new HashMap<>();
     this.s3 = newS3Client(conf);
   }
 
@@ -115,7 +123,14 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
     this.url = url;
     this.conf = conf;
     this.bucketName = bucketName;
+    this.bufferSizes = new HashMap<>();
+    this.openStreams = new HashMap<>();
     this.s3 = s3;
+  }
+
+  public void setBufferSize(TopicPartition topicPartition, int bufferSize) {
+    bufferSizes.putIfAbsent(topicPartition, new WeightedMovingAverage(conf.getForgettingFactor()));
+    bufferSizes.get(topicPartition).calculateWeightedMovingAverage(bufferSize);
   }
 
   /**
@@ -193,7 +208,7 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
   }
 
   public boolean bucketExists() {
-    return StringUtils.isNotBlank(bucketName) && s3.doesBucketExist(bucketName);
+    return StringUtils.isNotBlank(bucketName) && s3.doesBucketExistV2(bucketName);
   }
 
   @Override
@@ -217,13 +232,57 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
       throw new IllegalArgumentException("Path can not be empty!");
     }
 
+    TopicPartition tp = getTopicPartitionFromPath(path);
+    int bufferSize = getRecommendedBufferSize(tp);
     if (ParquetFormat.class.isAssignableFrom(
         this.conf.getClass(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG))) {
-      return new S3ParquetOutputStream(path, this.conf, s3);
+      S3OutputStream stream = new S3ParquetOutputStream(path, this.conf, this, bufferSize);
+      openStreams.put(stream, tp);
+      return stream;
     } else {
       // currently ignore what is passed as method argument.
-      return new S3OutputStream(path, this.conf, s3);
+      S3OutputStream stream = new S3OutputStream(path, this.conf, this, bufferSize);
+      openStreams.put(stream, tp);
+      return stream;
     }
+  }
+
+  public void closePartition(TopicPartition tp) {
+    bufferSizes.remove(tp);
+  }
+
+  public void closeStream(S3OutputStream stream) {
+    openStreams.remove(stream);
+  }
+
+  public int getRecommendedBufferSize(TopicPartition tp) {
+    WeightedMovingAverage weightedMovingAverage = bufferSizes.get(tp);
+    return Math.min(
+        (int) (weightedMovingAverage.getPreviousMovingAverage() * conf.getBufferSizePadding()),
+        conf.getPartSize()
+    );
+  }
+
+  public void reportLastUploadSize(S3OutputStream stream, int size) {
+    TopicPartition tp = openStreams.get(stream);
+    double movingAverage = bufferSizes.get(tp).calculateWeightedMovingAverage(size);
+    log.trace(
+        "Moving average part size for topic {} partition {}: {}",
+        tp.topic(),
+        tp.partition(),
+        movingAverage
+    );
+  }
+
+  protected TopicPartition getTopicPartitionFromPath(String path) {
+    String fileDelim = conf.getString(StorageCommonConfig.FILE_DELIM_CONFIG);
+    return bufferSizes
+        .keySet()
+        .stream()
+        .filter(tp -> path.contains(tp.topic()))
+        .filter(tp -> path.contains(fileDelim + tp.partition() + fileDelim))
+        .findFirst()
+        .orElse(null);
   }
 
   @Override
@@ -240,6 +299,10 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
     } else {
       s3.deleteObject(bucketName, name);
     }
+  }
+
+  public AmazonS3 s3() {
+    return s3;
   }
 
   @Override
@@ -272,5 +335,45 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
     throw new UnsupportedOperationException(
         "File reading is not currently supported in S3 Connector"
     );
+  }
+
+  private static class WeightedMovingAverage {
+    double forgettingFactor;
+    double previousMovingAverage;
+    double previousWeightFactor;
+    int previousSample;
+
+    public WeightedMovingAverage(double forgettingFactor) {
+      assert forgettingFactor >= 0 && forgettingFactor <= 1.0;
+      this.forgettingFactor = forgettingFactor;
+      this.previousMovingAverage = 0;
+      this.previousWeightFactor = 0;
+      this.previousSample = 0;
+    }
+
+    public double getPreviousMovingAverage() {
+      return previousMovingAverage;
+    }
+
+    public double calculateWeightedMovingAverage(int currentSample) {
+      double currentWeightFactor = getCurrentWeightFactor();
+      double weightedMovingAverage = ((1 - (1 / currentWeightFactor)) * previousSample)
+          + (currentSample / currentWeightFactor);
+
+      previousSample = currentSample;
+      previousMovingAverage = weightedMovingAverage;
+      previousWeightFactor = currentWeightFactor;
+
+      return weightedMovingAverage;
+    }
+
+    private double getCurrentWeightFactor() {
+      if (Double.MAX_VALUE - (forgettingFactor * previousWeightFactor) <= 1) {
+        // reset weighting factor if it gets too big
+        previousWeightFactor = 0;
+      }
+
+      return forgettingFactor * previousWeightFactor + 1;
+    }
   }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
@@ -80,7 +80,7 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
     format = new ByteArrayFormat(storage);
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
   }
 
   @After
@@ -95,7 +95,12 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
     setUp();
     PowerMockito.doReturn(5).when(connectorConfig).getPartSize();
-    S3OutputStream out = new S3OutputStream(S3_TEST_BUCKET_NAME, connectorConfig, s3);
+    S3OutputStream out = new S3OutputStream(
+        S3_TEST_BUCKET_NAME,
+        connectorConfig,
+        storage,
+        connectorConfig.getInitialBufferSize()
+    );
     out.write(new byte[]{65,66,67,68,69});
     out.write(70);
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
@@ -82,7 +82,7 @@ public class DataWriterJsonTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
     format = new JsonFormat(storage);
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
   }
 
   @After

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.s3;
 
-import akka.parboiled2.RuleTrace;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AnonymousAWSCredentials;
@@ -29,6 +28,7 @@ import com.amazonaws.services.s3.model.Tag;
 import com.amazonaws.services.s3.model.GetObjectTaggingResult;
 import com.amazonaws.services.s3.model.transform.XmlResponsesSaxParser;
 import io.confluent.connect.s3.format.parquet.ParquetUtils;
+import io.confluent.connect.s3.storage.S3Storage;
 import io.findify.s3mock.S3Mock;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -210,8 +210,13 @@ public class TestWithMockedS3 extends S3SinkConnectorTestBase {
   class S3OutputStreamFlaky extends S3OutputStream {
     private final AtomicInteger retries;
 
-    public S3OutputStreamFlaky(String key, S3SinkConnectorConfig conf, AmazonS3 s3, AtomicInteger retries) {
-      super(key, conf, s3);
+    public S3OutputStreamFlaky(
+        String key,
+        S3SinkConnectorConfig conf,
+        S3Storage storage,
+        AtomicInteger retries
+    ) {
+      super(key, conf, storage, conf.getInitialBufferSize());
       this.retries = retries;
     }
 


### PR DESCRIPTION
This PR adds dynamic buffer size allocation for output streams. It keeps track of the exponentially weighted moving average of the part sizes uploaded and uses that to guess the appropriate buffer size that an output stream will use. If the the buffer is too small, the buffer will be copied into a larger one. 

The measured performance impact was 3% decrease in overall throughput and the connector started at 75% throughput and it took 5 minutes to reach its peak throughput. 

Signed-off-by: Lev Zemlyanov <lev@confluent.io>