### PR TITLE
MINOR: bump storage common parent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.2</version>
+        <version>10.0.3</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem
Build issue
```
01:01:13  [ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project kafka-connect-storage-cloud: 
Can't release project due to non released dependencies :
01:01:13  [ERROR]     io.confluent:kafka-connect-storage-common:jar:10.0.0-SNAPSHOT:compile
01:01:13  [ERROR]     io.confluent:kafka-connect-storage-core:jar:10.0.0-SNAPSHOT:compile
01:01:13  [ERROR]     io.confluent:kafka-connect-storage-format:jar:10.0.0-SNAPSHOT:compile
01:01:13  [ERROR]     io.confluent:kafka-connect-storage-partitioner:jar:10.0.0-SNAPSHOT:compile
01:01:13  [ERROR] in project 'kafka-connect-storage-cloud' (io.confluent:kafka-connect-storage-cloud:pom:10.0.0-SNAPSHOT)
```

## Solution
Bump parent to version that includes fix https://github.com/confluentinc/kafka-connect-storage-common/pull/172

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
