### PR TITLE
CC-7933: Support writing key and headers to S3 in S3 sink connector

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -8,7 +8,7 @@
     <!-- Intentionally high coupling to pull together config classes -->
     <suppress
             checks="ClassDataAbstractionCoupling"
-            files="(S3OutputStream|S3SinkConnectorConfig|S3Storage).java"
+            files="(S3OutputStream|S3SinkConnectorConfig|S3Storage|S3SinkTask).java"
     />
 
     <suppress

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -36,6 +36,7 @@ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -61,6 +62,7 @@ import io.confluent.connect.storage.common.ComposableConfig;
 import io.confluent.connect.storage.common.GenericRecommender;
 import io.confluent.connect.storage.common.ParentValueRecommender;
 import io.confluent.connect.storage.common.StorageCommonConfig;
+import io.confluent.connect.storage.format.Format;
 import io.confluent.connect.storage.partitioner.DailyPartitioner;
 import io.confluent.connect.storage.partitioner.DefaultPartitioner;
 import io.confluent.connect.storage.partitioner.FieldPartitioner;
@@ -163,6 +165,13 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String S3_PATH_STYLE_ACCESS_ENABLED_CONFIG = "s3.path.style.access.enabled";
   public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = true;
 
+  public static final String STORE_KAFKA_KEYS_CONFIG = "store.kafka.keys";
+  public static final String STORE_KAFKA_HEADERS_CONFIG = "store.kafka.headers";
+  public static final String KEYS_FORMAT_CLASS_CONFIG = "keys.format.class";
+  public static final Class<? extends Format> KEYS_FORMAT_CLASS_DEFAULT = AvroFormat.class;
+  public static final String HEADERS_FORMAT_CLASS_CONFIG = "headers.format.class";
+  public static final Class<? extends Format> HEADERS_FORMAT_CLASS_DEFAULT = AvroFormat.class;
+
   private final String name;
 
   private final StorageCommonConfig commonConfig;
@@ -179,19 +188,26 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   private static final ParquetCodecRecommender PARQUET_COMPRESSION_RECOMMENDER =
       new ParquetCodecRecommender();
 
+  private static final Collection<Object> FORMAT_CLASS_VALID_VALUES = Arrays.<Object>asList(
+      AvroFormat.class,
+      JsonFormat.class,
+      ByteArrayFormat.class,
+      ParquetFormat.class
+  );
+
+  private static final ParentValueRecommender KEYS_FORMAT_CLASS_RECOMMENDER =
+      new ParentValueRecommender(
+          STORE_KAFKA_KEYS_CONFIG, true, FORMAT_CLASS_VALID_VALUES);
+  private static final ParentValueRecommender HEADERS_FORMAT_CLASS_RECOMMENDER =
+      new ParentValueRecommender(
+          STORE_KAFKA_HEADERS_CONFIG, true, FORMAT_CLASS_VALID_VALUES);
+
   static {
     STORAGE_CLASS_RECOMMENDER.addValidValues(
         Arrays.<Object>asList(S3Storage.class)
     );
 
-    FORMAT_CLASS_RECOMMENDER.addValidValues(
-        Arrays.<Object>asList(
-            AvroFormat.class,
-            JsonFormat.class,
-            ByteArrayFormat.class,
-            ParquetFormat.class
-        )
-    );
+    FORMAT_CLASS_RECOMMENDER.addValidValues(FORMAT_CLASS_VALID_VALUES);
 
     PARTITIONER_CLASS_RECOMMENDER.addValidValues(
         Arrays.<Object>asList(
@@ -568,6 +584,63 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.SHORT,
           "Behavior for null-valued records"
+      );
+    }
+
+    {
+      final String group = "Keys and Headers";
+      int orderInGroup = 0;
+
+      configDef.define(
+          STORE_KAFKA_KEYS_CONFIG,
+          Type.BOOLEAN,
+          false,
+          Importance.LOW,
+          "Enable or disable writing keys to storage.",
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          "Store kafka keys",
+          Collections.singletonList(KEYS_FORMAT_CLASS_CONFIG)
+      );
+
+      configDef.define(
+          STORE_KAFKA_HEADERS_CONFIG,
+          Type.BOOLEAN,
+          false,
+          Importance.LOW,
+          "Enable or disable writing headers to storage.",
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          "Store kafka headers",
+          Collections.singletonList(HEADERS_FORMAT_CLASS_CONFIG)
+      );
+
+      configDef.define(
+          KEYS_FORMAT_CLASS_CONFIG,
+          Type.CLASS,
+          KEYS_FORMAT_CLASS_DEFAULT,
+          Importance.LOW,
+          "The format class to use when writing keys to the store.",
+          group,
+          ++orderInGroup,
+          Width.NONE,
+          "Keys format class",
+          KEYS_FORMAT_CLASS_RECOMMENDER
+      );
+
+      configDef.define(
+          HEADERS_FORMAT_CLASS_CONFIG,
+          Type.CLASS,
+          HEADERS_FORMAT_CLASS_DEFAULT,
+          Importance.LOW,
+          "The format class to use when writing headers to the store.",
+          group,
+          ++orderInGroup,
+          Width.NONE,
+          "Headers format class",
+          HEADERS_FORMAT_CLASS_RECOMMENDER
       );
 
       configDef.define(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -199,6 +199,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       AvroFormat.class,
       JsonFormat.class,
       ParquetFormat.class
+      // ByteArrayFormat for headers is not supported.
+      // Would require undesired JsonConverter configuration in ByteArrayRecordWriterProvider.
   );
 
   private static final ParentValueRecommender KEYS_FORMAT_CLASS_RECOMMENDER =

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -195,12 +195,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       ParquetFormat.class
   );
 
+  private static final Collection<Object> HEADERS_FORMAT_CLASS_VALID_VALUES = Arrays.<Object>asList(
+      AvroFormat.class,
+      JsonFormat.class,
+      ParquetFormat.class
+  );
+
   private static final ParentValueRecommender KEYS_FORMAT_CLASS_RECOMMENDER =
       new ParentValueRecommender(
           STORE_KAFKA_KEYS_CONFIG, true, FORMAT_CLASS_VALID_VALUES);
   private static final ParentValueRecommender HEADERS_FORMAT_CLASS_RECOMMENDER =
       new ParentValueRecommender(
-          STORE_KAFKA_HEADERS_CONFIG, true, FORMAT_CLASS_VALID_VALUES);
+          STORE_KAFKA_HEADERS_CONFIG, true, HEADERS_FORMAT_CLASS_VALID_VALUES);
 
   static {
     STORAGE_CLASS_RECOMMENDER.addValidValues(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -195,12 +195,12 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       ParquetFormat.class
   );
 
+  // ByteArrayFormat for headers is not supported.
+  // Would require undesired JsonConverter configuration in ByteArrayRecordWriterProvider.
   private static final Collection<Object> HEADERS_FORMAT_CLASS_VALID_VALUES = Arrays.<Object>asList(
       AvroFormat.class,
       JsonFormat.class,
       ParquetFormat.class
-      // ByteArrayFormat for headers is not supported.
-      // Would require undesired JsonConverter configuration in ByteArrayRecordWriterProvider.
   );
 
   private static final ParentValueRecommender KEYS_FORMAT_CLASS_RECOMMENDER =

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -37,6 +37,7 @@ import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
 import io.confluent.connect.s3.format.KeyValueHeaderRecordWriterProvider;
 import io.confluent.connect.s3.format.RecordViewSetter;
+import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
 import io.confluent.connect.s3.format.RecordViews.KeyRecordView;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.s3.util.Version;
@@ -160,10 +161,12 @@ public class S3SinkTask extends SinkTask {
           .getRecordWriterProvider();
       ((RecordViewSetter) keyWriterProvider).setRecordView(new KeyRecordView());
     }
-    RecordWriterProvider<S3SinkConnectorConfig> headerWriterProvider =
-        config.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG)
-            ? newFormat(S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG).getRecordWriterProvider()
-            : null;
+    RecordWriterProvider<S3SinkConnectorConfig> headerWriterProvider = null;
+    if (config.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG)) {
+      headerWriterProvider = newFormat(S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG)
+          .getRecordWriterProvider();
+      ((RecordViewSetter) headerWriterProvider).setRecordView(new HeaderRecordView());
+    }
 
     return new KeyValueHeaderRecordWriterProvider(
         valueWriterProvider, keyWriterProvider, headerWriterProvider);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -35,6 +35,7 @@ import java.util.Map;
 
 import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
+import io.confluent.connect.s3.format.KeyValueHeaderRecordWriterProvider;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.s3.util.Version;
 import io.confluent.connect.storage.StorageFactory;
@@ -107,7 +108,11 @@ public class S3SinkTask extends SinkTask {
         throw new DataException("No-existent S3 bucket: " + connectorConfig.getBucketName());
       }
 
-      writerProvider = newFormat().getRecordWriterProvider();
+      writerProvider = new KeyValueHeaderRecordWriterProvider(
+          newFormat().getRecordWriterProvider(),
+          null,
+          null);
+
       partitioner = newPartitioner(connectorConfig);
 
       open(context.assignment());

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -36,6 +36,8 @@ import java.util.Map;
 import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
 import io.confluent.connect.s3.format.KeyValueHeaderRecordWriterProvider;
+import io.confluent.connect.s3.format.RecordViewSetter;
+import io.confluent.connect.s3.format.RecordViews.KeyRecordView;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.s3.util.Version;
 import io.confluent.connect.storage.StorageFactory;
@@ -152,10 +154,12 @@ public class S3SinkTask extends SinkTask {
     RecordWriterProvider<S3SinkConnectorConfig> valueWriterProvider =
         newFormat(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG).getRecordWriterProvider();
 
-    RecordWriterProvider<S3SinkConnectorConfig> keyWriterProvider =
-        config.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG)
-            ? newFormat(S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG).getRecordWriterProvider()
-            : null;
+    RecordWriterProvider<S3SinkConnectorConfig> keyWriterProvider = null;
+    if (config.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG)) {
+      keyWriterProvider = newFormat(S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG)
+          .getRecordWriterProvider();
+      ((RecordViewSetter) keyWriterProvider).setRecordView(new KeyRecordView());
+    }
     RecordWriterProvider<S3SinkConnectorConfig> headerWriterProvider =
         config.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG)
             ? newFormat(S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG).getRecordWriterProvider()

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3.format;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.storage.format.RecordWriter;
+import io.confluent.connect.storage.format.RecordWriterProvider;
+
+import static java.util.Objects.requireNonNull;
+
+public class KeyValueHeaderRecordWriterProvider
+    implements RecordWriterProvider<S3SinkConnectorConfig> {
+
+  private final RecordWriterProvider<S3SinkConnectorConfig> valueProvider;
+  private final RecordWriterProvider<S3SinkConnectorConfig> keyProvider;
+  private final RecordWriterProvider<S3SinkConnectorConfig> headerProvider;
+
+
+  public KeyValueHeaderRecordWriterProvider(
+      RecordWriterProvider<S3SinkConnectorConfig> valueProvider,
+      RecordWriterProvider<S3SinkConnectorConfig> keyProvider,
+      RecordWriterProvider<S3SinkConnectorConfig> headerProvider) {
+    this.valueProvider = requireNonNull(valueProvider);
+    this.keyProvider = keyProvider;
+    this.headerProvider = headerProvider;
+  }
+
+  @Override
+  public String getExtension() {
+    return valueProvider.getExtension();
+  }
+
+  @Override
+  public RecordWriter getRecordWriter(S3SinkConnectorConfig conf, String filename) {
+    RecordWriter valueWriter = valueProvider.getRecordWriter(conf, filename);
+    RecordWriter keyWriter =
+        keyProvider == null ? null : keyProvider.getRecordWriter(conf, filename);
+    RecordWriter headerWriter =
+        headerProvider == null ? null : headerProvider.getRecordWriter(conf, filename);
+
+    return new RecordWriter() {
+      @Override
+      public void write(SinkRecord sinkRecord) {
+        valueWriter.write(sinkRecord);
+        if (keyWriter != null) {
+          keyWriter.write(sinkRecord);
+        }
+        if (headerWriter != null) {
+          headerWriter.write(sinkRecord);
+        }
+      }
+
+      @Override
+      public void close() {
+        valueWriter.close();
+        if (keyWriter != null) {
+          keyWriter.close();
+        }
+        if (headerWriter != null) {
+          headerWriter.close();
+        }
+      }
+
+      @Override
+      public void commit() {
+        valueWriter.commit();
+        if (keyWriter != null) {
+          keyWriter.commit();
+        }
+        if (headerWriter != null) {
+          headerWriter.commit();
+        }
+      }
+    };
+  }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -67,8 +67,9 @@ public class KeyValueHeaderRecordWriterProvider
   @Override
   public RecordWriter getRecordWriter(S3SinkConnectorConfig conf, String filename) {
     // Remove extension to allow different formats for value, key and headers.
-    // Each provider will add its own extension. The filename comes in with the value file format, e.g. filename.avro,
-    // but when the format class is different for the key or the headers the extension needs to be removed.
+    // Each provider will add its own extension. The filename comes in with the value file format,
+    // e.g. filename.avro, but when the format class is different for the key or the headers the
+    // extension needs to be removed.
     int extensionIndex = filename.indexOf(valueProvider.getExtension());
     String strippedFilename = extensionIndex > -1
         ? filename.substring(0, extensionIndex)

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -17,6 +17,8 @@
 package io.confluent.connect.s3.format;
 
 
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
@@ -28,29 +30,30 @@ import org.slf4j.LoggerFactory;
 
 import static java.util.Objects.requireNonNull;
 
+/**
+ * A class that adds a record writer layer to manage writing values, keys and headers
+ * with a single call. It provides an abstraction for writing, committing and
+ * closing all three header, key and value files.
+ */
 public class KeyValueHeaderRecordWriterProvider
     implements RecordWriterProvider<S3SinkConnectorConfig> {
 
   private static final Logger log =
       LoggerFactory.getLogger(KeyValueHeaderRecordWriterProvider.class);
 
-  /**
-   * valueProvider may not be null.
-   */
+  @NotNull
   private final RecordWriterProvider<S3SinkConnectorConfig> valueProvider;
-  /**
-   * keyProvider may be null.
-   */
+
+  @Nullable
   private final RecordWriterProvider<S3SinkConnectorConfig> keyProvider;
-  /**
-   * headerProvider may be null.
-   */
+
+  @Nullable
   private final RecordWriterProvider<S3SinkConnectorConfig> headerProvider;
 
   public KeyValueHeaderRecordWriterProvider(
       RecordWriterProvider<S3SinkConnectorConfig> valueProvider,
-      RecordWriterProvider<S3SinkConnectorConfig> keyProvider,
-      RecordWriterProvider<S3SinkConnectorConfig> headerProvider) {
+      @Nullable RecordWriterProvider<S3SinkConnectorConfig> keyProvider,
+      @Nullable RecordWriterProvider<S3SinkConnectorConfig> headerProvider) {
     this.valueProvider = requireNonNull(valueProvider);
     this.keyProvider = keyProvider;
     this.headerProvider = headerProvider;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -67,11 +67,11 @@ public class KeyValueHeaderRecordWriterProvider
     return new RecordWriter() {
       @Override
       public void write(SinkRecord sinkRecord) {
-        valueWriter.write(sinkRecord);
-        if (keyWriter != null) {
+        valueWriter.write(sinkRecord); // null check happens in sink task
+        if (keyWriter != null && sinkRecord.key() != null) {
           keyWriter.write(sinkRecord);
         }
-        if (headerWriter != null) {
+        if (headerWriter != null && sinkRecord.headers() != null) {
           headerWriter.write(sinkRecord);
         }
       }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -66,11 +66,9 @@ public class KeyValueHeaderRecordWriterProvider
 
   @Override
   public RecordWriter getRecordWriter(S3SinkConnectorConfig conf, String filename) {
-    // Remove extension to allow different formats for value, key and headers
-    // each provider will add its own extension.
-    // The filename comes in with the value file format, ex. a.avro,
-    // but when the format class is different for the keys,
-    // header this needs to be removed.
+    // Remove extension to allow different formats for value, key and headers.
+    // Each provider will add its own extension. The filename comes in with the value file format, e.g. filename.avro,
+    // but when the format class is different for the key or the headers the extension needs to be removed.
     int extensionIndex = filename.indexOf(valueProvider.getExtension());
     String strippedFilename = extensionIndex > -1
         ? filename.substring(0, extensionIndex)

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -48,11 +48,21 @@ public class KeyValueHeaderRecordWriterProvider
 
   @Override
   public RecordWriter getRecordWriter(S3SinkConnectorConfig conf, String filename) {
-    RecordWriter valueWriter = valueProvider.getRecordWriter(conf, filename);
+    // Remove extension to allow different formats for value, key and headers
+    // each provider will add its own extension.
+    // The filename comes in with the value file format, ex. a.avro,
+    // but when the format class is different for the keys,
+    // header this needs to be removed.
+    int extensionIndex = filename.indexOf(valueProvider.getExtension());
+    String strippedFilename = extensionIndex > -1
+        ? filename.substring(0, extensionIndex)
+        : filename;
+
+    RecordWriter valueWriter = valueProvider.getRecordWriter(conf, strippedFilename);
     RecordWriter keyWriter =
-        keyProvider == null ? null : keyProvider.getRecordWriter(conf, filename);
+        keyProvider == null ? null : keyProvider.getRecordWriter(conf, strippedFilename);
     RecordWriter headerWriter =
-        headerProvider == null ? null : headerProvider.getRecordWriter(conf, filename);
+        headerProvider == null ? null : headerProvider.getRecordWriter(conf, strippedFilename);
 
     return new RecordWriter() {
       @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -19,7 +19,7 @@ package io.confluent.connect.s3.format;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
-import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
@@ -86,7 +86,7 @@ public class KeyValueHeaderRecordWriterProvider
         valueWriter.write(sinkRecord); // null check happens in sink task
         // keyWriter != null means writing keys is turned on
         if (keyWriter != null && sinkRecord.key() == null) {
-          throw new ConnectException(
+          throw new DataException(
               String.format("Key cannot be null for SinkRecord: %s", sinkRecord)
           );
         } else if (keyWriter != null) {
@@ -95,7 +95,7 @@ public class KeyValueHeaderRecordWriterProvider
 
         // headerWriter != null means writing headers is turned on
         if (headerWriter != null && sinkRecord.headers() == null) {
-          throw new ConnectException(
+          throw new DataException(
               String.format("Headers cannot be null for SinkRecord: %s", sinkRecord)
           );
         } else if (headerWriter != null) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordView.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordView.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3.format;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public interface RecordView {
+  Schema getViewSchema(SinkRecord record);
+
+  Object getView(SinkRecord record);
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordView.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordView.java
@@ -23,4 +23,6 @@ public interface RecordView {
   Schema getViewSchema(SinkRecord record);
 
   Object getView(SinkRecord record);
+
+  String getExtension();
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordView.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordView.java
@@ -29,17 +29,21 @@ public interface RecordView {
    * The schema of the record view. eg. record.keySchema when the RecordView is KeyRecordView.
    *
    * @param record the SinkRecord to get the view schema on.
+   * @param enveloped whether the schema should be enveloped in a struct
+   *                  (applicable for keys/headers in Parquet formats)
    * @return the schema of the current record view
    */
-  Schema getViewSchema(SinkRecord record);
+  Schema getViewSchema(SinkRecord record, boolean enveloped);
 
   /**
    * The value of the current record view. ed. record.key when the RecordView is KeyRecordView.
    *
    * @param record the SinkRecord to get the value from
+   * @param enveloped whether the view should be enveloped in a struct
+   *                  (applicable for keys/headers in Parquet formats)
    * @return the value based on the current RecordView
    */
-  Object getView(SinkRecord record);
+  Object getView(SinkRecord record, boolean enveloped);
 
   /**
    * Get the extension for the current RecordView, eg. .keys for KeyRecordView.

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordView.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordView.java
@@ -19,10 +19,32 @@ package io.confluent.connect.s3.format;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+/**
+ * An interface to get the schema for all three (Key, Vale, Header) record portions
+ * in a consistent way.
+ */
 public interface RecordView {
+
+  /**
+   * The schema of the record view. eg. record.keySchema when the RecordView is KeyRecordView.
+   *
+   * @param record the SinkRecord to get the view schema on.
+   * @return the schema of the current record view
+   */
   Schema getViewSchema(SinkRecord record);
 
+  /**
+   * The value of the current record view. ed. record.key when the RecordView is KeyRecordView.
+   *
+   * @param record the SinkRecord to get the value from
+   * @return the value based on the current RecordView
+   */
   Object getView(SinkRecord record);
 
+  /**
+   * Get the extension for the current RecordView, eg. .keys for KeyRecordView.
+   *
+   * @return the view's file extension
+   */
   String getExtension();
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViewSetter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViewSetter.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3.format;
+
+import io.confluent.connect.s3.format.RecordViews.ValueRecordView;
+
+import static java.util.Objects.requireNonNull;
+
+public class RecordViewSetter {
+  protected RecordView recordView = new ValueRecordView();
+
+  public void setRecordView(RecordView recordView) {
+    this.recordView = requireNonNull(recordView);
+  }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViewSetter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViewSetter.java
@@ -27,11 +27,13 @@ public class RecordViewSetter {
     this.recordView = requireNonNull(recordView);
   }
 
-  protected String getAdjustedFilename(String filename, String extension) {
-    int extensionOffset = filename.indexOf(extension);
-    return extensionOffset > -1
-        ? filename.substring(0, extensionOffset) + recordView.getExtension()
-        + filename.substring(extensionOffset)
-        : filename;
+  protected String getAdjustedFilename(String filename, String initialExtension) {
+    if (filename.endsWith(initialExtension)) {
+      int index = filename.indexOf(initialExtension);
+      return filename.substring(0, index) + recordView.getExtension() + initialExtension;
+    } else {
+      // filename is already stripped
+      return filename + recordView.getExtension() + initialExtension;
+    }
   }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViewSetter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViewSetter.java
@@ -27,13 +27,4 @@ public class RecordViewSetter {
     this.recordView = requireNonNull(recordView);
   }
 
-  protected String getAdjustedFilename(String filename, String initialExtension) {
-    if (filename.endsWith(initialExtension)) {
-      int index = filename.indexOf(initialExtension);
-      return filename.substring(0, index) + recordView.getExtension() + initialExtension;
-    } else {
-      // filename is already stripped
-      return filename + recordView.getExtension() + initialExtension;
-    }
-  }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViewSetter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViewSetter.java
@@ -26,4 +26,12 @@ public class RecordViewSetter {
   public void setRecordView(RecordView recordView) {
     this.recordView = requireNonNull(recordView);
   }
+
+  protected String getAdjustedFilename(String filename, String extension) {
+    int extensionOffset = filename.indexOf(extension);
+    return extensionOffset > -1
+        ? filename.substring(0, extensionOffset) + recordView.getExtension()
+        + filename.substring(extensionOffset)
+        : filename;
+  }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
@@ -36,6 +36,11 @@ public final class RecordViews {
     public Object getView(SinkRecord record) {
       return record.key();
     }
+
+    @Override
+    public String getExtension() {
+      return ".keys";
+    }
   }
 
   public static final class ValueRecordView extends BaseRecordView {
@@ -47,6 +52,11 @@ public final class RecordViews {
     @Override
     public Object getView(SinkRecord record) {
       return record.value();
+    }
+
+    @Override
+    public String getExtension() {
+      return "";
     }
   }
 
@@ -69,6 +79,11 @@ public final class RecordViews {
               .put("key", h.key())
               .put("value", Values.convertToString(h.schema(), h.value())))
           .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getExtension() {
+      return ".headers";
     }
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
@@ -17,7 +17,13 @@
 package io.confluent.connect.s3.format;
 
 import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Values;
 import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public final class RecordViews {
   public static final class KeyRecordView implements RecordView {
@@ -41,6 +47,27 @@ public final class RecordViews {
     @Override
     public Object getView(SinkRecord record) {
       return record.value();
+    }
+  }
+
+  public static final class HeaderRecordView implements RecordView {
+    private static final Schema SINGLE_HEADER_SCHEMA = SchemaBuilder.struct()
+        .field("key", Schema.STRING_SCHEMA)
+        .field("value", Schema.STRING_SCHEMA)
+        .build();
+
+    @Override
+    public Schema getViewSchema(SinkRecord record) {
+      return SchemaBuilder.array(SINGLE_HEADER_SCHEMA);
+    }
+
+    @Override
+    public Object getView(SinkRecord record) {
+      return StreamSupport.stream(record.headers().spliterator(), false)
+          .map(h -> new Struct(SINGLE_HEADER_SCHEMA)
+              .put("key", h.key())
+              .put("value", Values.convertToString(h.schema(), h.value())))
+          .collect(Collectors.toList());
     }
   }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3.format;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public final class RecordViews {
+  public static final class KeyRecordView implements RecordView {
+    @Override
+    public Schema getViewSchema(SinkRecord record) {
+      return record.keySchema();
+    }
+
+    @Override
+    public Object getView(SinkRecord record) {
+      return record.key();
+    }
+  }
+
+  public static final class ValueRecordView implements RecordView {
+    @Override
+    public Schema getViewSchema(SinkRecord record) {
+      return record.valueSchema();
+    }
+
+    @Override
+    public Object getView(SinkRecord record) {
+      return record.value();
+    }
+  }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public final class RecordViews {
-  public static final class KeyRecordView implements RecordView {
+  public static final class KeyRecordView extends BaseRecordView {
     @Override
     public Schema getViewSchema(SinkRecord record) {
       return record.keySchema();
@@ -38,7 +38,7 @@ public final class RecordViews {
     }
   }
 
-  public static final class ValueRecordView implements RecordView {
+  public static final class ValueRecordView extends BaseRecordView {
     @Override
     public Schema getViewSchema(SinkRecord record) {
       return record.valueSchema();
@@ -50,8 +50,9 @@ public final class RecordViews {
     }
   }
 
-  public static final class HeaderRecordView implements RecordView {
-    private static final Schema SINGLE_HEADER_SCHEMA = SchemaBuilder.struct()
+  public static final class HeaderRecordView extends BaseRecordView {
+    // VisibleForTesting
+    static final Schema SINGLE_HEADER_SCHEMA = SchemaBuilder.struct()
         .field("key", Schema.STRING_SCHEMA)
         .field("value", Schema.STRING_SCHEMA)
         .build();
@@ -68,6 +69,13 @@ public final class RecordViews {
               .put("key", h.key())
               .put("value", Values.convertToString(h.schema(), h.value())))
           .collect(Collectors.toList());
+    }
+  }
+
+  private abstract static class BaseRecordView implements RecordView {
+    @Override
+    public String toString() {
+      return this.getClass().getSimpleName();
     }
   }
 }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
@@ -26,22 +26,6 @@ import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
 public final class RecordViews {
-  public static final class KeyRecordView extends BaseRecordView {
-    @Override
-    public Schema getViewSchema(SinkRecord record) {
-      return record.keySchema();
-    }
-
-    @Override
-    public Object getView(SinkRecord record) {
-      return record.key();
-    }
-
-    @Override
-    public String getExtension() {
-      return ".keys";
-    }
-  }
 
   public static final class ValueRecordView extends BaseRecordView {
     @Override
@@ -57,6 +41,23 @@ public final class RecordViews {
     @Override
     public String getExtension() {
       return "";
+    }
+  }
+
+  public static final class KeyRecordView extends BaseRecordView {
+    @Override
+    public Schema getViewSchema(SinkRecord record) {
+      return record.keySchema();
+    }
+
+    @Override
+    public Object getView(SinkRecord record) {
+      return record.key();
+    }
+
+    @Override
+    public String getExtension() {
+      return ".keys";
     }
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
@@ -69,7 +69,7 @@ public final class RecordViews {
 
     @Override
     public Schema getViewSchema(SinkRecord record) {
-      return SchemaBuilder.array(SINGLE_HEADER_SCHEMA);
+      return SchemaBuilder.array(SINGLE_HEADER_SCHEMA).build();
     }
 
     @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/RecordViews.java
@@ -29,12 +29,12 @@ public final class RecordViews {
 
   public static final class ValueRecordView extends BaseRecordView {
     @Override
-    public Schema getViewSchema(SinkRecord record) {
+    public Schema getViewSchema(SinkRecord record, boolean enveloped) {
       return record.valueSchema();
     }
 
     @Override
-    public Object getView(SinkRecord record) {
+    public Object getView(SinkRecord record, boolean enveloped) {
       return record.value();
     }
 
@@ -45,14 +45,26 @@ public final class RecordViews {
   }
 
   public static final class KeyRecordView extends BaseRecordView {
+    private static final String KEY_FIELD_NAME = "key";
+    private static final String KEY_STRUCT_NAME = "RecordKey";
+
     @Override
-    public Schema getViewSchema(SinkRecord record) {
-      return record.keySchema();
+    public Schema getViewSchema(SinkRecord record, boolean enveloped) {
+      Schema keySchema = record.keySchema();
+      if (enveloped) {
+        keySchema = SchemaBuilder.struct().name(KEY_STRUCT_NAME)
+            .field(KEY_FIELD_NAME, keySchema).build();
+      }
+      return keySchema;
     }
 
     @Override
-    public Object getView(SinkRecord record) {
-      return record.key();
+    public Object getView(SinkRecord record, boolean enveloped) {
+      Object view =  record.key();
+      if (enveloped) {
+        view = new Struct(getViewSchema(record, true)).put(KEY_FIELD_NAME, view);
+      }
+      return view;
     }
 
     @Override
@@ -62,6 +74,9 @@ public final class RecordViews {
   }
 
   public static final class HeaderRecordView extends BaseRecordView {
+    private static final String HEADER_FIELD_NAME = "headers";
+    private static final String HEADER_STRUCT_NAME = "RecordHeaders";
+
     // VisibleForTesting
     static final Schema SINGLE_HEADER_SCHEMA = SchemaBuilder.struct()
         .field("key", Schema.STRING_SCHEMA)
@@ -69,17 +84,27 @@ public final class RecordViews {
         .build();
 
     @Override
-    public Schema getViewSchema(SinkRecord record) {
-      return SchemaBuilder.array(SINGLE_HEADER_SCHEMA).build();
+    public Schema getViewSchema(SinkRecord record, boolean enveloped) {
+      Schema headerSchema = SchemaBuilder.array(SINGLE_HEADER_SCHEMA).build();
+      if (enveloped) {
+        headerSchema = SchemaBuilder.struct().name(HEADER_STRUCT_NAME)
+            .field(HEADER_FIELD_NAME, headerSchema).build();
+      }
+      return headerSchema;
     }
 
     @Override
-    public Object getView(SinkRecord record) {
-      return StreamSupport.stream(record.headers().spliterator(), false)
+    public Object getView(SinkRecord record, boolean enveloped) {
+      Object view = StreamSupport.stream(record.headers().spliterator(), false)
           .map(h -> new Struct(SINGLE_HEADER_SCHEMA)
               .put("key", h.key())
               .put("value", Values.convertToString(h.schema(), h.value())))
           .collect(Collectors.toList());
+
+      if (enveloped) {
+        view = new Struct(getViewSchema(record, true)).put(HEADER_FIELD_NAME, view);
+      }
+      return view;
     }
 
     @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.s3.format.avro;
 
+import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
+
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -57,7 +59,7 @@ public class AvroRecordWriterProvider extends RecordViewSetter
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     // This is not meant to be a thread-safe writer!
     return new RecordWriter() {
-      final String adjustedFilename = getAdjustedFilename(filename, getExtension());
+      final String adjustedFilename = getAdjustedFilename(recordView, filename, getExtension());
       final DataFileWriter<Object> writer = new DataFileWriter<>(new GenericDatumWriter<>());
       Schema schema = null;
       S3OutputStream s3out;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -68,7 +68,7 @@ public class AvroRecordWriterProvider extends RecordViewSetter
           schema = recordView.getViewSchema(record);
           try {
             log.info("Opening record writer for: {}", adjustedFilename);
-            s3out = storage.create(adjustedFilename, true);
+            s3out = storage.create(adjustedFilename, true, AvroFormat.class);
             org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
             writer.setCodec(CodecFactory.fromString(conf.getAvroCodec()));
             writer.create(avroSchema, s3out);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -67,7 +67,7 @@ public class AvroRecordWriterProvider extends RecordViewSetter
       @Override
       public void write(SinkRecord record) {
         if (schema == null) {
-          schema = recordView.getViewSchema(record);
+          schema = recordView.getViewSchema(record, false);
           try {
             log.info("Opening record writer for: {}", adjustedFilename);
             s3out = storage.create(adjustedFilename, true, AvroFormat.class);
@@ -79,7 +79,7 @@ public class AvroRecordWriterProvider extends RecordViewSetter
           }
         }
         log.trace("Sink record with view {}: {}", recordView, record);
-        Object value = avroData.fromConnectData(schema, recordView.getView(record));
+        Object value = avroData.fromConnectData(schema, recordView.getView(record, false));
         try {
           // AvroData wraps primitive types so their schema can be included. We need to unwrap
           // NonRecordContainers to just their value to properly handle these types

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -57,11 +57,7 @@ public class AvroRecordWriterProvider extends RecordViewSetter
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     // This is not meant to be a thread-safe writer!
     return new RecordWriter() {
-      int extensionOffset = filename.indexOf(getExtension());
-      final String adjustedFilename = extensionOffset > -1
-          ? filename.substring(0, extensionOffset) + recordView.getExtension()
-          + filename.substring(extensionOffset)
-          : filename;
+      final String adjustedFilename = getAdjustedFilename(filename, getExtension());
       final DataFileWriter<Object> writer = new DataFileWriter<>(new GenericDatumWriter<>());
       Schema schema = null;
       S3OutputStream s3out;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -75,7 +75,7 @@ public class AvroRecordWriterProvider extends RecordViewSetter
             throw new ConnectException(e);
           }
         }
-        log.trace("Sink record: {}", record);
+        log.trace("Sink record with view {}: {}", recordView, record);
         Object value = avroData.fromConnectData(schema, recordView.getView(record));
         try {
           // AvroData wraps primitive types so their schema can be included. We need to unwrap

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.s3.format.bytearray;
 
+import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
+
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.format.RecordViewSetter;
 import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
@@ -63,7 +65,7 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
   @Override
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     return new RecordWriter() {
-      final String adjustedFilename = getAdjustedFilename(filename, getExtension());
+      final String adjustedFilename = getAdjustedFilename(recordView, filename, getExtension());
       final S3OutputStream s3out = storage.create(adjustedFilename, true, ByteArrayFormat.class);
       final OutputStream s3outWrapper = s3out.wrapForCompression();
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -58,11 +58,7 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
   @Override
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     return new RecordWriter() {
-      int extensionOffset = filename.indexOf(getExtension());
-      final String adjustedFilename = extensionOffset > -1
-          ? filename.substring(0, extensionOffset) + recordView.getExtension()
-          + filename.substring(extensionOffset)
-          : filename;
+      final String adjustedFilename = getAdjustedFilename(filename, getExtension());
       final S3OutputStream s3out = storage.create(adjustedFilename, true);
       final OutputStream s3outWrapper = s3out.wrapForCompression();
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.s3.format.bytearray;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.s3.format.RecordViewSetter;
 import io.confluent.connect.s3.storage.S3OutputStream;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.format.RecordWriter;
@@ -31,7 +32,8 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
-public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3SinkConnectorConfig> {
+public class ByteArrayRecordWriterProvider extends RecordViewSetter
+    implements RecordWriterProvider<S3SinkConnectorConfig> {
 
   private static final Logger log = LoggerFactory.getLogger(ByteArrayRecordWriterProvider.class);
   private final S3Storage storage;
@@ -64,7 +66,7 @@ public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3Sin
         log.trace("Sink record: {}", record);
         try {
           byte[] bytes = converter.fromConnectData(
-              record.topic(), record.valueSchema(), record.value());
+              record.topic(), recordView.getViewSchema(record), recordView.getView(record));
           s3outWrapper.write(bytes);
           s3outWrapper.write(lineSeparatorBytes);
         } catch (IOException | DataException e) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -26,7 +26,6 @@ import io.confluent.connect.storage.format.RecordWriterProvider;
 import org.apache.kafka.connect.converters.ByteArrayConverter;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,7 +42,6 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
   private final ByteArrayConverter converter;
   private final String extension;
   private final byte[] lineSeparatorBytes;
-  private final JsonConverter jsonConverter;
 
   ByteArrayRecordWriterProvider(S3Storage storage, ByteArrayConverter converter) {
     this.storage = storage;
@@ -52,7 +50,6 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
     this.lineSeparatorBytes = storage.conf()
         .getFormatByteArrayLineSeparator()
         .getBytes(StandardCharsets.UTF_8);
-    this.jsonConverter = new JsonConverter();
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -43,6 +43,7 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
   private final ByteArrayConverter converter;
   private final String extension;
   private final byte[] lineSeparatorBytes;
+  private final JsonConverter jsonConverter;
 
   ByteArrayRecordWriterProvider(S3Storage storage, ByteArrayConverter converter) {
     this.storage = storage;
@@ -51,6 +52,7 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
     this.lineSeparatorBytes = storage.conf()
         .getFormatByteArrayLineSeparator()
         .getBytes(StandardCharsets.UTF_8);
+    this.jsonConverter = new JsonConverter();
   }
 
   @Override
@@ -71,7 +73,6 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
         try {
           byte[] bytes;
           if (recordView instanceof HeaderRecordView) {
-            JsonConverter jsonConverter = new JsonConverter();
             jsonConverter.configure(Collections.singletonMap("schemas.enable", false), false);
             bytes = jsonConverter.fromConnectData(
                 record.topic(), recordView.getViewSchema(record), recordView.getView(record));

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -63,7 +63,7 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
 
       @Override
       public void write(SinkRecord record) {
-        log.trace("Sink record: {}", record);
+        log.trace("Sink record with view {}: {}", recordView, record);
         try {
           byte[] bytes = converter.fromConnectData(
               record.topic(), recordView.getViewSchema(record), recordView.getView(record));

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -64,7 +64,7 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     return new RecordWriter() {
       final String adjustedFilename = getAdjustedFilename(filename, getExtension());
-      final S3OutputStream s3out = storage.create(adjustedFilename, true);
+      final S3OutputStream s3out = storage.create(adjustedFilename, true, ByteArrayFormat.class);
       final OutputStream s3outWrapper = s3out.wrapForCompression();
 
       @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -19,12 +19,10 @@ import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.format.RecordViewSetter;
-import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
 import io.confluent.connect.s3.storage.S3OutputStream;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
-import java.util.Collections;
 import org.apache.kafka.connect.converters.ByteArrayConverter;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
@@ -73,15 +71,8 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
       public void write(SinkRecord record) {
         log.trace("Sink record with view {}: {}", recordView, record);
         try {
-          byte[] bytes;
-          if (recordView instanceof HeaderRecordView) {
-            jsonConverter.configure(Collections.singletonMap("schemas.enable", false), false);
-            bytes = jsonConverter.fromConnectData(
-                record.topic(), recordView.getViewSchema(record), recordView.getView(record));
-          } else {
-            bytes = converter.fromConnectData(
-              record.topic(), recordView.getViewSchema(record), recordView.getView(record));
-          }
+          byte[] bytes = converter.fromConnectData(record.topic(),
+              recordView.getViewSchema(record, false), recordView.getView(record, false));
           s3outWrapper.write(bytes);
           s3outWrapper.write(lineSeparatorBytes);
         } catch (IOException | DataException e) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -58,7 +58,12 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
   @Override
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     return new RecordWriter() {
-      final S3OutputStream s3out = storage.create(filename, true);
+      int extensionOffset = filename.indexOf(getExtension());
+      final String adjustedFilename = extensionOffset > -1
+          ? filename.substring(0, extensionOffset) + recordView.getExtension()
+          + filename.substring(extensionOffset)
+          : filename;
+      final S3OutputStream s3out = storage.create(adjustedFilename, true);
       final OutputStream s3outWrapper = s3out.wrapForCompression();
 
       @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -62,11 +62,7 @@ public class JsonRecordWriterProvider extends RecordViewSetter
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     try {
       return new RecordWriter() {
-        int extensionOffset = filename.indexOf(getExtension());
-        final String adjustedFilename = extensionOffset > -1
-            ? filename.substring(0, extensionOffset) + recordView.getExtension()
-            + filename.substring(extensionOffset)
-            : filename;
+        final String adjustedFilename = getAdjustedFilename(filename, getExtension());
         final S3OutputStream s3out = storage.create(adjustedFilename, true);
         final OutputStream s3outWrapper = s3out.wrapForCompression();
         final JsonGenerator writer = mapper.getFactory()

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -29,12 +29,14 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.s3.format.RecordViewSetter;
 import io.confluent.connect.s3.storage.S3OutputStream;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
 
-public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConnectorConfig> {
+public class JsonRecordWriterProvider extends RecordViewSetter
+    implements RecordWriterProvider<S3SinkConnectorConfig> {
 
   private static final Logger log = LoggerFactory.getLogger(JsonRecordWriterProvider.class);
   private static final String EXTENSION = ".json";
@@ -70,11 +72,11 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConn
         public void write(SinkRecord record) {
           log.trace("Sink record: {}", record);
           try {
-            Object value = record.value();
+            Object value = recordView.getView(record);
             if (value instanceof Struct) {
               byte[] rawJson = converter.fromConnectData(
                   record.topic(),
-                  record.valueSchema(),
+                  recordView.getViewSchema(record),
                   value
               );
               s3outWrapper.write(rawJson);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -75,11 +75,11 @@ public class JsonRecordWriterProvider extends RecordViewSetter
         public void write(SinkRecord record) {
           log.trace("Sink record with view {}: {}", recordView, record);
           try {
-            Object value = recordView.getView(record);
+            Object value = recordView.getView(record, false);
             if (value instanceof Struct) {
               byte[] rawJson = converter.fromConnectData(
                   record.topic(),
-                  recordView.getViewSchema(record),
+                  recordView.getViewSchema(record, false),
                   value
               );
               s3outWrapper.write(rawJson);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -70,7 +70,7 @@ public class JsonRecordWriterProvider extends RecordViewSetter
 
         @Override
         public void write(SinkRecord record) {
-          log.trace("Sink record: {}", record);
+          log.trace("Sink record with view {}: {}", recordView, record);
           try {
             Object value = recordView.getView(record);
             if (value instanceof Struct) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -15,6 +15,8 @@
 
 package io.confluent.connect.s3.format.json;
 
+import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
+
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.connect.data.Struct;
@@ -62,7 +64,7 @@ public class JsonRecordWriterProvider extends RecordViewSetter
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     try {
       return new RecordWriter() {
-        final String adjustedFilename = getAdjustedFilename(filename, getExtension());
+        final String adjustedFilename = getAdjustedFilename(recordView, filename, getExtension());
         final S3OutputStream s3out = storage.create(adjustedFilename, true, JsonFormat.class);
         final OutputStream s3outWrapper = s3out.wrapForCompression();
         final JsonGenerator writer = mapper.getFactory()

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -63,7 +63,7 @@ public class JsonRecordWriterProvider extends RecordViewSetter
     try {
       return new RecordWriter() {
         final String adjustedFilename = getAdjustedFilename(filename, getExtension());
-        final S3OutputStream s3out = storage.create(adjustedFilename, true);
+        final S3OutputStream s3out = storage.create(adjustedFilename, true, JsonFormat.class);
         final OutputStream s3outWrapper = s3out.wrapForCompression();
         final JsonGenerator writer = mapper.getFactory()
                                          .createGenerator(s3outWrapper)

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -62,7 +62,12 @@ public class JsonRecordWriterProvider extends RecordViewSetter
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     try {
       return new RecordWriter() {
-        final S3OutputStream s3out = storage.create(filename, true);
+        int extensionOffset = filename.indexOf(getExtension());
+        final String adjustedFilename = extensionOffset > -1
+            ? filename.substring(0, extensionOffset) + recordView.getExtension()
+            + filename.substring(extensionOffset)
+            : filename;
+        final S3OutputStream s3out = storage.create(adjustedFilename, true);
         final OutputStream s3outWrapper = s3out.wrapForCompression();
         final JsonGenerator writer = mapper.getFactory()
                                          .createGenerator(s3outWrapper)

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -59,6 +59,11 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
   @Override
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     return new RecordWriter() {
+      int extensionOffset = filename.indexOf(getExtension());
+      final String adjustedFilename = extensionOffset > -1
+          ? filename.substring(0, extensionOffset) + recordView.getExtension()
+          + filename.substring(extensionOffset)
+          : filename;
       Schema schema = null;
       ParquetWriter<GenericRecord> writer;
       S3ParquetOutputFile s3ParquetOutputFile;
@@ -68,10 +73,10 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
         if (schema == null) {
           schema = recordView.getViewSchema(record);
           try {
-            log.info("Opening record writer for: {}", filename);
+            log.info("Opening record writer for: {}", adjustedFilename);
             org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
 
-            s3ParquetOutputFile = new S3ParquetOutputFile(storage, filename);
+            s3ParquetOutputFile = new S3ParquetOutputFile(storage, adjustedFilename);
             writer = AvroParquetWriter
                     .<GenericRecord>builder(s3ParquetOutputFile)
                     .withSchema(avroSchema)

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -84,7 +84,7 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
             throw new ConnectException(e);
           }
         }
-        log.trace("Sink record: {}", record.toString());
+        log.trace("Sink record with view {}: {}", recordView, record);
         Object value = avroData.fromConnectData(schema, recordView.getView(record));
         try {
           writer.write((GenericRecord) value);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -22,17 +22,12 @@ import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.format.RecordViewSetter;
-import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
-import io.confluent.connect.s3.format.RecordViews.KeyRecordView;
 import io.confluent.connect.s3.storage.S3ParquetOutputStream;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.Schema.Type;
-import org.apache.kafka.connect.data.SchemaBuilder;
-import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.parquet.avro.AvroParquetWriter;
@@ -49,10 +44,6 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
     implements RecordWriterProvider<S3SinkConnectorConfig> {
   private static final Logger log = LoggerFactory.getLogger(ParquetRecordWriterProvider.class);
   private static final String EXTENSION = ".parquet";
-  private static final String HEADER_FIELD_NAME = "headers";
-  private static final String KEY_FIELD_NAME = "key";
-  private static final String HEADER_STRUCT_NAME = "RecordHeaders";
-  private static final String KEY_STRUCT_NAME = "RecordKey";
   private static final int PAGE_SIZE = 64 * 1024;
   private final S3Storage storage;
   private final AvroData avroData;
@@ -77,21 +68,8 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
 
       @Override
       public void write(SinkRecord record) {
-        boolean schemaPadded = false;
         if (schema == null) {
-          schema = recordView.getViewSchema(record);
-          // pad the schema for AvroParquetWriter that only accepts record types
-          if (schema.type() != Type.STRUCT) {
-            if (recordView instanceof HeaderRecordView) {
-              schema = SchemaBuilder.struct().name(HEADER_STRUCT_NAME)
-                  .field(HEADER_FIELD_NAME, schema).build();
-            } else if (recordView instanceof KeyRecordView) {
-              schema = SchemaBuilder.struct().name(KEY_STRUCT_NAME)
-                  .field(KEY_FIELD_NAME, schema).build();
-            }
-            schemaPadded = true;
-          }
-
+          schema = recordView.getViewSchema(record, true);
           try {
             log.info("Opening record writer for: {}", adjustedFilename);
             org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
@@ -110,16 +88,7 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
           }
         }
         log.trace("Sink record with view {}: {}", recordView, record);
-        Object view = recordView.getView(record);
-        if (schemaPadded) {
-          // fill the schema if it was padded
-          if (recordView instanceof HeaderRecordView) {
-            view = new Struct(schema).put(HEADER_FIELD_NAME, view);
-          } else if (recordView instanceof KeyRecordView) {
-            view = new Struct(schema).put(KEY_FIELD_NAME, view);
-          }
-        }
-        Object value = avroData.fromConnectData(schema, view);
+        Object value = avroData.fromConnectData(schema, recordView.getView(record, true));
         try {
           writer.write((GenericRecord) value);
         } catch (IOException e) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -59,11 +59,7 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
   @Override
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     return new RecordWriter() {
-      int extensionOffset = filename.indexOf(getExtension());
-      final String adjustedFilename = extensionOffset > -1
-          ? filename.substring(0, extensionOffset) + recordView.getExtension()
-          + filename.substring(extensionOffset)
-          : filename;
+      final String adjustedFilename = getAdjustedFilename(filename, getExtension());
       Schema schema = null;
       ParquetWriter<GenericRecord> writer;
       S3ParquetOutputFile s3ParquetOutputFile;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -97,7 +97,9 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
       @Override
       public void close() {
         try {
-          writer.close();
+          if (writer != null) {
+            writer.close();
+          }
         } catch (IOException e) {
           throw new ConnectException(e);
         }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -163,7 +163,7 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
 
     @Override
     public PositionOutputStream create(long blockSizeHint) {
-      s3out = (S3ParquetOutputStream) storage.create(filename, true);
+      s3out = (S3ParquetOutputStream) storage.create(filename, true, ParquetFormat.class);
       return s3out;
     }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -17,6 +17,8 @@
 
 package io.confluent.connect.s3.format.parquet;
 
+import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
+
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.format.RecordViewSetter;
@@ -68,7 +70,7 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
   @Override
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     return new RecordWriter() {
-      final String adjustedFilename = getAdjustedFilename(filename, getExtension());
+      final String adjustedFilename = getAdjustedFilename(recordView, filename, getExtension());
       Schema schema = null;
       ParquetWriter<GenericRecord> writer;
       S3ParquetOutputFile s3ParquetOutputFile;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -204,10 +204,10 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
 
   @Override
   public OutputStream create(String path, S3SinkConnectorConfig conf, boolean overwrite) {
-    return create(path, overwrite);
+    return create(path, overwrite, this.conf.getClass(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG));
   }
 
-  public S3OutputStream create(String path, boolean overwrite) {
+  public S3OutputStream create(String path, boolean overwrite, Class<?> formatClass) {
     if (!overwrite) {
       throw new UnsupportedOperationException(
           "Creating a file without overwriting is not currently supported in S3 Connector"
@@ -218,8 +218,7 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
       throw new IllegalArgumentException("Path can not be empty!");
     }
 
-    if (ParquetFormat.class.isAssignableFrom(
-        this.conf.getClass(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG))) {
+    if (ParquetFormat.class.isAssignableFrom(formatClass)) {
       return new S3ParquetOutputStream(path, this.conf, s3);
     } else {
       // currently ignore what is passed as method argument.

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2020 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3.util;
+
+import io.confluent.connect.s3.format.RecordView;
+
+public class Utils {
+
+  /**
+   * Get the filename for the respective record view. Appends the Value, Key or Header file
+   * extensions before the existing file extension. Typically unchanged for the Value view.
+   *
+   * @param recordView the record view (key, header or value)
+   * @param filename the current name of the file, equivalent
+   * @param initialExtension the file extension without the appended view extension, eg. .avro
+   * @return the filename with the view extension appended, eg. file1.keys.avro
+   */
+  public static String getAdjustedFilename(RecordView recordView, String filename,
+      String initialExtension) {
+    if (filename.endsWith(initialExtension)) {
+      int index = filename.indexOf(initialExtension);
+      return filename.substring(0, index) + recordView.getExtension() + initialExtension;
+    } else {
+      // filename is already stripped
+      return filename + recordView.getExtension() + initialExtension;
+    }
+  }
+
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -127,7 +127,7 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
       private final AtomicInteger retries = new AtomicInteger(0);
 
       @Override
-      public S3OutputStream create(String path, boolean overwrite) {
+      public S3OutputStream create(String path, boolean overwrite, Class<?> formatClass) {
         return new TopicPartitionWriterTest.S3OutputStreamFlaky(path, this.conf(), s3, retries);
       }
     };

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -49,6 +49,8 @@ import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
 import io.confluent.connect.avro.AvroDataConfig;
 
+import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -493,6 +495,82 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     } catch (ConfigException e) {
       assertEquals(expectedError, e.getMessage());
     }
+  }
+
+  @Test
+  public void testKeyStorageDefaultFalse() {
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertFalse(connectorConfig.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG));
+  }
+
+  @Test
+  public void testKeyStorageSupported() {
+    properties.put(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG, "true");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertTrue(connectorConfig.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG));
+  }
+
+  @Test
+  public void testKeyFormatClassDefault() {
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(AvroFormat.class, connectorConfig.getClass(KEYS_FORMAT_CLASS_CONFIG));
+  }
+
+  @Test
+  public void testKeyFormatClassSupported() {
+    properties.put(KEYS_FORMAT_CLASS_CONFIG, AvroFormat.class.getCanonicalName());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(AvroFormat.class, connectorConfig.getClass(KEYS_FORMAT_CLASS_CONFIG));
+
+    properties.put(KEYS_FORMAT_CLASS_CONFIG, JsonFormat.class.getCanonicalName());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(JsonFormat.class, connectorConfig.getClass(KEYS_FORMAT_CLASS_CONFIG));
+
+    properties.put(KEYS_FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getCanonicalName());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(ByteArrayFormat.class, connectorConfig.getClass(KEYS_FORMAT_CLASS_CONFIG));
+
+    properties.put(KEYS_FORMAT_CLASS_CONFIG, ParquetFormat.class.getCanonicalName());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(ParquetFormat.class, connectorConfig.getClass(KEYS_FORMAT_CLASS_CONFIG));
+  }
+
+  @Test
+  public void testHeaderStorageDefaultFalse() {
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertFalse(connectorConfig.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG));
+  }
+
+  @Test
+  public void testHeaderStorageSupported() {
+    properties.put(S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG, "true");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertTrue(connectorConfig.getBoolean(S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG));
+  }
+
+  @Test
+  public void testHeaderFormatClassDefault() {
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(AvroFormat.class, connectorConfig.getClass(HEADERS_FORMAT_CLASS_CONFIG));
+  }
+
+  @Test
+  public void testHeaderFormatClassSupported() {
+    properties.put(HEADERS_FORMAT_CLASS_CONFIG, AvroFormat.class.getCanonicalName());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(AvroFormat.class, connectorConfig.getClass(HEADERS_FORMAT_CLASS_CONFIG));
+
+    properties.put(HEADERS_FORMAT_CLASS_CONFIG, JsonFormat.class.getCanonicalName());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(JsonFormat.class, connectorConfig.getClass(HEADERS_FORMAT_CLASS_CONFIG));
+
+    properties.put(HEADERS_FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getCanonicalName());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(ByteArrayFormat.class, connectorConfig.getClass(HEADERS_FORMAT_CLASS_CONFIG));
+
+    properties.put(HEADERS_FORMAT_CLASS_CONFIG, ParquetFormat.class.getCanonicalName());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(ParquetFormat.class, connectorConfig.getClass(HEADERS_FORMAT_CLASS_CONFIG));
   }
 }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -111,7 +111,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
       private final AtomicInteger retries = new AtomicInteger(0);
 
       @Override
-      public S3OutputStream create(String path, boolean overwrite) {
+      public S3OutputStream create(String path, boolean overwrite, Class<?> formatClass) {
         return new S3OutputStreamFlaky(path, this.conf(), s3, retries);
       }
     };

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewSetterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewSetterTest.java
@@ -93,4 +93,29 @@ public class RecordViewSetterTest {
     }
   }
 
+  @Test
+  public void testParquetEncodingExtensions() {
+    RecordViewSetter rv = new RecordViewSetter();
+    rv.setRecordView(new HeaderRecordView());
+
+    List<String> givenFilenames1 = new ArrayList<>(Arrays.asList(
+        "x.snappy.parquet",
+        "sample-filename.snappy.parquet",
+        "sample.filename.snappy.parquet",
+        "sample.file.name.snappy.parquet"
+    ));
+
+    List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
+        "x.headers.snappy.parquet",
+        "sample-filename.headers.snappy.parquet",
+        "sample.filename.headers.snappy.parquet",
+        "sample.file.name.headers.snappy.parquet"
+    ));
+
+    for (int i = 0; i < expectedFilenames.size(); i++) {
+      String adjustedFilename = rv.getAdjustedFilename(givenFilenames1.get(i), ".snappy.parquet");
+      assertEquals(expectedFilenames.get(i), adjustedFilename);
+    }
+  }
+
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewSetterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewSetterTest.java
@@ -1,0 +1,96 @@
+package io.confluent.connect.s3.format;
+
+import static org.junit.Assert.assertEquals;
+
+import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
+import io.confluent.connect.s3.format.RecordViews.KeyRecordView;
+import io.confluent.connect.s3.format.RecordViews.ValueRecordView;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+public class RecordViewSetterTest {
+
+  private static List<String> givenFilenames = new ArrayList<>(Arrays.asList(
+      "x.avro",
+      "asdf.avro",
+      "keys.avro",
+      "key.avro",
+      "headers.avro",
+      "header.avro",
+      "sample-filename.avro",
+      "sample.filename.avro",
+      "sample.file.name.avro"
+  ));
+
+  @Test
+  public void getAdjustedFilenameForValues() {
+    RecordViewSetter rv = new RecordViewSetter();
+    rv.setRecordView(new ValueRecordView());
+
+    List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
+        "x.avro",
+        "asdf.avro",
+        "keys.avro",
+        "key.avro",
+        "headers.avro",
+        "header.avro",
+        "sample-filename.avro",
+        "sample.filename.avro",
+        "sample.file.name.avro"
+    ));
+
+    for (int i = 0; i < expectedFilenames.size(); i++) {
+      String adjustedFilename = rv.getAdjustedFilename(givenFilenames.get(i), ".avro");
+      assertEquals(expectedFilenames.get(i), adjustedFilename);
+    }
+  }
+
+  @Test
+  public void getAdjustedFilenameForKeys() {
+    RecordViewSetter rv = new RecordViewSetter();
+    rv.setRecordView(new KeyRecordView());
+
+    List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
+        "x.keys.avro",
+        "asdf.keys.avro",
+        "keys.keys.avro",
+        "key.keys.avro",
+        "headers.keys.avro",
+        "header.keys.avro",
+        "sample-filename.keys.avro",
+        "sample.filename.keys.avro",
+        "sample.file.name.keys.avro"
+    ));
+
+    for (int i = 0; i < expectedFilenames.size(); i++) {
+      String adjustedFilename = rv.getAdjustedFilename(givenFilenames.get(i), ".avro");
+      assertEquals(expectedFilenames.get(i), adjustedFilename);
+    }
+  }
+
+  @Test
+  public void getAdjustedFilenameForHeaders() {
+    RecordViewSetter rv = new RecordViewSetter();
+    rv.setRecordView(new HeaderRecordView());
+
+    List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
+        "x.headers.avro",
+        "asdf.headers.avro",
+        "keys.headers.avro",
+        "key.headers.avro",
+        "headers.headers.avro",
+        "header.headers.avro",
+        "sample-filename.headers.avro",
+        "sample.filename.headers.avro",
+        "sample.file.name.headers.avro"
+    ));
+
+    for (int i = 0; i < expectedFilenames.size(); i++) {
+      String adjustedFilename = rv.getAdjustedFilename(givenFilenames.get(i), ".avro");
+      assertEquals(expectedFilenames.get(i), adjustedFilename);
+    }
+  }
+
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewsTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewsTest.java
@@ -1,0 +1,48 @@
+package io.confluent.connect.s3.format;
+
+import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.header.ConnectHeaders;
+import org.apache.kafka.connect.header.Headers;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
+import io.confluent.connect.s3.format.RecordViews.KeyRecordView;
+import io.confluent.connect.s3.format.RecordViews.ValueRecordView;
+
+import static io.confluent.connect.s3.format.RecordViews.HeaderRecordView.SINGLE_HEADER_SCHEMA;
+import static org.junit.Assert.assertEquals;
+
+public class RecordViewsTest {
+
+  @Test
+  public void testToString() {
+    assertEquals("ValueRecordView", new ValueRecordView().toString());
+    assertEquals("KeyRecordView", new KeyRecordView().toString());
+    assertEquals("HeaderRecordView", new HeaderRecordView().toString());
+  }
+
+  @Test
+  public void testHeaderConvertsToString() {
+    Headers headers = new ConnectHeaders()
+        .addString("string", "string")
+        .addInt("int", 12)
+        .addBoolean("boolean", false);
+
+    List<Struct> expected = Arrays.asList(
+        new Struct(SINGLE_HEADER_SCHEMA)
+            .put("key", "string").put("value", "string"),
+        new Struct(SINGLE_HEADER_SCHEMA).put("key", "int").put("value", "12"),
+        new Struct(SINGLE_HEADER_SCHEMA).put("key", "boolean").put("value", "false"));
+
+    SinkRecord record = new SinkRecord(
+        "topic", 0, null, null, null, null, 0, 0L, TimestampType.NO_TIMESTAMP_TYPE, headers);
+
+    Object headerView = new HeaderRecordView().getView(record);
+    assertEquals(expected, headerView);
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewsTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewsTest.java
@@ -40,10 +40,10 @@ public class RecordViewsTest {
   @Test
   public void testRecordKeyValueViews() {
     SinkRecord sampleRecord = getSampleSinkRecord();
-    assertEquals(sampleRecord.key(), new KeyRecordView().getView(sampleRecord));
-    assertEquals(sampleRecord.value(), new ValueRecordView().getView(sampleRecord));
-    assertEquals(sampleRecord.keySchema(), new KeyRecordView().getViewSchema(sampleRecord));
-    assertEquals(sampleRecord.valueSchema(), new ValueRecordView().getViewSchema(sampleRecord));
+    assertEquals(sampleRecord.key(), new KeyRecordView().getView(sampleRecord, false));
+    assertEquals(sampleRecord.value(), new ValueRecordView().getView(sampleRecord, false));
+    assertEquals(sampleRecord.keySchema(), new KeyRecordView().getViewSchema(sampleRecord, false));
+    assertEquals(sampleRecord.valueSchema(), new ValueRecordView().getViewSchema(sampleRecord, false));
   }
 
   @Test
@@ -54,7 +54,7 @@ public class RecordViewsTest {
         new Struct(SINGLE_HEADER_SCHEMA).put("key", "int").put("value", "12"),
         new Struct(SINGLE_HEADER_SCHEMA).put("key", "boolean").put("value", "false"));
 
-    Object headerView = new HeaderRecordView().getView(getSampleSinkRecord());
+    Object headerView = new HeaderRecordView().getView(getSampleSinkRecord(), false);
     assertEquals(expectedHeaders, headerView);
   }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewsTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/RecordViewsTest.java
@@ -1,7 +1,11 @@
 package io.confluent.connect.s3.format;
 
+import java.util.Date;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.data.Timestamp;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Headers;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -27,22 +31,86 @@ public class RecordViewsTest {
   }
 
   @Test
-  public void testHeaderConvertsToString() {
-    Headers headers = new ConnectHeaders()
-        .addString("string", "string")
-        .addInt("int", 12)
-        .addBoolean("boolean", false);
+  public void testGetExtension() {
+    assertEquals("", new ValueRecordView().getExtension());
+    assertEquals(".keys", new KeyRecordView().getExtension());
+    assertEquals(".headers", new HeaderRecordView().getExtension());
+  }
 
-    List<Struct> expected = Arrays.asList(
+  @Test
+  public void testRecordKeyValueViews() {
+    SinkRecord sampleRecord = getSampleSinkRecord();
+    assertEquals(sampleRecord.key(), new KeyRecordView().getView(sampleRecord));
+    assertEquals(sampleRecord.value(), new ValueRecordView().getView(sampleRecord));
+    assertEquals(sampleRecord.keySchema(), new KeyRecordView().getViewSchema(sampleRecord));
+    assertEquals(sampleRecord.valueSchema(), new ValueRecordView().getViewSchema(sampleRecord));
+  }
+
+  @Test
+  public void testHeaderConvertsToString() {
+    List<Struct> expectedHeaders = Arrays.asList(
         new Struct(SINGLE_HEADER_SCHEMA)
             .put("key", "string").put("value", "string"),
         new Struct(SINGLE_HEADER_SCHEMA).put("key", "int").put("value", "12"),
         new Struct(SINGLE_HEADER_SCHEMA).put("key", "boolean").put("value", "false"));
 
-    SinkRecord record = new SinkRecord(
-        "topic", 0, null, null, null, null, 0, 0L, TimestampType.NO_TIMESTAMP_TYPE, headers);
+    Object headerView = new HeaderRecordView().getView(getSampleSinkRecord());
+    assertEquals(expectedHeaders, headerView);
+  }
 
-    Object headerView = new HeaderRecordView().getView(record);
-    assertEquals(expected, headerView);
+  private SinkRecord getSampleSinkRecord() {
+    Headers headers = new ConnectHeaders()
+        .addString("string", "string")
+        .addInt("int", 12)
+        .addBoolean("boolean", false);
+
+    Schema keyschema = getExampleKeyStructSchema();
+    Schema valueschema = getExampleValueStructSchema();
+
+    return new SinkRecord(
+        "topic", 0,
+        keyschema, getExampleKeyStruct(keyschema),
+        valueschema, getExampleValueStruct(valueschema),
+        0, 0L, TimestampType.NO_TIMESTAMP_TYPE, headers);
+  }
+
+  private Schema getExampleKeyStructSchema() {
+    return SchemaBuilder.struct()
+        .field("recordKeyID", Schema.INT64_SCHEMA)
+        .field("keyString", Schema.STRING_SCHEMA)
+        .field("keyBytes", Schema.BYTES_SCHEMA)
+        .build();
+  }
+
+  private Struct getExampleKeyStruct(Schema structSchema) {
+    Date sampleDate = new Date(1111111);
+    sampleDate.setTime(0);
+    return new Struct(structSchema)
+        .put("recordKeyID", (long) 0)
+        .put("keyString", "theStringVal")
+        .put("keyBytes", "theBytes".getBytes());
+  }
+
+  private Schema getExampleValueStructSchema() {
+    return SchemaBuilder.struct()
+        .field("ID", Schema.INT64_SCHEMA)
+        .field("myString", Schema.STRING_SCHEMA)
+        .field("myBool", Schema.BOOLEAN_SCHEMA)
+        .field("myBytes", Schema.BYTES_SCHEMA)
+        .field("myDate", org.apache.kafka.connect.data.Date.SCHEMA)
+        .field("myTime", Timestamp.SCHEMA)
+        .build();
+  }
+
+  private Struct getExampleValueStruct(Schema structSchema) {
+    Date sampleDate = new Date(1111111);
+    sampleDate.setTime(0);
+    return new Struct(structSchema)
+        .put("ID", (long) 0)
+        .put("myString", "theStringVal")
+        .put("myBool", true)
+        .put("myBytes", "theBytes".getBytes())
+        .put("myDate", sampleDate)
+        .put("myTime", new Date(33333333));
   }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/UtilsTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/UtilsTest.java
@@ -1,5 +1,6 @@
-package io.confluent.connect.s3.format;
+package io.confluent.connect.s3.util;
 
+import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
 import static org.junit.Assert.assertEquals;
 
 import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
@@ -10,7 +11,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.Test;
 
-public class RecordViewSetterTest {
+public class UtilsTest {
 
   private static List<String> givenFilenames = new ArrayList<>(Arrays.asList(
       "x.avro",
@@ -26,9 +27,6 @@ public class RecordViewSetterTest {
 
   @Test
   public void getAdjustedFilenameForValues() {
-    RecordViewSetter rv = new RecordViewSetter();
-    rv.setRecordView(new ValueRecordView());
-
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.avro",
         "asdf.avro",
@@ -42,16 +40,13 @@ public class RecordViewSetterTest {
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
-      String adjustedFilename = rv.getAdjustedFilename(givenFilenames.get(i), ".avro");
+      String adjustedFilename = getAdjustedFilename(new ValueRecordView(), givenFilenames.get(i), ".avro");
       assertEquals(expectedFilenames.get(i), adjustedFilename);
     }
   }
 
   @Test
   public void getAdjustedFilenameForKeys() {
-    RecordViewSetter rv = new RecordViewSetter();
-    rv.setRecordView(new KeyRecordView());
-
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.keys.avro",
         "asdf.keys.avro",
@@ -65,16 +60,13 @@ public class RecordViewSetterTest {
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
-      String adjustedFilename = rv.getAdjustedFilename(givenFilenames.get(i), ".avro");
+      String adjustedFilename = getAdjustedFilename(new KeyRecordView(), givenFilenames.get(i), ".avro");
       assertEquals(expectedFilenames.get(i), adjustedFilename);
     }
   }
 
   @Test
   public void getAdjustedFilenameForHeaders() {
-    RecordViewSetter rv = new RecordViewSetter();
-    rv.setRecordView(new HeaderRecordView());
-
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.headers.avro",
         "asdf.headers.avro",
@@ -88,16 +80,13 @@ public class RecordViewSetterTest {
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
-      String adjustedFilename = rv.getAdjustedFilename(givenFilenames.get(i), ".avro");
+      String adjustedFilename = getAdjustedFilename(new HeaderRecordView(), givenFilenames.get(i), ".avro");
       assertEquals(expectedFilenames.get(i), adjustedFilename);
     }
   }
 
   @Test
   public void testParquetEncodingExtensions() {
-    RecordViewSetter rv = new RecordViewSetter();
-    rv.setRecordView(new HeaderRecordView());
-
     List<String> givenFilenames1 = new ArrayList<>(Arrays.asList(
         "x.snappy.parquet",
         "sample-filename.snappy.parquet",
@@ -113,7 +102,7 @@ public class RecordViewSetterTest {
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
-      String adjustedFilename = rv.getAdjustedFilename(givenFilenames1.get(i), ".snappy.parquet");
+      String adjustedFilename = getAdjustedFilename(new HeaderRecordView(), givenFilenames1.get(i), ".snappy.parquet");
       assertEquals(expectedFilenames.get(i), adjustedFilename);
     }
   }


### PR DESCRIPTION
## Summary
This PR adds the ability for the connector to write record keys and headers to separate key and header files if desired. 

The updated code exposes new connector configurations that allow the user to specify if they want to write the contents from the Kafka record key and header to files at the destination in addition to the original value file. 

The connector achieves this by introducing new configs along with a `RecordView` interface and `KeyValueRecordProvider` class.  We introduce our own `RecordWriterProvider` that provides an abstraction so that the `TopicPartitionWriter`  class can write  these new files without any code changes.

## New Classes
**KeyValueHeaderRecordWriterProvider**
This class provides an abstraction for writing, committing and closing all three header, key and value files.

**RecordView**
An interface to get the schema for all three record portions. 

**RecordViews**
Implementation of `RecordView`. 

**RecordViewSetter**
A class to provide functionality to set the recordView for a particular writerProvider, used in `SinkTask::newRecordWriterProvider`.

**Utils**
A general utility class for util functions.

## Functional Changes 
**S3SinkConnectorConfig**
Added the new configurations:
`store.kafka.keys`
`store.kafka.headers`
`keys.format.class` 
`headers.format.class`
and their corresponding recommenders.

**S3SinkTask**
Added the utility function `newRecordWriterProvider` to get the `KeyValueHeaderRecordWriterProvider` with the given headerWriterProvider and keyWriterProviders if storing the headers/keys is configured. 

**ParquetRecordWriterProvider**
Extend `RecordViewSetter` to use the default record view as value. Added filename manipulation logic to append the key/header extension if needed.

**JsonRecordWriterProvider**
Extend `RecordViewSetter` to use the default record view as value. Added filename manipulation logic to append the key/header extension if needed.

**ByteArrayRecordWriterProvider**
Extend `RecordViewSetter` to use the default record view as value. Added filename manipulation logic to append the key/header extension if needed.

**AvroRecordWriterProvider**
Extend `RecordViewSetter` to use the default record view as value. Added filename manipulation logic to append the key/header extension if needed.

## Tests
**Muckrake Tests** https://github.com/confluentinc/muckrake/pull/1020 (System tests PR) 