### PR TITLE
CCMSG-1021: Upgrade AWS SDK to 1.11.1015 and exclude jackson-dataformat-cbor

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -35,7 +35,7 @@
     </description>
 
     <properties>
-        <aws.version>1.11.725</aws.version>
+        <aws.version>1.11.1015</aws.version>
         <s3mock.version>0.2.5</s3mock.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
     </properties>
@@ -61,6 +61,14 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
+            <exclusions>
+            <exclusion>
+                <!-- This is not used by the connector and is removed to address CVE-2020-28491
+                    Once the jackson version gets upgraded consider lifting this exclusion -->
+                <groupId>com.fasterxml.jackson.dataformat</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+            </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
## Problem
Upgrade to the latest AWS SDK version
Fix CVE in jackson-dataformat-cbor

## Solution
Currently jackson is pinned to version 2.10.5 from https://github.com/confluentinc/common
Because of this selection the transitive dependency `jackson-dataformat-cbor` imported from the AWS SDK is also being included in version 2.10.5. Instead of upgrading jackson for this connector only and on a patch release, it's preferred to exclude `jackson-dataformat-cbor` because it's unused by the connector and the way it uses AWS SDK for S3. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
