### PR TITLE
CCMSG-861: Catch additional exception to report in DLQ

### DIFF
--- a/checkstyle/suppressions.xml
+++ b/checkstyle/suppressions.xml
@@ -16,4 +16,9 @@
             files="(S3SinkConnectorConfig).java"
     />
 
+    <suppress
+      checks="CyclomaticComplexity"
+      files="(TopicPartitionWriter).java"
+    />
+
 </suppressions>


### PR DESCRIPTION
## Problem
There is an additional opportunity to catch and report an exception to the DLQ. 

## Solution
Catch exception on `encodePartition` and report it to the DLQ using the reporter if available. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
`10.0.x` the earliest DLQ branch.