### PR TITLE
CC-11480: Add configuration property to choose between path style and virtual hosted bucket access to S3

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -151,6 +151,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String S3_RETRY_BACKOFF_CONFIG = "s3.retry.backoff.ms";
   public static final int S3_RETRY_BACKOFF_DEFAULT = 200;
 
+  public static final String S3_PATH_STYLE_ACCESS_ENABLED_CONFIG = "s3.path.style.access.enabled";
+  public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = false;
+
   private final String name;
 
   private final StorageCommonConfig commonConfig;
@@ -511,6 +514,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           "Behavior for null-valued records"
       );
 
+      configDef.define(
+          S3_PATH_STYLE_ACCESS_ENABLED_CONFIG,
+          Type.BOOLEAN,
+          S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT,
+          Importance.LOW,
+          "Specifies whether or not to enable path style access to the bucket used by the "
+              + "connector",
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          "Enable Path Style Access to S3"
+      );
     }
     return configDef;
   }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -152,7 +152,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final int S3_RETRY_BACKOFF_DEFAULT = 200;
 
   public static final String S3_PATH_STYLE_ACCESS_ENABLED_CONFIG = "s3.path.style.access.enabled";
-  public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = false;
+  public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = true;
 
   private final String name;
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -37,6 +37,7 @@ import io.confluent.connect.storage.Storage;
 import io.confluent.connect.storage.common.util.StringUtils;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.REGION_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PROXY_URL_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_RETRY_BACKOFF_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_RETRY_MAX_BACKOFF_TIME_MS;
@@ -79,7 +80,9 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
                                         .withAccelerateModeEnabled(
                                             config.getBoolean(WAN_MODE_CONFIG)
                                         )
-                                        .withPathStyleAccessEnabled(true)
+                                        .withPathStyleAccessEnabled(
+                                            config.getBoolean(S3_PATH_STYLE_ACCESS_ENABLED_CONFIG)
+                                        )
                                         .withCredentials(config.getCredentialsProvider())
                                         .withClientConfiguration(clientConfiguration);
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -169,7 +169,7 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
   }
 
   public boolean bucketExists() {
-    return StringUtils.isNotBlank(bucketName) && s3.doesBucketExist(bucketName);
+    return StringUtils.isNotBlank(bucketName) && s3.doesBucketExistV2(bucketName);
   }
 
   @Override

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorTestBase.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorTestBase.java
@@ -72,6 +72,7 @@ public class S3SinkConnectorTestBase extends StorageSinkTestBase {
     props.put(StorageCommonConfig.STORAGE_CLASS_CONFIG, "io.confluent.connect.s3.storage.S3Storage");
     props.put(S3SinkConnectorConfig.S3_BUCKET_CONFIG, S3_TEST_BUCKET_NAME);
     props.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
+    props.put(S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG, "false");
     props.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, PartitionerConfig.PARTITIONER_CLASS_DEFAULT.getName());
     props.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "int");
     props.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'year'=YYYY_'month'=MM_'day'=dd_'hour'=HH");
@@ -100,7 +101,7 @@ public class S3SinkConnectorTestBase extends StorageSinkTestBase {
   public AmazonS3 newS3Client(S3SinkConnectorConfig config) {
     AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
                .withAccelerateModeEnabled(config.getBoolean(S3SinkConnectorConfig.WAN_MODE_CONFIG))
-               .withPathStyleAccessEnabled(true)
+               .withPathStyleAccessEnabled(config.getBoolean(S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG))
                .withCredentials(new DefaultAWSCredentialsProviderChain());
 
     builder = url == null ?

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
@@ -181,7 +181,7 @@ public class TestWithMockedS3 extends S3SinkConnectorTestBase {
 
     AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
                .withAccelerateModeEnabled(config.getBoolean(S3SinkConnectorConfig.WAN_MODE_CONFIG))
-               .withPathStyleAccessEnabled(true)
+               .withPathStyleAccessEnabled(config.getBoolean(S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG))
                .withCredentials(provider);
 
     builder = url == null ?


### PR DESCRIPTION
## Problem
The connector since the beginning has been explicitly choosing to use path style access for S3 buckets in its requests. This access type is being deprecated and removed in Sept 30, 2020 for _new_ buckets on S3 that are created after that date. 

Addresses issue: https://github.com/confluentinc/kafka-connect-storage-cloud/issues/337

## Solution
A configuration property `s3.path.style.access.enabled` is introduced to control the behavior. The behavior is matching the current existing behavior and will be backported to previous connector versions. A new connector version will be generated in a follow up that will have virtual hosted access as the default. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
S3 source connector

## Test Strategy
End to end tests with buckets in several regions and testing with and without setting `store.url`. 


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [x] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
See above