### PR TITLE
Allow integrity checks during upload

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -165,6 +165,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   private final StorageCommonConfig commonConfig;
   private final PartitionerConfig partitionerConfig;
 
+  public static final String UPLOAD_INTEGRITY_CHECK = "upload.integrity.check";
+  public static final boolean UPLOAD_INTEGRITY_CHECK_DEFAULT = false;
+
   private final Map<String, ComposableConfig> propertyToConfig = new HashMap<>();
   private final Set<AbstractConfig> allConfigs = new HashSet<>();
 
@@ -567,6 +570,22 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           "Behavior for null-valued records"
       );
 
+      configDef.define(
+              UPLOAD_INTEGRITY_CHECK,
+              Type.BOOLEAN,
+              UPLOAD_INTEGRITY_CHECK_DEFAULT,
+              Importance.LOW,
+              "Enable or disable integrity checks while uploading parts during "
+              + " a multi-part upload. If true, the MD5 digest of each part would be sent "
+              + "which would then be used to verify a successful transfer of the part. "
+              + "Else, no MD5 digest would be sent and the integrity "
+              + "of data during upload cannot be guaranteed.",
+              group,
+              ++orderInGroup,
+              Width.SHORT,
+              "Upload Integrity Check"
+      );
+
     }
     return configDef;
   }
@@ -625,6 +644,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public int getPartSize() {
     return getInt(PART_SIZE_CONFIG);
+  }
+
+  public boolean uploadIntegrityCheck() {
+    return getBoolean(UPLOAD_INTEGRITY_CHECK);
   }
 
   @SuppressWarnings("unchecked")

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -31,6 +31,7 @@ import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.storage.common.util.StringUtils;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.parquet.io.PositionOutputStream;
 import org.slf4j.Logger;
@@ -41,6 +42,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 /**
@@ -250,6 +252,18 @@ public class S3OutputStream extends PositionOutputStream {
                                             .withPartNumber(currentPartNumber)
                                             .withPartSize(partSize)
                                             .withGeneralProgressListener(progressListener);
+
+      if (connectorConfig.uploadIntegrityCheck()) {
+        try {
+          String digest = Base64.getEncoder().encodeToString(DigestUtils.md5(inputStream));
+          // Reset the marker so that the stream may be read again while uploading
+          inputStream.reset();
+          request.setMd5Digest(digest);
+        } catch (IOException e) {
+          log.warn("Error calculating md5 digest for part {} for id '{}'; skipping check",
+                  currentPartNumber, uploadId);
+        }
+      }
       log.debug("Uploading part {} for id '{}'", currentPartNumber, uploadId);
       partETags.add(s3.uploadPart(request).getPartETag());
     }


### PR DESCRIPTION
Adds a configuration that enables integrity checks using
Content-MD5 headers for each chunk of a multi-part upload.

This would be useful to users who want to ensure no data corruption occurs during
the upload.

Unfortunately, S3Mock doesn't check the header and therefore I couldn't write a test for it
but the feature is documented [here](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/s3/model/UploadPartRequest.html#setMd5Digest-java.lang.String-) and the encoding is documented  [here](https://aws.amazon.com/premiumsupport/knowledge-center/data-integrity-s3/) and [here](https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutObject.html#API_PutObject_RequestSyntax)

I'll be glad to add a test if there's an alternative to it
