### PR TITLE
Handle uppercase to s3 path

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -143,6 +143,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
   public static final String BEHAVIOR_ON_NULL_VALUES_DEFAULT = BehaviorOnNullValues.FAIL.toString();
 
+  public static final String S3_PATH_ALLOW_UPPERCASE_CONFIG = "s3.path.allow.uppercase";
+  public static final boolean S3_PATH_ALLOW_UPPERCASE_DEFAULT = true;
+
   /**
    * Maximum back-off time when retrying failed requests.
    */
@@ -525,6 +528,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.SHORT,
           "Enable Path Style Access to S3"
+      );
+
+      configDef.define(
+          S3_PATH_ALLOW_UPPERCASE_CONFIG,
+          Type.BOOLEAN,
+          S3_PATH_ALLOW_UPPERCASE_DEFAULT,
+          Importance.LOW,
+          "Allow to contain uppercase character in s3 path string.",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "S3 Path's Letter Case"
       );
     }
     return configDef;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -82,6 +82,7 @@ public class TopicPartitionWriter {
   private final String zeroPadOffsetFormat;
   private final String dirDelim;
   private final String fileDelim;
+  private boolean isUppercaseAllowed;
   private final Time time;
   private DateTimeZone timeZone;
   private final S3SinkConnectorConfig connectorConfig;
@@ -156,6 +157,7 @@ public class TopicPartitionWriter {
     zeroPadOffsetFormat = "%0"
         + connectorConfig.getInt(S3SinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG)
         + "d";
+    isUppercaseAllowed = connectorConfig.getBoolean(S3SinkConnectorConfig.S3_PATH_ALLOW_UPPERCASE_CONFIG);
 
     // Initialize scheduled rotation timer if applicable
     setNextScheduledRotation();
@@ -209,6 +211,8 @@ public class TopicPartitionWriter {
         }
         Schema valueSchema = record.valueSchema();
         String encodedPartition = partitioner.encodePartition(record, now);
+        if (!isUppercaseAllowed)
+          encodedPartition = encodedPartition.toLowerCase();
         Schema currentValueSchema = currentSchemas.get(encodedPartition);
         if (currentValueSchema == null) {
           currentSchemas.put(encodedPartition, valueSchema);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
@@ -98,7 +98,7 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
     format = new ParquetFormat(storage);
 
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
   }
 
   @After

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -65,6 +65,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 
 public class TopicPartitionWriterTest extends TestWithMockedS3 {
   // The default
@@ -93,7 +94,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     format = new AvroFormat(storage);
 
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
 
     Format<S3SinkConnectorConfig, String> format = new AvroFormat(storage);
     writerProvider = format.getRecordWriterProvider();
@@ -857,6 +858,42 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 3, extension, ZERO_PAD_FMT));
     expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 6, extension, ZERO_PAD_FMT));
     verify(expectedFiles, 3, schema, records);
+  }
+
+  @Test
+  public void testNotAllowedUppercasePath() throws Exception {
+    localProps.put(S3SinkConnectorConfig.S3_PATH_ALLOW_UPPERCASE_CONFIG, "false");
+    setUp();
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new FieldPartitioner<>();
+    partitioner.configure(parsedConfig);
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context);
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 1, 1);
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // Test actual write
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    @SuppressWarnings("unchecked")
+    List<String> partitionFields = (List<String>) parsedConfig.get(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG);
+    String partitionField = partitionFields.get(0).toUpperCase();   // path will contain uppercase letter.
+    String dirPrefix = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + 16);
+    String uppercaseContainedFile = FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 0, extension, ZERO_PAD_FMT);
+
+    List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
+    for (S3ObjectSummary summary : summaries) {
+      assertNotEquals(uppercaseContainedFile, summary.getKey());
+    }
   }
 
   private Struct createRecord(Schema schema, int ibase, float fbase) {


### PR DESCRIPTION
## Problem

fixs #381 

* the encoded partition path can contain uppercase.
* if the S3 path contain uppercase, the AWS Athena can not create metadata for the S3 path. [ref](https://aws.amazon.com/premiumsupport/knowledge-center/athena-aws-glue-msck-repair-table/?nc1=h_ls)

## Solution

* add new configuration that handle s3 path's letter case. `s3.path.allow.uppercase`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
