### PR TITLE
SEC-1996: Replace commons-httpclient with apache httpclient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -148,6 +148,10 @@
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-httpclient</groupId>
+                    <artifactId>commons-httpclient</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
commons-httpclient is brought in by transitive depency and is pretty old, their last update is 2007 and they are deprecated.
They contain a CVE https://confluentinc.atlassian.net/browse/SEC-1996

## Solution
Switch to the new package https://mvnrepository.com/artifact/org.apache.httpcomponents/httpclient

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
All usages of commons-httpclient


## Test Strategy
Rely on existing tests.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
