### PR TITLE
MINOR: Upgrade storage common to 10.0.5 and catch PartitionException in TopicPartitionWriter's error handling

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -17,6 +17,7 @@ package io.confluent.connect.s3;
 
 import com.amazonaws.SdkClientException;
 import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.storage.errors.PartitionException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -226,7 +227,7 @@ public class TopicPartitionWriter {
         String encodedPartition;
         try {
           encodedPartition = partitioner.encodePartition(record, now);
-        } catch (ConnectException e) {
+        } catch (PartitionException e) {
           if (reporter != null) {
             reporter.report(record, e);
             buffer.poll();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -23,6 +23,7 @@ import io.confluent.connect.s3.format.KeyValueHeaderRecordWriterProvider;
 import io.confluent.connect.s3.format.RecordViewSetter;
 import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
 import io.confluent.connect.s3.format.RecordViews.KeyRecordView;
+import io.confluent.connect.storage.errors.PartitionException;
 import io.confluent.kafka.serializers.NonRecordContainer;
 import org.apache.avro.util.Utf8;
 import org.apache.kafka.common.record.TimestampType;
@@ -1001,7 +1002,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
     // Test actual write
     topicPartitionWriter.write();
-    ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(ConnectException.class);
+    ArgumentCaptor<Throwable> exceptionCaptor = ArgumentCaptor.forClass(PartitionException.class);
     Mockito.verify(mockReporter, times(1)).report(any(), exceptionCaptor.capture());
     assertEquals("Error encoding partition.", exceptionCaptor.getValue().getMessage());
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>10.0.3</version>
+        <version>10.0.5</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem
Currently `ConnectException` is caught in the `TPW` when encoding a partition. 


## Solution
Revise to a more appropriate `PartitionException` for the DLQ. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [X] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Targeting to `10.0.x`