### PR TITLE
Move null value handling earlier in SinkTask put

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -177,12 +177,6 @@ public class S3SinkTask extends SinkTask {
       TopicPartition tp = new TopicPartition(topic, partition);
 
       if (maybeSkipOnNullValue(record)) {
-        log.debug(
-            "Null valued record from topic '{}', partition {} and offset {} was skipped.",
-            record.topic(),
-            record.kafkaPartition(),
-            record.kafkaOffset()
-        );
         continue;
       }
       topicPartitionWriters.get(tp).buffer(record);
@@ -213,6 +207,12 @@ public class S3SinkTask extends SinkTask {
     if (record.value() == null) {
       if (connectorConfig.nullValueBehavior()
           .equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
+        log.debug(
+            "Null valued record from topic '{}', partition {} and offset {} was skipped.",
+            record.topic(),
+            record.kafkaPartition(),
+            record.kafkaOffset()
+        );
         return true;
       } else {
         throw new ConnectException("Null valued records are not writeable with current "

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -176,7 +176,8 @@ public class S3SinkTask extends SinkTask {
       int partition = record.kafkaPartition();
       TopicPartition tp = new TopicPartition(topic, partition);
       if (record.value() == null) {
-        if (connectorConfig.nullValueBehavior().equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
+        if (connectorConfig.nullValueBehavior()
+            .equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
           log.debug("Null valued record cannot be written to output as Avro. "
               + "Skipping. Record Key: {}", record.key());
           return;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -178,8 +178,8 @@ public class S3SinkTask extends SinkTask {
       if (record.value() == null) {
         if (connectorConfig.nullValueBehavior()
             .equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
-          log.debug("Null valued record cannot be written to output as Avro. "
-              + "Skipping. Record Key: {}", record.key());
+          log.debug("Null valued record cannot be written to output: offset {}",
+              record.kafkaOffset());
           continue;
         } else {
           throw new ConnectException("Null valued records are not writeable with current "

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -177,9 +177,12 @@ public class S3SinkTask extends SinkTask {
       TopicPartition tp = new TopicPartition(topic, partition);
 
       if (maybeSkipOnNullValue(record)) {
-        log.debug("Null valued record cannot be written to output: offset {}",
-            record.kafkaOffset());
-        continue;
+        log.debug(
+            "Null valued record from topic '{}', partition {} and offset {} was skipped.",
+            record.topic(),
+            record.kafkaPartition(),
+            record.kafkaOffset()
+        );
       }
       topicPartitionWriters.get(tp).buffer(record);
     }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -180,7 +180,7 @@ public class S3SinkTask extends SinkTask {
             .equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
           log.debug("Null valued record cannot be written to output as Avro. "
               + "Skipping. Record Key: {}", record.key());
-          return;
+          continue;
         } else {
           throw new ConnectException("Null valued records are not writeable with current "
               + S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG + " 'settings.");

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -183,6 +183,7 @@ public class S3SinkTask extends SinkTask {
             record.kafkaPartition(),
             record.kafkaOffset()
         );
+        continue;
       }
       topicPartitionWriters.get(tp).buffer(record);
     }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.s3;
 
 import com.amazonaws.AmazonClientException;
+import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -174,6 +175,16 @@ public class S3SinkTask extends SinkTask {
       String topic = record.topic();
       int partition = record.kafkaPartition();
       TopicPartition tp = new TopicPartition(topic, partition);
+      if (record.value() == null) {
+        if (connectorConfig.nullValueBehavior().equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
+          log.debug("Null valued record cannot be written to output as Avro. "
+              + "Skipping. Record Key: {}", record.key());
+          return;
+        } else {
+          throw new ConnectException("Null valued records are not writeable with current "
+              + S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG + " 'settings.");
+        }
+      }
       topicPartitionWriters.get(tp).buffer(record);
     }
     if (log.isDebugEnabled()) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -15,7 +15,6 @@
 
 package io.confluent.connect.s3.format.avro;
 
-import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
@@ -81,16 +80,6 @@ public class AvroRecordWriterProvider implements RecordWriterProvider<S3SinkConn
           // NonRecordContainers to just their value to properly handle these types
           if (value instanceof NonRecordContainer) {
             value = ((NonRecordContainer) value).getValue();
-          }
-          if (value == null) {
-            if (conf.nullValueBehavior().equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
-              log.debug("Null valued record cannot be written to output as Avro. "
-                  + "Skipping. Record Key: {}", record.key());
-              return;
-            } else {
-              throw new ConnectException("Null valued records are not writeable with current "
-                  + S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG + " 'settings.");
-            }
           }
           writer.append(value);
         } catch (IOException e) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -16,7 +16,6 @@
 package io.confluent.connect.s3.format.bytearray;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
-import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
 import io.confluent.connect.s3.storage.S3OutputStream;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.format.RecordWriter;
@@ -66,16 +65,6 @@ public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3Sin
         try {
           byte[] bytes = converter.fromConnectData(
               record.topic(), record.valueSchema(), record.value());
-          if (bytes == null) {
-            if (conf.nullValueBehavior().equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
-              log.debug("Null valued record cannot be written to output as Avro. "
-                  + "Skipping. Record Key: {}", record.key());
-              return;
-            } else {
-              throw new ConnectException("Null valued records are not writeable with current "
-                  + S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG + " 'settings.");
-            }
-          }
           s3outWrapper.write(bytes);
           s3outWrapper.write(lineSeparatorBytes);
         } catch (IOException | DataException e) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -17,7 +17,6 @@ package io.confluent.connect.s3.format.json;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
@@ -81,17 +80,6 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConn
               s3outWrapper.write(rawJson);
               s3outWrapper.write(LINE_SEPARATOR_BYTES);
             } else {
-              if (value == null) {
-                if (conf.nullValueBehavior()
-                    .equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
-                  log.debug("Null valued record cannot be written to output as Avro. "
-                      + "Skipping. Record Key: {}", record.key());
-                  return;
-                } else {
-                  throw new ConnectException("Null valued records are not writeable with current "
-                      + S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG + " 'settings.");
-                }
-              }
               writer.writeObject(value);
               writer.writeRaw(LINE_SEPARATOR);
             }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -191,44 +191,6 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
   }
 
   @Test
-  public void testNullValue() throws Exception {
-    localProps.put(StorageSinkConnectorConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, "true");
-    localProps.put(StorageSinkConnectorConfig.CONNECT_META_DATA_CONFIG, "true");
-    localProps.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "ignore");
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1");
-
-    setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
-
-    TopicPartition tp = context.assignment().iterator().next();
-    List<SinkRecord> sinkRecords = Collections
-        .singletonList(new SinkRecord(TOPIC, tp.partition(), null, "key", null, null, 42));
-    task.put(sinkRecords);
-    task.close(context.assignment());
-    task.stop();
-
-    List<String> fileNames = getExpectedFiles(new long[]{42L, 42L}, tp);
-    verifyFileListing(fileNames);
-    Collection<Object> records = readRecords(topicsDir, getDirectory(tp.topic(), tp.partition()),
-        tp, 42, extension, ZERO_PAD_FMT, S3_TEST_BUCKET_NAME, s3);
-    assertEquals(0, records.size());
-  }
-
-  @Test(expected = ConnectException.class)
-  public void testNullValueThrows() throws Exception {
-    localProps.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "fail");
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1");
-
-    setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
-
-    TopicPartition tp = context.assignment().iterator().next();
-    List<SinkRecord> sinkRecords = Collections
-        .singletonList(new SinkRecord(TOPIC, tp.partition(), null, "key", null, null, 42));
-    task.put(sinkRecords);
-  }
-
-  @Test
   public void testWriteRecordsOfUnionsWithEnhancedAvroData() throws Exception {
     localProps.put(StorageSinkConnectorConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, "true");
     localProps.put(StorageSinkConnectorConfig.CONNECT_META_DATA_CONFIG, "true");

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
@@ -116,44 +116,6 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
   }
 
   @Test
-  public void testNullValue() throws Exception {
-    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
-    localProps.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "ignore");
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1");
-
-    setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
-
-    TopicPartition tp = context.assignment().iterator().next();
-    List<SinkRecord> sinkRecords = Collections
-        .singletonList(new SinkRecord(TOPIC, tp.partition(), null, "key", null, null, 42));
-    task.put(sinkRecords);
-    task.close(context.assignment());
-    task.stop();
-
-    List<String> fileNames = getExpectedFiles(new long[]{42L, 42L}, tp, ".bin");
-    verifyFileListing(fileNames);
-    Collection<Object> records = readRecords(topicsDir, getDirectory(tp.topic(), tp.partition()),
-        tp, 42, ".bin", ZERO_PAD_FMT, S3_TEST_BUCKET_NAME, s3);
-    assertEquals(0, records.size());
-  }
-
-  @Test(expected = ConnectException.class)
-  public void testNullValueThrows() throws Exception {
-    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
-    localProps.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "fail");
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1");
-
-    setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
-
-    TopicPartition tp = context.assignment().iterator().next();
-    List<SinkRecord> sinkRecords = Collections
-        .singletonList(new SinkRecord(TOPIC, tp.partition(), null, "key", null, null, 42));
-    task.put(sinkRecords);
-  }
-
-  @Test
   public void testGzipCompression() throws Exception {
     CompressionType compressionType = CompressionType.GZIP;
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
@@ -174,43 +174,6 @@ public class DataWriterJsonTest extends TestWithMockedS3 {
     verify(sinkRecords, validOffsets, context.assignment(), ".json.gz");
   }
 
-  @Test
-  public void testNullValue() throws Exception {
-    localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
-    localProps.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "ignore");
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1");
-
-    setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
-
-    TopicPartition tp = context.assignment().iterator().next();
-    List<SinkRecord> sinkRecords = Collections
-        .singletonList(new SinkRecord(TOPIC, tp.partition(), null, "key", null, null, 42));
-    task.put(sinkRecords);
-    task.close(context.assignment());
-    task.stop();
-
-    List<String> fileNames = getExpectedFiles(new long[]{42L, 42L}, tp, ".json");
-    verifyFileListing(fileNames);
-    Collection<Object> records = readRecords(topicsDir, getDirectory(tp.topic(), tp.partition()),
-        tp, 42, ".json", ZERO_PAD_FMT, S3_TEST_BUCKET_NAME, s3);
-    assertEquals(0, records.size());
-  }
-
-  @Test(expected = ConnectException.class)
-  public void testNullValueThrows() throws Exception {
-    localProps.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG, "fail");
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1");
-
-    setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
-
-    TopicPartition tp = context.assignment().iterator().next();
-    List<SinkRecord> sinkRecords = Collections
-        .singletonList(new SinkRecord(TOPIC, tp.partition(), null, "key", null, null, 42));
-    task.put(sinkRecords);
-  }
-
   protected List<SinkRecord> createRecordsInterleaved(int size, long startOffset, Set<TopicPartition> partitions) {
     String key = "key";
     Schema schema = createSchema();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -113,17 +113,26 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
     task.start(properties);
     verifyAll();
 
-    List<SinkRecord> sinkRecords = new ArrayList<>();
+    List<SinkRecord> sinkRecords = createRecordsWithPrimitive(3, 0,
+        Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
     sinkRecords.add(
         new SinkRecord(TOPIC, PARTITION, null, null, Schema.OPTIONAL_STRING_SCHEMA, null,
             0));
     sinkRecords.add(new SinkRecord(TOPIC, PARTITION, null, null, null, null, 1));
+    sinkRecords.addAll(createRecordsWithPrimitive(4, 3,
+        Collections.singleton(new TopicPartition(TOPIC, PARTITION))));
     task.put(sinkRecords);
     task.close(context.assignment());
     task.stop();
 
-    long[] validOffsets = {};
-    verify(sinkRecords, validOffsets);
+    long[] validOffsets = {0, 3, 6};
+
+    // expect sink records like the ones we put, but without the null records
+    List<SinkRecord> expectedSinkRecords = createRecordsWithPrimitive(3, 0,
+        Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
+    expectedSinkRecords.addAll(createRecordsWithPrimitive(4, 3,
+        Collections.singleton(new TopicPartition(TOPIC, PARTITION))));
+    verify(expectedSinkRecords, validOffsets);
   }
 
   @Test

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -103,7 +103,7 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
   }
 
   @Test
-  public void testWriteTwoRecords() throws Exception {
+  public void testWriteNullRecords() throws Exception {
     setUp();
     replayAll();
     task = new S3SinkTask();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
+import org.apache.kafka.connect.data.Schema;
 import org.easymock.Capture;
 import org.easymock.EasyMock;
 import org.junit.After;
@@ -30,6 +31,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -97,6 +99,30 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
     task.stop();
 
     long[] validOffsets = {0, 3, 6};
+    verify(sinkRecords, validOffsets);
+  }
+
+  @Test
+  public void testWriteTwoRecords() throws Exception {
+    setUp();
+    replayAll();
+    task = new S3SinkTask();
+    task.initialize(context);
+    properties.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
+        S3SinkConnectorConfig.BehaviorOnNullValues.IGNORE.toString());
+    task.start(properties);
+    verifyAll();
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    sinkRecords.add(
+        new SinkRecord(TOPIC, PARTITION, null, null, Schema.OPTIONAL_STRING_SCHEMA, null,
+            0));
+    sinkRecords.add(new SinkRecord(TOPIC, PARTITION, null, null, null, null, 1));
+    task.put(sinkRecords);
+    task.close(context.assignment());
+    task.stop();
+
+    long[] validOffsets = {};
     verify(sinkRecords, validOffsets);
   }
 


### PR DESCRIPTION
Why
-----
TopicPartitionWriter threw "SchemaProjectorException( "Switch between schema-based and schema-less data is not supported");" from storage common, despite having an AvroConverter, which we would expect to require every record to have a schema. The exceptional case, it turns out, is a null-valued schema which can have no schema. This alerted us that our original implementation of null-value-behavior in the writerprovider was carrying an assumption that the null-valued record would be well-handled by the topicpartitionwriter, which in this case, is not.

How
------
Moved the `nullValueBehavior` logic from the WriterProvider to be much earlier in Task.put, so we can continue to the next record before it can throw escalations or waste resources.

Testing
-----
Unit test included for regressions.