### PR TITLE
CC-9723: DLQ support in S3 sink

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -20,7 +20,6 @@ import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
@@ -108,7 +107,7 @@ public class S3SinkTask extends SinkTask {
           url
       );
       if (!storage.bucketExists()) {
-        throw new DataException("No-existent S3 bucket: " + connectorConfig.getBucketName());
+        throw new ConnectException("No-existent S3 bucket: " + connectorConfig.getBucketName());
       }
 
       writerProvider = newRecordWriterProvider(connectorConfig);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -20,7 +20,9 @@ import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -59,6 +61,7 @@ public class S3SinkTask extends SinkTask {
   private Format<S3SinkConnectorConfig, String> format;
   private RecordWriterProvider<S3SinkConnectorConfig> writerProvider;
   private final Time time;
+  private ErrantRecordReporter reporter;
 
   /**
    * No-arg constructor. Used by Connect framework.
@@ -114,6 +117,16 @@ public class S3SinkTask extends SinkTask {
       partitioner = newPartitioner(connectorConfig);
 
       open(context.assignment());
+      try {
+        reporter = context.errantRecordReporter();
+        if (reporter == null) {
+          log.info("Errant record reporter not configured.");
+        }
+      } catch (NoSuchMethodError | NoClassDefFoundError | UnsupportedOperationException e) {
+        // Will occur in Connect runtimes earlier than 2.6
+        log.warn("AK versions prior to 2.6 do not support the errant record reporter");
+      }
+
       log.info("Started S3 connector task with assigned partitions: {}",
           topicPartitionWriters.keySet()
       );
@@ -203,6 +216,9 @@ public class S3SinkTask extends SinkTask {
       TopicPartition tp = new TopicPartition(topic, partition);
 
       if (maybeSkipOnNullValue(record)) {
+        if (reporter != null) {
+          reporter.report(record, new DataException("Cannot write null value record"));
+        }
         continue;
       }
       topicPartitionWriters.get(tp).buffer(record);
@@ -304,7 +320,8 @@ public class S3SinkTask extends SinkTask {
         partitioner,
         connectorConfig,
         context,
-        time
+        time,
+        reporter
     );
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -124,7 +124,8 @@ public class S3SinkTask extends SinkTask {
         }
       } catch (NoSuchMethodError | NoClassDefFoundError | UnsupportedOperationException e) {
         // Will occur in Connect runtimes earlier than 2.6
-        log.warn("AK versions prior to 2.6 do not support the errant record reporter");
+        log.warn("Connect versions prior to Apache Kafka 2.6 do not support "
+            + "the errant record reporter");
       }
 
       log.info("Started S3 connector task with assigned partitions: {}",

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -218,7 +218,7 @@ public class S3SinkTask extends SinkTask {
 
       if (maybeSkipOnNullValue(record)) {
         if (reporter != null) {
-          reporter.report(record, new DataException("Cannot write null value record"));
+          reporter.report(record, new DataException("Skipping null value record."));
         }
         continue;
       }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -110,7 +110,7 @@ public class S3SinkTask extends SinkTask {
           url
       );
       if (!storage.bucketExists()) {
-        throw new ConnectException("No-existent S3 bucket: " + connectorConfig.getBucketName());
+        throw new ConnectException("Non-existent S3 bucket: " + connectorConfig.getBucketName());
       }
 
       writerProvider = newRecordWriterProvider(connectorConfig);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -22,6 +22,7 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.IllegalWorkerStateException;
 import org.apache.kafka.connect.errors.SchemaProjectorException;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.joda.time.DateTime;
@@ -91,24 +92,31 @@ public class TopicPartitionWriter {
   private DateTimeZone timeZone;
   private final S3SinkConnectorConfig connectorConfig;
   private static final Time SYSTEM_TIME = new SystemTime();
+  private ErrantRecordReporter reporter;
 
-  public TopicPartitionWriter(TopicPartition tp,
-                              S3Storage storage,
-                              RecordWriterProvider<S3SinkConnectorConfig> writerProvider,
-                              Partitioner<?> partitioner,
-                              S3SinkConnectorConfig connectorConfig,
-                              SinkTaskContext context) {
-    this(tp, storage, writerProvider, partitioner, connectorConfig, context, SYSTEM_TIME);
+  public TopicPartitionWriter(
+      TopicPartition tp,
+      S3Storage storage,
+      RecordWriterProvider<S3SinkConnectorConfig> writerProvider,
+      Partitioner<?> partitioner,
+      S3SinkConnectorConfig connectorConfig,
+      SinkTaskContext context,
+      ErrantRecordReporter reporter
+  ) {
+    this(tp, storage, writerProvider, partitioner, connectorConfig, context, SYSTEM_TIME, reporter);
   }
 
   // Visible for testing
-  TopicPartitionWriter(TopicPartition tp,
-                       S3Storage storage,
-                       RecordWriterProvider<S3SinkConnectorConfig> writerProvider,
-                       Partitioner<?> partitioner,
-                       S3SinkConnectorConfig connectorConfig,
-                       SinkTaskContext context,
-                       Time time) {
+  TopicPartitionWriter(
+      TopicPartition tp,
+      S3Storage storage,
+      RecordWriterProvider<S3SinkConnectorConfig> writerProvider,
+      Partitioner<?> partitioner,
+      S3SinkConnectorConfig connectorConfig,
+      SinkTaskContext context,
+      Time time,
+      ErrantRecordReporter reporter
+  ) {
     this.connectorConfig = connectorConfig;
     this.time = time;
     this.tp = tp;
@@ -116,6 +124,7 @@ public class TopicPartitionWriter {
     this.context = context;
     this.writerProvider = writerProvider;
     this.partitioner = partitioner;
+    this.reporter = reporter;
     this.timestampExtractor = partitioner instanceof TimeBasedPartitioner
                                   ? ((TimeBasedPartitioner) partitioner).getTimestampExtractor()
                                   : null;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -106,15 +106,14 @@ public class TopicPartitionWriter {
   }
 
   // Visible for testing
-  TopicPartitionWriter(
-      TopicPartition tp,
-      S3Storage storage,
-      RecordWriterProvider<S3SinkConnectorConfig> writerProvider,
-      Partitioner<?> partitioner,
-      S3SinkConnectorConfig connectorConfig,
-      SinkTaskContext context,
-      Time time,
-      ErrantRecordReporter reporter
+  TopicPartitionWriter(TopicPartition tp,
+                       S3Storage storage,
+                       RecordWriterProvider<S3SinkConnectorConfig> writerProvider,
+                       Partitioner<?> partitioner,
+                       S3SinkConnectorConfig connectorConfig,
+                       SinkTaskContext context,
+                       Time time,
+                       ErrantRecordReporter reporter
   ) {
     this.connectorConfig = connectorConfig;
     this.time = time;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -219,7 +219,7 @@ public class TopicPartitionWriter {
         // fallthrough
       case WRITE_PARTITION_PAUSED:
         SinkRecord record = buffer.peek();
-        if (recordProducesDataException(record)){
+        if (recordProducesDataException(record)) {
           buffer.poll(); // remove faulty record
           break;
         }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -328,8 +328,7 @@ public class TopicPartitionWriter {
       } else {
         throw new ConnectException(e);
       }
-    }
-    finally {
+    } finally {
       tempWriter.close();
     }
   }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -319,17 +319,18 @@ public class TopicPartitionWriter {
     RecordWriter tempWriter = writerProvider.getRecordWriter(connectorConfig, "");
     try {
       tempWriter.write(record);
-      tempWriter.close();
       return false;
     } catch (DataException e) {
       if (reporter != null) {
         reporter.report(record, e);
         log.warn("Errant record written to DLQ due to: {}", e.getMessage());
-        tempWriter.close();
         return true;
       } else {
         throw new ConnectException(e);
       }
+    }
+    finally {
+      tempWriter.close();
     }
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -86,20 +86,22 @@ public class KeyValueHeaderRecordWriterProvider
       public void write(SinkRecord sinkRecord) {
         valueWriter.write(sinkRecord); // null check happens in sink task
         // keyWriter != null means writing keys is turned on
-        if (keyWriter != null && sinkRecord.key() == null) {
-          throw new DataException(
-              String.format("Key cannot be null for SinkRecord: %s", sinkRecord)
-          );
-        } else if (keyWriter != null) {
+        if (keyWriter != null) {
+          if (sinkRecord.key() == null) {
+            throw new DataException(
+                String.format("Key cannot be null for SinkRecord: %s", sinkRecord)
+            );
+          }
           keyWriter.write(sinkRecord);
         }
 
         // headerWriter != null means writing headers is turned on
-        if (headerWriter != null && sinkRecord.headers() == null) {
-          throw new DataException(
-              String.format("Headers cannot be null for SinkRecord: %s", sinkRecord)
-          );
-        } else if (headerWriter != null) {
+        if (headerWriter != null) {
+          if (sinkRecord.headers() == null || sinkRecord.headers().isEmpty()) {
+            throw new DataException(
+                String.format("Headers cannot be null for SinkRecord: %s", sinkRecord)
+            );
+          }
           headerWriter.write(sinkRecord);
         }
       }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -25,7 +25,6 @@ import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
 import org.apache.kafka.connect.converters.ByteArrayConverter;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
@@ -73,7 +72,7 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
               recordView.getViewSchema(record, false), recordView.getView(record, false));
           s3outWrapper.write(bytes);
           s3outWrapper.write(lineSeparatorBytes);
-        } catch (IOException | DataException e) {
+        } catch (IOException e) {
           throw new ConnectException(e);
         }
       }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -33,7 +33,6 @@ import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.storage.common.util.StringUtils;
-import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.parquet.io.PositionOutputStream;
 import org.slf4j.Logger;
@@ -169,7 +168,7 @@ public class S3OutputStream extends PositionOutputStream {
       log.debug("Upload complete for bucket '{}' key '{}'", bucket, key);
     } catch (IOException e) {
       log.error("Multipart upload failed to complete for bucket '{}' key '{}'", bucket, key);
-      throw new RetriableException(
+      throw new ConnectException(
           String.format("Multipart upload failed to complete: %s", e.getMessage())
       );
     } finally {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -33,6 +33,7 @@ import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.storage.common.util.StringUtils;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.parquet.io.PositionOutputStream;
 import org.slf4j.Logger;
@@ -168,7 +169,7 @@ public class S3OutputStream extends PositionOutputStream {
       log.debug("Upload complete for bucket '{}' key '{}'", bucket, key);
     } catch (IOException e) {
       log.error("Multipart upload failed to complete for bucket '{}' key '{}'", bucket, key);
-      throw new ConnectException(
+      throw new RetriableException(
           String.format("Multipart upload failed to complete: %s", e.getMessage())
       );
     } finally {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -34,7 +34,6 @@ import com.amazonaws.services.s3.model.UploadPartRequest;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.storage.common.util.StringUtils;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.DataException;
 import org.apache.parquet.io.PositionOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -169,7 +168,9 @@ public class S3OutputStream extends PositionOutputStream {
       log.debug("Upload complete for bucket '{}' key '{}'", bucket, key);
     } catch (IOException e) {
       log.error("Multipart upload failed to complete for bucket '{}' key '{}'", bucket, key);
-      throw new DataException("Multipart upload failed to complete.", e);
+      throw new ConnectException(
+          String.format("Multipart upload failed to complete: %s", e.getMessage())
+      );
     } finally {
       buffer.clear();
       multiPartUpload = null;

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -925,7 +925,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testExceptionOnNullKeysReported() throws Exception {
     String recordValue = "1";
-    int kafkaOffset = 1;
+    int kafkaOffset = 2;
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null,
         Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
 
@@ -1078,7 +1078,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
       topicPartitionWriter.buffer(faultyRecord);
       topicPartitionWriter.buffer(faultyRecord); // send second to verify file rotation as expected
       // write rest of records
-      for (int i = 2; i < sinkRecords.size(); i++) {
+      for (int i = 4; i < sinkRecords.size(); i++) {
         topicPartitionWriter.buffer(sinkRecords.get(i));
       }
     } else {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -32,9 +32,12 @@ import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.errors.RetriableException;
+import org.apache.kafka.connect.errors.SchemaProjectorException;
 import org.apache.kafka.connect.header.ConnectHeaders;
 import org.apache.kafka.connect.header.Header;
+import org.apache.kafka.connect.sink.ErrantRecordReporter;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.easymock.EasyMock;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -70,13 +73,18 @@ import io.confluent.connect.storage.partitioner.Partitioner;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
 import io.confluent.connect.storage.partitioner.TimestampExtractor;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 
+import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
 import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 
 public class TopicPartitionWriterTest extends TestWithMockedS3 {
   // The default
@@ -212,7 +220,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
   @Test
   public void testWriteRecordFieldPartitioner() throws Exception {
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "9");
+    localProps.put(FLUSH_SIZE_CONFIG, "9");
     setUp();
 
     // Define the partitioner
@@ -321,7 +329,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
   @Test
   public void testWriteRecordTimeBasedPartitionWallclockMocked() throws Exception {
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.HOURS.toMillis(1))
@@ -393,7 +401,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testWriteRecordTimeBasedPartitionRecordTimestampHours() throws Exception {
     // Do not roll on size, only based on time.
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.MINUTES.toMillis(1))
@@ -450,7 +458,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
   @Test
   public void testWriteRecordTimeBasedPartitionRecordTimestampDays() throws Exception {
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.MINUTES.toMillis(1))
@@ -538,7 +546,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
   @Test
   public void testWallclockUsesBatchTimePartitionBoundary() throws Exception {
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "6");
+    localProps.put(FLUSH_SIZE_CONFIG, "6");
     setUp();
 
     // Define the partitioner
@@ -580,7 +588,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testWriteRecordTimeBasedPartitionWallclockMockedWithScheduleRotation()
       throws Exception {
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.HOURS.toMillis(1))
@@ -658,7 +666,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
   @Test(expected = RetriableException.class)
   public void testPropagateRetriableErrorsDuringTimeBasedCommits() throws Exception {
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.HOURS.toMillis(1))
@@ -704,7 +712,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testWriteRecordTimeBasedPartitionFieldTimestampHours() throws Exception {
     // Do not roll on size, only based on time.
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.MINUTES.toMillis(1))
@@ -782,7 +790,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testNoFilesWrittenWithoutCommit() throws Exception {
     // Setting size-based rollup to 10 but will produce fewer records. Commit should not happen.
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "10");
+    localProps.put(FLUSH_SIZE_CONFIG, "10");
     setUp();
 
     // Define the partitioner
@@ -812,7 +820,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testRotateIntervalIsIgnoredWhenUsedWithNoTimeBasedPartitioner() throws Exception {
     // Setting size-based rollup to 10 but will produce fewer records. Commit should not happen.
-    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "10");
+    localProps.put(FLUSH_SIZE_CONFIG, "10");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.MINUTES.toMillis(1))
@@ -915,77 +923,99 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   }
 
   @Test
-  public void testExceptionOnNullKeys() {
+  public void testExceptionOnNullKeysReported() throws Exception {
     String recordValue = "1";
     int kafkaOffset = 1;
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null,
         Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
 
-    Exception thrownException = assertThrows(DataException.class, () -> writeRecordWithKeysAndHeaders(faultyRecord));
-    String expectedMessage = String.format("Key cannot be null for SinkRecord: %s", faultyRecord);
-    assertEquals(expectedMessage, thrownException.getMessage());
+    String exceptionMessage = String.format("Key cannot be null for SinkRecord: %s", faultyRecord.toString());
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false);
+    tearDown(); // clear mock S3 port for follow up test
+    // test with faulty being first in batch
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, true);
   }
 
   @Test
-  public void testExceptionOnEmptyHeaders() {
+  public void testExceptionOnEmptyHeadersReported() throws Exception{
     String recordValue = "1";
     int kafkaOffset = 1;
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
         Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, Collections.emptyList());
 
-    Exception thrownException = assertThrows(DataException.class, () -> writeRecordWithKeysAndHeaders(faultyRecord));
-    String expectedMessage = String.format("Headers cannot be null for SinkRecord: %s", faultyRecord);
-    assertEquals(expectedMessage, thrownException.getMessage());
+    String exceptionMessage = String.format("Headers cannot be null for SinkRecord: %s", faultyRecord.toString());
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false);
+    tearDown(); // clear mock S3 port for follow up test
+    // test with faulty being first in batch
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, true);
   }
 
   @Test
-  public void testExceptionOnNullHeaders() {
+  public void testExceptionOnNullHeadersReported() throws Exception {
     String recordValue = "1";
     int kafkaOffset = 1;
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
         Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, null);
 
-    Exception thrownException = assertThrows(DataException.class, () -> writeRecordWithKeysAndHeaders(faultyRecord));
-    String expectedMessage = String.format("Headers cannot be null for SinkRecord: %s", faultyRecord);
-    assertEquals(expectedMessage, thrownException.getMessage());
+    String exceptionMessage = String.format("Headers cannot be null for SinkRecord: %s", faultyRecord.toString());
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false);
+    tearDown(); // clear mock S3 port for follow up test
+    // test with faulty being first in batch
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, true);
   }
 
   @Test
-  public void testRecordKeysAnsHeadersWritten() throws Exception {
-    writeRecordWithKeysAndHeaders(null);
+  public void testSchemaProjectionExceptionReported() throws Exception {
+    String recordValue = "1";
+    int kafkaOffset = 1;
+    SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
+        null, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
+
+    String exceptionMessage = "Switch between schema-based and schema-less data is not supported";
+    testExceptionReportedToDLQ(faultyRecord, SchemaProjectorException.class, exceptionMessage, false);
   }
 
-  private void writeRecordWithKeysAndHeaders(SinkRecord faultyRecord) throws Exception {
+  // test DLQ for lower level exception coming from AvroData
+  @Test
+  public void testDataExceptionReportedIncorrectSchema() throws Exception {
+    String recordValue = "1";
+    int kafkaOffset = 1;
+    SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
+        Schema.BOOLEAN_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
+
+    String exceptionMessage = "Invalid type for BOOLEAN: class java.lang.String";
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false);
+    tearDown(); // clear mock S3 port for follow up test
+    // test with faulty being first in batch
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, true);
+  }
+
+  // test DLQ for lower level exception coming from AvroData
+  @Test
+  public void testDataExceptionReportedNullValueForNonOptionalSchema() throws Exception {
+    SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
+        Schema.STRING_SCHEMA, null, 1, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
+
+    String exceptionMessage = "Found null value for non-optional schema";
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false);
+    tearDown(); // clear mock S3 port for follow up test
+    // test with faulty being first in batch
+    testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, true);
+  }
+
+  @Test
+  public void testRecordKeysAndHeadersWritten() throws Exception {
     setUp();
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
 
-    // setup key record provider for writing record key files.
-    RecordWriterProvider<S3SinkConnectorConfig> keyWriterProvider =
-        new AvroFormat(storage).getRecordWriterProvider();
-    ((RecordViewSetter) keyWriterProvider).setRecordView(new KeyRecordView());
-    // setup header record provider for writing record header files.
-    RecordWriterProvider<S3SinkConnectorConfig> headerWriterProvider =
-        new AvroFormat(storage).getRecordWriterProvider();
-    ((RecordViewSetter) headerWriterProvider).setRecordView(new HeaderRecordView());
-    // initialize the KVHWriterProvider with header and key writers turned on.
-    RecordWriterProvider<S3SinkConnectorConfig> writerProvider = new KeyValueHeaderRecordWriterProvider(
-        new AvroFormat(storage).getRecordWriterProvider(),
-        keyWriterProvider,
-        headerWriterProvider
-    );
-
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+        TOPIC_PARTITION, storage, getKeyHeaderValueProvider(), partitioner,  connectorConfig, context, null);
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, 3, 3);
     List<SinkRecord> sinkRecords = createSinkRecordsWithHeaders(records, "key", schema);
-
-    if (faultyRecord != null) {
-      topicPartitionWriter.buffer(faultyRecord);
-    }
 
     for (SinkRecord record : sinkRecords) {
       topicPartitionWriter.buffer(record);
@@ -1014,6 +1044,98 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     expectedKeyFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 3, ".keys.avro", ZERO_PAD_FMT));
     expectedKeyFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 6, ".keys.avro", ZERO_PAD_FMT));
     verifyRecordElement(expectedKeyFiles, 3, sinkRecords, RecordElement.KEYS);
+  }
+
+  // Test if a given exception type was reported to the DLQ
+  private <T extends DataException> void testExceptionReportedToDLQ(
+      SinkRecord faultyRecord,
+      Class<T> exceptionType,
+      String exceptionMessage,
+      boolean faultyFirst
+  ) throws Exception {
+    setUp();
+    // Define the partitioner
+    Partitioner<?> partitioner = new DefaultPartitioner<>();
+    partitioner.configure(parsedConfig);
+
+    SinkTaskContext mockContext = mock(SinkTaskContext.class);
+    ErrantRecordReporter mockReporter = mock(ErrantRecordReporter.class);
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, getKeyHeaderValueProvider(), partitioner,  connectorConfig, mockContext, mockReporter);
+
+    // create sample records to write
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 3, 3);
+    List<SinkRecord> sinkRecords = createSinkRecordsWithHeaders(records, "key", schema);
+
+    // write a few valid records before the faulty one
+    // enables DLQ testing for mid-batch errors
+    if (!faultyFirst) {
+      topicPartitionWriter.buffer(sinkRecords.get(0));
+      topicPartitionWriter.buffer(sinkRecords.get(1));
+      // should throw exception and get reported
+      topicPartitionWriter.buffer(faultyRecord);
+      topicPartitionWriter.buffer(faultyRecord); // send second to verify file rotation as expected
+      // write rest of records
+      for (int i = 2; i < sinkRecords.size(); i++) {
+        topicPartitionWriter.buffer(sinkRecords.get(i));
+      }
+    } else {
+      topicPartitionWriter.buffer(faultyRecord);
+      topicPartitionWriter.buffer(faultyRecord); // send second to verify file rotation as expected
+      // write valid records
+      for (SinkRecord record : sinkRecords) {
+        topicPartitionWriter.buffer(record);
+      }
+    }
+
+    // Test actual write
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    // Verify exception was reported
+    ArgumentCaptor<T> exceptionCaptor = ArgumentCaptor.forClass(exceptionType);
+    Mockito.verify(mockReporter, times(2)).report(any(), exceptionCaptor.capture());
+    assertEquals(exceptionMessage, exceptionCaptor.getValue().getMessage());
+    StackTraceElement[] e = exceptionCaptor.getValue().getStackTrace();
+
+    String dirPrefix = partitioner.generatePartitionedPath(TOPIC, "partition=" + PARTITION);
+
+    List<String> expectedFiles = new ArrayList<>();
+    expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 0, extension, ZERO_PAD_FMT));
+    expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 3, extension, ZERO_PAD_FMT));
+    expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 6, extension, ZERO_PAD_FMT));
+    verifyRecordElement(expectedFiles, 3, sinkRecords, RecordElement.VALUES);
+
+    List<String> expectedHeaderFiles = new ArrayList<>();
+    expectedHeaderFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 0, ".headers.avro", ZERO_PAD_FMT));
+    expectedHeaderFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 3, ".headers.avro", ZERO_PAD_FMT));
+    expectedHeaderFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 6, ".headers.avro", ZERO_PAD_FMT));
+    verifyRecordElement(expectedHeaderFiles, 3, sinkRecords, RecordElement.HEADERS);
+
+    List<String> expectedKeyFiles = new ArrayList<>();
+    expectedKeyFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 0, ".keys.avro", ZERO_PAD_FMT));
+    expectedKeyFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 3, ".keys.avro", ZERO_PAD_FMT));
+    expectedKeyFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 6, ".keys.avro", ZERO_PAD_FMT));
+    verifyRecordElement(expectedKeyFiles, 3, sinkRecords, RecordElement.KEYS);
+  }
+
+  private RecordWriterProvider<S3SinkConnectorConfig> getKeyHeaderValueProvider() {
+    // setup key record provider for writing record key files.
+    RecordWriterProvider<S3SinkConnectorConfig> keyWriterProvider =
+        new AvroFormat(storage).getRecordWriterProvider();
+    ((RecordViewSetter) keyWriterProvider).setRecordView(new KeyRecordView());
+    // setup header record provider for writing record header files.
+    RecordWriterProvider<S3SinkConnectorConfig> headerWriterProvider =
+        new AvroFormat(storage).getRecordWriterProvider();
+    ((RecordViewSetter) headerWriterProvider).setRecordView(new HeaderRecordView());
+    // initialize the KVHWriterProvider with header and key writers turned on.
+    return new KeyValueHeaderRecordWriterProvider(
+        new AvroFormat(storage).getRecordWriterProvider(),
+        keyWriterProvider,
+        headerWriterProvider
+    );
   }
 
   private Struct createRecord(Schema schema, int ibase, float fbase) {
@@ -1138,7 +1260,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
     Collections.sort(actualFiles);
     Collections.sort(expectedFileKeys);
-    assertEquals(actualFiles, expectedFileKeys);
+    assertEquals(expectedFileKeys, actualFiles);
 
     int index = 0;
     for (String fileKey : actualFiles) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -153,7 +153,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -186,7 +186,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -220,7 +220,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -277,7 +277,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -335,7 +335,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
         PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockedWallclockTimestampExtractor.class.getName());
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -407,7 +407,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -464,7 +464,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -521,7 +521,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -552,7 +552,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Time systemTime = EasyMock.createMock(SystemTime.class);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, systemTime);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, systemTime, null);
 
     // Freeze clock passed into topicPartitionWriter, so we know what time it will use for "now"
     long freezeTime = 3599000L;
@@ -603,7 +603,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Bring the clock to present.
     time.sleep(SYSTEM.milliseconds());
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -681,7 +681,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Bring the clock to present.
     time.sleep(SYSTEM.milliseconds());
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -717,7 +717,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchemaWithTimestampField();
@@ -789,7 +789,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -823,7 +823,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -852,7 +852,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -886,7 +886,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
+            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -977,7 +977,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     );
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, 3, 3);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -1098,7 +1098,6 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     ArgumentCaptor<T> exceptionCaptor = ArgumentCaptor.forClass(exceptionType);
     Mockito.verify(mockReporter, times(2)).report(any(), exceptionCaptor.capture());
     assertEquals(exceptionMessage, exceptionCaptor.getValue().getMessage());
-    StackTraceElement[] e = exceptionCaptor.getValue().getStackTrace();
 
     String dirPrefix = partitioner.generatePartitionedPath(TOPIC, "partition=" + PARTITION);
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -939,7 +939,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testExceptionOnEmptyHeadersReported() throws Exception{
     String recordValue = "1";
-    int kafkaOffset = 1;
+    int kafkaOffset = 2;
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
         Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, Collections.emptyList());
 
@@ -978,12 +978,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   // test DLQ for lower level exception coming from AvroData
   @Test
   public void testDataExceptionReportedIncorrectSchema() throws Exception {
-    String recordValue = "1";
+    Schema sampleValueSchema = createSchema();
     int kafkaOffset = 1;
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
-        Schema.BOOLEAN_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
+        sampleValueSchema, "1", kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
 
-    String exceptionMessage = "Invalid type for BOOLEAN: class java.lang.String";
+    String exceptionMessage = "Invalid type for STRUCT: class java.lang.String";
     testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false);
     tearDown(); // clear mock S3 port for follow up test
     // test with faulty being first in batch
@@ -1078,7 +1078,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
       topicPartitionWriter.buffer(faultyRecord);
       topicPartitionWriter.buffer(faultyRecord); // send second to verify file rotation as expected
       // write rest of records
-      for (int i = 4; i < sinkRecords.size(); i++) {
+      for (int i = 2; i < sinkRecords.size(); i++) {
         topicPartitionWriter.buffer(sinkRecords.get(i));
       }
     } else {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -42,7 +42,7 @@ public abstract class BaseConnectorIT {
 
   protected static final int MAX_TASKS = 3;
   private static final long CONNECTOR_STARTUP_DURATION_MS = TimeUnit.MINUTES.toMillis(1);
-  private static final long S3_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(30);
+  private static final long S3_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(60);
 
   protected static AmazonS3 S3Client;
   protected static final String TEST_BUCKET_NAME =

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -321,9 +321,11 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
   private void produceRecordsNoHeaders(int recordCount, SinkRecord record) {
     // Send records to Kafka
     for (long i = 0; i < recordCount; i++) {
+      byte[] key = jsonConverter.fromConnectData(record.topic(), Schema.STRING_SCHEMA, record.key());
       byte[] value = jsonConverter.fromConnectData(record.topic(), record.valueSchema(), record.value());
+      String kafkaKey = new String(value, UTF_8);
       String kafkaValue = new String(value, UTF_8);
-      connect.kafka().produce(TEST_TOPIC_NAME, null, kafkaValue);
+      connect.kafka().produce(TEST_TOPIC_NAME, kafkaKey, kafkaValue);
     }
   }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -105,6 +105,10 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
   private static final String AVRO_EXTENSION = "avro";
   private static final String PARQUET_EXTENSION = "snappy.parquet";
   private static final String JSON_EXTENSION = "json";
+  // DLQ Tests
+  private static final String DLQ_TOPIC_CONFIG = "errors.deadletterqueue.topic.name";
+  private static final String DLQ_TOPIC_NAME = "DLQ-topic";
+
   private static final List<String> KAFKA_TOPICS = Collections.singletonList(TEST_TOPIC_NAME);
   private static final long NUM_RECORDS_INSERT = 20;
   private static final int FLUSH_SIZE_STANDARD = 3;
@@ -210,6 +214,47 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
     assertTrue(fileNamesValid(TEST_BUCKET_NAME, expectedFilenames));
     assertTrue(fileContentsAsExpected(TEST_BUCKET_NAME, FLUSH_SIZE_STANDARD, recordValueStruct));
   }
+
+//  @Test
+//  public void testFaultyRecordReportedToDLQ() throws Throwable {
+//    props.put(DLQ_TOPIC_CONFIG, DLQ_TOPIC_NAME);
+//
+//    // start sink connector
+//    connect.configureConnector(CONNECTOR_NAME, props);
+//    // wait for tasks to spin up
+//    waitForConnectorToStart(CONNECTOR_NAME, Math.min(KAFKA_TOPICS.size(), MAX_TASKS));
+//
+//    Schema recordValueSchema = getSampleStructSchema();
+//    Struct recordValueStruct = getSampleStructVal(recordValueSchema);
+//    // Send first batch of valid records to Kafka
+//    for (long i = 0; i < NUM_RECORDS_INSERT; i++) {
+//      SinkRecord record = getSampleRecordWithOffset(recordValueSchema, recordValueStruct, i);
+//      String kafkaValue = new String(formatter.formatValue(record), UTF_8);
+//      connect.kafka().produce(TEST_TOPIC_NAME, null, kafkaValue);
+//    }
+//    long currentOffset = NUM_RECORDS_INSERT - 1;
+//
+//    // send two faulty records
+//    getSampleRecordWithOffset(Schema.STRING_SCHEMA, null, ++currentOffset);
+//    getSampleRecordWithOffset(Schema.STRING_SCHEMA, null, ++currentOffset);
+//
+//    currentOffset++;
+//    // Send second batch of valid records to Kafka
+//    for (long i = currentOffset; i < currentOffset + NUM_RECORDS_INSERT; i++) {
+//      SinkRecord record = getSampleRecordWithOffset(recordValueSchema, recordValueStruct, i);
+//      String kafkaValue = new String(formatter.formatValue(record), UTF_8);
+//      connect.kafka().produce(TEST_TOPIC_NAME, null, kafkaValue);
+//    }
+//
+//    log.info("Waiting for files in S3...");
+//    int expectedFileCount = (int) (NUM_RECORDS_INSERT * 2) / FLUSH_SIZE_STANDARD;
+//    waitForFilesInBucket(TEST_BUCKET_NAME, expectedFileCount);
+//
+//    List<String> expectedFilenames = getExpectedFilenames(TEST_TOPIC_NAME, EXPECTED_PARTITION,
+//        FLUSH_SIZE_STANDARD, NUM_RECORDS_INSERT * 2, AVRO_EXTENSION);
+//    assertTrue(fileNamesValid(TEST_BUCKET_NAME, expectedFilenames));
+//    assertTrue(fileContentsAsExpected(TEST_BUCKET_NAME, FLUSH_SIZE_STANDARD, recordValueStruct));
+//  }
 
   private SinkRecord getSampleRecordWithOffset(
       Schema recordValueSchema,

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
@@ -11,7 +11,6 @@ import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.services.s3.AmazonS3;
 import io.confluent.connect.s3.S3SinkConnectorTestBase;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.RetriableException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,12 +41,12 @@ public class S3OutputStreamTest extends S3SinkConnectorTestBase {
     e.setErrorType(ErrorType.Service);
 
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
-    assertThrows("Multipart upload failed to complete.", RetriableException.class, () -> stream.commit());
+    assertThrows("Multipart upload failed to complete.", ConnectException.class, () -> stream.commit());
   }
 
   @Test
   public void testPropagateOtherRetriableS3Exceptions() {
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(new AmazonClientException("this is an other s3 exception"));
-    assertThrows("Multipart upload failed to complete.", RetriableException.class, () -> stream.commit());
+    assertThrows("Multipart upload failed to complete.", ConnectException.class, () -> stream.commit());
   }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
@@ -11,7 +11,7 @@ import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.services.s3.AmazonS3;
 import io.confluent.connect.s3.S3SinkConnectorTestBase;
 import org.apache.kafka.connect.errors.ConnectException;
-import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -42,12 +42,12 @@ public class S3OutputStreamTest extends S3SinkConnectorTestBase {
     e.setErrorType(ErrorType.Service);
 
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
-    assertThrows("Multipart upload failed to complete.", DataException.class, () -> stream.commit());
+    assertThrows("Multipart upload failed to complete.", RetriableException.class, () -> stream.commit());
   }
 
   @Test
   public void testPropagateOtherRetriableS3Exceptions() {
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(new AmazonClientException("this is an other s3 exception"));
-    assertThrows("Multipart upload failed to complete.", DataException.class, () -> stream.commit());
+    assertThrows("Multipart upload failed to complete.", RetriableException.class, () -> stream.commit());
   }
 }


### PR DESCRIPTION
## Problem
The S3 Sink connector currently does not report faulty records to the DLQ. Having this functionality provides more information on failed records and is useful for debugging and monitoring purposes.

## Solution
Add the `ErrantRecordReporter` introduced by [KIP-610](https://cwiki.apache.org/confluence/display/KAFKA/KIP-610%3A+Error+Reporting+in+Sink+Connectors) that writes failed records and their errors to the specified DLQ topic. The topic name can be specified by `errors.deadletterqueue.topic.name`.

### Writes to DLQ in the following cases
1. Record value is `null` and `behavior.on.null.values` is `IGNORE`. (S3SinkTask)
2. The record was determined to be malformed on attempting write. (TopicPartitionWriter)
3. The record key is `null` but `write.record.keys` is turned on.
4. The record headers are `null` but `write.record.headers` is turned on. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
In storage sink connectors that don't yet implement this functionality. 

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
`master` for this new feature, and due to `ErrantRecordReporter` dependency. 