### PR TITLE
Override com.fasterxml.jackson.dataformat:jackson-dataformat-cbor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,6 +166,11 @@
             <version>1.9.4</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-cbor</artifactId>
+            <version>${jackson.cbor.version}</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>


### PR DESCRIPTION
## Problem
Resolve CVE CVE-2020-28491

## Solution
Override  com.fasterxml.jackson.dataformat:jackson-dataformat-cbor to use 2.11.4 defined in common.
https://github.com/confluentinc/common/pull/334

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
