### PR TITLE
CC-12772: bump test containers version to addres commons-compress CVE

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -128,6 +128,7 @@
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
             <version>${org.testcontainer.version}</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -42,7 +42,7 @@
         <parquet.tools.version>1.11.1</parquet.tools.version>
         <formatters.version>0.2.2</formatters.version>
         <confluent.connect.testcontainers.version>1.0.1</confluent.connect.testcontainers.version>
-        <org.testcontainer.version>1.11.4</org.testcontainer.version>
+        <org.testcontainer.version>1.15.0</org.testcontainer.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
Signed-off-by: Lev Zemlyanov <lev@confluent.io>

## Problem
test containers brings in `commons-compress:1.18` which has a CVE

## Solution
bump to `1.15.0` which uses `1.20` and set it to `test` scope because its a test dependency

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
twistlock is clean

##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
backport to `5.5.x` where this CVE was introduced