### PR TITLE
CC-13830: Upgrade S3 connector to use HttpClient defined in kafka-connect-storage-common

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -38,7 +38,6 @@
     <properties>
         <aws.version>1.11.725</aws.version>
         <s3mock.version>0.1.5</s3mock.version>
-        <apache.httpclient.version>4.5.9</apache.httpclient.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
     </properties>
 
@@ -78,7 +77,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>${apache.httpclient.version}</version>
+            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>${httpclient.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
## Problem
Sync version of org.apache.httpcomponents:httpclient version and fix CVE

## Solution
Use the one defined in kafka-connect-storage-common

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
Merge to master
<!-- If you are reverting or rolling back, is it safe? --> 
