### PR TITLE
CC-11480: Add configuration property to choose between path style and virtual hosted bucket access to S3 (back port to 5.0.x)

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -144,6 +144,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String S3_RETRY_BACKOFF_CONFIG = "s3.retry.backoff.ms";
   public static final int S3_RETRY_BACKOFF_DEFAULT = 200;
 
+  public static final String S3_PATH_STYLE_ACCESS_ENABLED_CONFIG = "s3.path.style.access.enabled";
+  public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = false;
+
   private final String name;
 
   private final StorageCommonConfig commonConfig;
@@ -470,6 +473,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           "S3 HTTP Send Uses Expect Continue"
       );
 
+      configDef.define(
+          S3_PATH_STYLE_ACCESS_ENABLED_CONFIG,
+          Type.BOOLEAN,
+          S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT,
+          Importance.LOW,
+          "Specifies whether or not to enable path style access to the bucket used by the "
+              + "connector",
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          "Enable Path Style Access to S3"
+      );
     }
     return configDef;
   }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -145,7 +145,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final int S3_RETRY_BACKOFF_DEFAULT = 200;
 
   public static final String S3_PATH_STYLE_ACCESS_ENABLED_CONFIG = "s3.path.style.access.enabled";
-  public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = false;
+  public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = true;
 
   private final String name;
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -37,6 +37,7 @@ import io.confluent.connect.storage.Storage;
 import io.confluent.connect.storage.common.util.StringUtils;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.REGION_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PROXY_URL_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_RETRY_BACKOFF_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_RETRY_MAX_BACKOFF_TIME_MS;
@@ -79,7 +80,9 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
                                         .withAccelerateModeEnabled(
                                             config.getBoolean(WAN_MODE_CONFIG)
                                         )
-                                        .withPathStyleAccessEnabled(true)
+                                        .withPathStyleAccessEnabled(
+                                            config.getBoolean(S3_PATH_STYLE_ACCESS_ENABLED_CONFIG)
+                                        )
                                         .withCredentials(config.getCredentialsProvider())
                                         .withClientConfiguration(clientConfiguration);
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -169,7 +169,7 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
   }
 
   public boolean bucketExists() {
-    return StringUtils.isNotBlank(bucketName) && s3.doesBucketExist(bucketName);
+    return StringUtils.isNotBlank(bucketName) && s3.doesBucketExistV2(bucketName);
   }
 
   @Override

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorTestBase.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorTestBase.java
@@ -74,6 +74,7 @@ public class S3SinkConnectorTestBase extends StorageSinkTestBase {
     props.put(StorageCommonConfig.STORAGE_CLASS_CONFIG, "io.confluent.connect.s3.storage.S3Storage");
     props.put(S3SinkConnectorConfig.S3_BUCKET_CONFIG, S3_TEST_BUCKET_NAME);
     props.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
+    props.put(S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG, "false");
     props.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, PartitionerConfig.PARTITIONER_CLASS_DEFAULT.getName());
     props.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "int");
     props.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'year'=YYYY_'month'=MM_'day'=dd_'hour'=HH");
@@ -104,7 +105,7 @@ public class S3SinkConnectorTestBase extends StorageSinkTestBase {
   public AmazonS3 newS3Client(S3SinkConnectorConfig config) {
     AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
                .withAccelerateModeEnabled(config.getBoolean(S3SinkConnectorConfig.WAN_MODE_CONFIG))
-               .withPathStyleAccessEnabled(true)
+               .withPathStyleAccessEnabled(config.getBoolean(S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG))
                .withCredentials(new DefaultAWSCredentialsProviderChain());
 
     builder = url == null ?

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
@@ -173,7 +173,7 @@ public class TestWithMockedS3 extends S3SinkConnectorTestBase {
 
     AmazonS3ClientBuilder builder = AmazonS3ClientBuilder.standard()
                .withAccelerateModeEnabled(config.getBoolean(S3SinkConnectorConfig.WAN_MODE_CONFIG))
-               .withPathStyleAccessEnabled(true)
+               .withPathStyleAccessEnabled(config.getBoolean(S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG))
                .withCredentials(provider);
 
     builder = url == null ?


### PR DESCRIPTION
## Problem
Back port of https://github.com/confluentinc/kafka-connect-storage-cloud/pull/356 

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
