### PR TITLE
[fix] Invalid object key with a topic name with .extension

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
@@ -32,7 +32,7 @@ public class Utils {
   public static String getAdjustedFilename(RecordView recordView, String filename,
       String initialExtension) {
     if (filename.endsWith(initialExtension)) {
-      int index = filename.indexOf(initialExtension);
+      int index = filename.lastIndexOf(initialExtension);
       return filename.substring(0, index) + recordView.getExtension() + initialExtension;
     } else {
       // filename is already stripped


### PR DESCRIPTION
## Problem

Fixes https://github.com/confluentinc/kafka-connect-storage-cloud/issues/395