### PR TITLE
CC-12695: stop throwing retriable exceptions on non-retriable S3 errors

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -21,7 +21,6 @@ import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.IllegalWorkerStateException;
-import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.errors.SchemaProjectorException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -490,13 +489,9 @@ public class TopicPartitionWriter {
 
   private void commitFiles() {
     currentStartOffset = minStartOffset();
-    try {
-      for (Map.Entry<String, String> entry : commitFiles.entrySet()) {
-        commitFile(entry.getKey());
-        log.debug("Committed {} for {}", entry.getValue(), tp);
-      }
-    } catch (ConnectException e) {
-      throw new RetriableException(e);
+    for (Map.Entry<String, String> entry : commitFiles.entrySet()) {
+      commitFile(entry.getKey());
+      log.debug("Committed {} for {}", entry.getValue(), tp);
     }
 
     offsetToCommit = currentOffset + 1;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -21,6 +21,7 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +98,7 @@ public class AvroRecordWriterProvider implements RecordWriterProvider<S3SinkConn
           s3out.commit();
           writer.close();
         } catch (IOException e) {
-          throw new ConnectException(e);
+          throw new RetriableException(e);
         }
       }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -24,6 +24,7 @@ import io.confluent.connect.storage.format.RecordWriterProvider;
 import org.apache.kafka.connect.converters.ByteArrayConverter;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -79,7 +80,7 @@ public class ByteArrayRecordWriterProvider implements RecordWriterProvider<S3Sin
           s3out.commit();
           s3outWrapper.close();
         } catch (IOException e) {
-          throw new ConnectException(e);
+          throw new RetriableException(e);
         }
       }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
@@ -98,7 +99,7 @@ public class JsonRecordWriterProvider implements RecordWriterProvider<S3SinkConn
             s3out.commit();
             s3outWrapper.close();
           } catch (IOException e) {
-            throw new ConnectException(e);
+            throw new RetriableException(e);
           }
         }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -215,7 +215,6 @@ public class S3OutputStream extends OutputStream {
         // Therefore, the connector should propagate this exception and fail.
         throw new ConnectException("Unable to initiate MultipartUpload", e);
       }
-
       throw new IOException("Unable to initiate MultipartUpload.", e);
     } catch (SdkClientException e) {
       throw new IOException("Unable to initiate MultipartUpload.", e);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -16,9 +16,9 @@
 
 package io.confluent.connect.s3.storage;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
-import com.amazonaws.SdkClientException;
 import com.amazonaws.event.ProgressEvent;
 import com.amazonaws.event.ProgressListener;
 import com.amazonaws.services.s3.AmazonS3;
@@ -216,7 +216,7 @@ public class S3OutputStream extends OutputStream {
         throw new ConnectException("Unable to initiate MultipartUpload", e);
       }
       throw new IOException("Unable to initiate MultipartUpload.", e);
-    } catch (SdkClientException e) {
+    } catch (AmazonClientException e) {
       throw new IOException("Unable to initiate MultipartUpload.", e);
     }
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -72,9 +72,9 @@ import static io.confluent.connect.avro.AvroData.AVRO_TYPE_ENUM;
 import static io.confluent.connect.avro.AvroData.CONNECT_ENUM_DOC_PROP;
 import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DataWriterAvroTest extends TestWithMockedS3 {
@@ -109,7 +109,7 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
     format = new AvroFormat(storage);
 
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
   }
 
   //@Before should be omitted in order to be able to add properties per test.
@@ -132,7 +132,7 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
     format = new AvroFormat(storage);
 
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
   }
 
   @After
@@ -924,7 +924,7 @@ public class DataWriterAvroTest extends TestWithMockedS3 {
     verifyFileListing(expectedFiles);
   }
 
-  protected void verifyFileListing(List<String> expectedFiles) throws IOException {
+  protected void verifyFileListing(List<String> expectedFiles) {
     List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
     List<String> actualFiles = new ArrayList<>();
     for (S3ObjectSummary summary : summaries) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
@@ -44,8 +44,8 @@ import java.util.Set;
 import java.util.zip.Deflater;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DataWriterByteArrayTest extends TestWithMockedS3 {
@@ -79,7 +79,7 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
     format = new ByteArrayFormat(storage);
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
   }
 
   @After
@@ -195,7 +195,7 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
   }
 
   protected String getDirectory(String topic, int partition) {
-    String encodedPartition = "partition=" + String.valueOf(partition);
+    String encodedPartition = "partition=" + partition;
     return partitioner.generatePartitionedPath(topic, encodedPartition);
   }
 
@@ -209,7 +209,7 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
     return expectedFiles;
   }
 
-  protected void verifyFileListing(long[] validOffsets, Set<TopicPartition> partitions, String extension) throws IOException {
+  protected void verifyFileListing(long[] validOffsets, Set<TopicPartition> partitions, String extension) {
     List<String> expectedFiles = new ArrayList<>();
     for (TopicPartition tp : partitions) {
       expectedFiles.addAll(getExpectedFiles(validOffsets, tp, extension));
@@ -217,7 +217,7 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
     verifyFileListing(expectedFiles);
   }
 
-  protected void verifyFileListing(List<String> expectedFiles) throws IOException {
+  protected void verifyFileListing(List<String> expectedFiles) {
     List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
     List<String> actualFiles = new ArrayList<>();
     for (S3ObjectSummary summary : summaries) {
@@ -230,8 +230,7 @@ public class DataWriterByteArrayTest extends TestWithMockedS3 {
     assertThat(actualFiles, is(expectedFiles));
   }
 
-  protected void verifyContents(List<SinkRecord> expectedRecords, int startIndex, Collection<Object> records)
-      throws IOException{
+  protected void verifyContents(List<SinkRecord> expectedRecords, int startIndex, Collection<Object> records) {
     for (Object record : records) {
       byte[] bytes = (byte[]) record;
       SinkRecord expectedRecord = expectedRecords.get(startIndex++);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
@@ -46,8 +46,8 @@ import io.confluent.connect.storage.partitioner.DefaultPartitioner;
 import io.confluent.connect.storage.partitioner.Partitioner;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 public class DataWriterJsonTest extends TestWithMockedS3 {
@@ -83,7 +83,7 @@ public class DataWriterJsonTest extends TestWithMockedS3 {
     partitioner.configure(parsedConfig);
     format = new JsonFormat(storage);
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
   }
 
   @After

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -24,15 +24,12 @@ import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider;
@@ -51,15 +48,13 @@ import io.confluent.connect.avro.AvroDataConfig;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
 public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
 
   protected Map<String, String> localProps = new HashMap<>();
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   @Before
   @Override
@@ -266,10 +261,6 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
 
   @Test
   public void testConfigurableCredentialProviderMissingConfigs() {
-
-    thrown.expect(ConfigException.class);
-    thrown.expectMessage("are mandatory configuration properties");
-
     String configPrefix = S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CONFIG_PREFIX;
     properties.put(
         S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
@@ -281,14 +272,11 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     );
 
     connectorConfig = new S3SinkConnectorConfig(properties);
-    connectorConfig.getCredentialsProvider();
+    assertThrows("are mandatory configuration properties", ConfigException.class, () -> connectorConfig.getCredentialsProvider());
   }
 
   @Test
   public void testConfigurableAwsAssumeRoleCredentialsProviderMissingConfigs() {
-    thrown.expect(ConfigException.class);
-    thrown.expectMessage("Missing required configuration");
-
     properties.put(
         S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
         AwsAssumeRoleCredentialsProvider.class.getName()
@@ -311,7 +299,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     AwsAssumeRoleCredentialsProvider credentialsProvider =
         (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider();
 
-    credentialsProvider.configure(properties);
+    assertThrows("Missing required configuration", ConfigException.class, () -> credentialsProvider.configure(properties));
   }
 
   private void assertDefaultPartitionerVisibility(List<ConfigValue> values) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
@@ -16,7 +16,6 @@
 
 package io.confluent.connect.s3;
 
-import akka.parboiled2.RuleTrace;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AnonymousAWSCredentials;
@@ -28,7 +27,7 @@ import com.amazonaws.services.s3.model.ObjectListing;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.findify.s3mock.S3Mock;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.RetriableException;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
@@ -195,7 +194,7 @@ public class TestWithMockedS3 extends S3SinkConnectorTestBase {
     public void commit() throws IOException {
       if (retries.getAndIncrement() == 0) {
         close();
-        throw new ConnectException("Fake exception");
+        throw new RetriableException("Fake exception");
       }
       super.commit();
     }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -64,8 +64,8 @@ import io.confluent.connect.storage.partitioner.TimestampExtractor;
 
 import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 public class TopicPartitionWriterTest extends TestWithMockedS3 {
   // The default
@@ -638,7 +638,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   }
 
   @Test(expected = RetriableException.class)
-  public void testPropagateErrorsDuringTimeBasedCommits() throws Exception {
+  public void testPropagateRetriableErrorsDuringTimeBasedCommits() throws Exception {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
@@ -5,9 +5,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
-import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import io.confluent.connect.s3.S3SinkConnectorTestBase;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -47,7 +47,7 @@ public class S3OutputStreamTest extends S3SinkConnectorTestBase {
 
   @Test
   public void testPropagateOtherRetriableS3Exceptions() {
-    when(s3Mock.initiateMultipartUpload(any())).thenThrow(new SdkClientException("this is an other s3 exception"));
+    when(s3Mock.initiateMultipartUpload(any())).thenThrow(new AmazonClientException("this is an other s3 exception"));
     assertThrows("Multipart upload failed to complete.", DataException.class, () -> stream.commit());
   }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
@@ -1,0 +1,53 @@
+package io.confluent.connect.s3.storage;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.AmazonServiceException.ErrorType;
+import com.amazonaws.SdkClientException;
+import com.amazonaws.services.s3.AmazonS3;
+import io.confluent.connect.s3.S3SinkConnectorTestBase;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.junit.Before;
+import org.junit.Test;
+
+public class S3OutputStreamTest extends S3SinkConnectorTestBase {
+
+  private AmazonS3 s3Mock;
+  private S3OutputStream stream;
+
+  @Before
+  public void before() throws Exception {
+    super.setUp();
+    s3Mock = mock(AmazonS3.class);
+    stream = new S3OutputStream("key", connectorConfig, s3Mock);
+  }
+
+  @Test
+  public void testPropagateUnretriableS3Exceptions() {
+    AmazonServiceException e = new AmazonServiceException("this is an s3 exception");
+    e.setErrorType(ErrorType.Client);
+
+    when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
+    assertThrows("Unable to initiate Multipart Upload.", ConnectException.class, () -> stream.commit());
+  }
+
+  @Test
+  public void testPropagateRetriableS3Exceptions() {
+    AmazonServiceException e = new AmazonServiceException("this is an s3 exception");
+    e.setErrorType(ErrorType.Service);
+
+    when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
+    assertThrows("Multipart upload failed to complete.", DataException.class, () -> stream.commit());
+  }
+
+  @Test
+  public void testPropagateOtherRetriableS3Exceptions() {
+    when(s3Mock.initiateMultipartUpload(any())).thenThrow(new SdkClientException("this is an other s3 exception"));
+    assertThrows("Multipart upload failed to complete.", DataException.class, () -> stream.commit());
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3ProxyTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3ProxyTest.java
@@ -22,10 +22,7 @@ import com.amazonaws.services.s3.AmazonS3;
 import org.apache.kafka.common.config.ConfigException;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-import org.mockito.ArgumentMatchers;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -34,11 +31,9 @@ import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.S3SinkConnectorTestBase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class S3ProxyTest extends S3SinkConnectorTestBase {
-
-  @Rule
-  public ExpectedException thrown = ExpectedException.none();
 
   protected S3Storage storage;
   protected AmazonS3 s3;
@@ -80,18 +75,14 @@ public class S3ProxyTest extends S3SinkConnectorTestBase {
   public void testNoProtocolThrowsException() throws Exception {
     localProps.put(S3SinkConnectorConfig.S3_PROXY_URL_CONFIG, "localhost");
     setUp();
-    thrown.expect(ConfigException.class);
-    thrown.expectMessage(ArgumentMatchers.contains("no protocol: localhost"));
-    clientConfig = storage.newClientConfiguration(connectorConfig);
+    assertThrows("no protocol: localhost", ConfigException.class, () -> storage.newClientConfiguration(connectorConfig));
   }
 
   @Test
   public void testUnknownProtocolThrowsException() throws Exception {
     localProps.put(S3SinkConnectorConfig.S3_PROXY_URL_CONFIG, "unknown://localhost");
     setUp();
-    thrown.expect(ConfigException.class);
-    thrown.expectMessage(ArgumentMatchers.contains("unknown protocol: localhost"));
-    clientConfig = storage.newClientConfiguration(connectorConfig);
+    assertThrows("unknown protocol: localhost", ConfigException.class, () -> storage.newClientConfiguration(connectorConfig));
   }
 
   @Test


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
the connector will retry non-retriable S3 exceptions i.e `InvalidAccessKey`

if [initiating an upload](https://github.com/confluentinc/kafka-connect-storage-cloud/blob/5.0.x/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java#L206-L210) throws an exception, it is wrapped in an `IOException`, which follows from [here](https://github.com/confluentinc/kafka-connect-storage-cloud/blob/5.0.x/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java#L130) to [here](https://github.com/confluentinc/kafka-connect-storage-cloud/blob/5.0.x/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java#L156)
where it is [swallowed and rethrown](https://github.com/confluentinc/kafka-connect-storage-cloud/blob/5.0.x/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java#L160-L162) as a `DataException` and [propagated to all of the RecordWriters](https://github.com/confluentinc/kafka-connect-storage-cloud/blob/5.0.x/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java#L97-L101) which is then propagated to [committing files in TPW](https://github.com/confluentinc/kafka-connect-storage-cloud/blob/5.0.x/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java#L519) and [then finally caught and rethrown](https://github.com/confluentinc/kafka-connect-storage-cloud/blob/5.0.x/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java#L493-L500) as a `RetriableException` because `DataException instanceof ConnectException == true` which results in the faulty retrying of exceptions that should fail the connector

## Solution
do not retry every exception in TPW, instead let the exceptions be propagated as necessary.
to keep existing behavior, the `RetriableExceptions` are now thrown by the `RecordWriters` on failed commits and will not swallow existing `ConnectExceptions`
in `S3OutputStream`, catch and handle the different exceptions properly and propagate non-retriable exceptions as `ConnectExceptions` and all others as `IOExceptions` like previous behavior

bonus: fixed a lot of deprecation warnings

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
add tests that make sure the exceptions are properly propagated
fix the old tests to ensure the expected behavior matches

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.0.x` where this retrying functionality was added in #281 