### PR TITLE
CC-8170: Exclude jackson-mapper-asl and commons-beanutils from hadoop-common import

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,6 +135,10 @@
                     <groupId>commons-beanutils</groupId>
                     <artifactId>commons-beanutils-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.codehaus.jackson</groupId>
+                    <artifactId>jackson-mapper-asl</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
This PR explicitly excludes `jackson-mapper-asl` from being pulled in with `hadoop-common`. Code inspection indicates that the jar is not being used and can be removed. Passing muckrake system tests - https://jenkins.confluent.io/job/system-test-confluent-platform-branch-builder/3626/