### PR TITLE
S3 path rename

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-cloud</artifactId>
-        <version>10.1.0-SNAPSHOT</version>
+        <version>5.5.1</version>
     </parent>
 
     <artifactId>kafka-connect-s3</artifactId>

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -476,7 +476,7 @@ public class TopicPartitionWriter {
                       + fileDelim
                       + String.format(zeroPadOffsetFormat, startOffset)
                       + extension;
-    return fileKey(topicsDir, dirPrefix, name);
+    return fileKey(topicsDir, '', name);
   }
 
   private void writeRecord(SinkRecord record) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -455,7 +455,8 @@ public class TopicPartitionWriter {
       commitFile = commitFiles.get(encodedPartition);
     } else {
       long startOffset = startOffsets.get(encodedPartition);
-      String prefix = getDirectoryPrefix(encodedPartition);
+      // String prefix = getDirectoryPrefix(encodedPartition);
+      String prefix = "";
       commitFile = fileKeyToCommit(prefix, startOffset);
       commitFiles.put(encodedPartition, commitFile);
     }
@@ -476,7 +477,7 @@ public class TopicPartitionWriter {
                       + fileDelim
                       + String.format(zeroPadOffsetFormat, startOffset)
                       + extension;
-    return fileKey(topicsDir, '', name);
+    return fileKey(topicsDir, dirPrefix, name);
   }
 
   private void writeRecord(SinkRecord record) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -455,29 +455,27 @@ public class TopicPartitionWriter {
       commitFile = commitFiles.get(encodedPartition);
     } else {
       long startOffset = startOffsets.get(encodedPartition);
-      // String prefix = getDirectoryPrefix(encodedPartition);
-      String prefix = "";
-      commitFile = fileKeyToCommit(prefix, startOffset);
+      commitFile = fileKeyToCommit(startOffset);
       commitFiles.put(encodedPartition, commitFile);
     }
     return commitFile;
   }
 
-  private String fileKey(String topicsPrefix, String keyPrefix, String name) {
-    String suffix = keyPrefix + dirDelim + name;
+  private String fileKey(String topicsPrefix, String name) {
+    String suffix =  dirDelim + name;
     return StringUtils.isNotBlank(topicsPrefix)
            ? topicsPrefix + dirDelim + suffix
            : suffix;
   }
 
-  private String fileKeyToCommit(String dirPrefix, long startOffset) {
+  private String fileKeyToCommit(long startOffset) {
     String name = tp.topic()
                       + fileDelim
                       + tp.partition()
                       + fileDelim
                       + String.format(zeroPadOffsetFormat, startOffset)
                       + extension;
-    return fileKey(topicsDir, dirPrefix, name);
+    return fileKey(topicsDir, name);
   }
 
   private void writeRecord(SinkRecord record) {

--- a/pom.xml
+++ b/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>5.5.1</version>
     </parent>
 
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-storage-cloud</artifactId>
     <packaging>pom</packaging>
-    <version>10.1.0-SNAPSHOT</version>
+    <version>5.5.1</version>
     <name>kafka-connect-storage-cloud</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -68,7 +68,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>http://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 
@@ -143,12 +143,6 @@
                     <artifactId>log4j</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
-            <version>${confluent-log4j.version}</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
## Problem
Getting a too long directory path when files getting written to s3 storage.

## Solution
Removed basic directory prefix from the S3 key.
