### PR TITLE
Elastic byte buffer for S3OutputStream (base on v10.0.x)

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -172,6 +172,16 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String HEADERS_FORMAT_CLASS_CONFIG = "headers.format.class";
   public static final Class<? extends Format> HEADERS_FORMAT_CLASS_DEFAULT = AvroFormat.class;
 
+  /**
+   * Elastic buffer to save memory. {@link io.confluent.connect.s3.storage.S3OutputStream#buffer}
+   */
+
+  public static final String ELASTIC_BUFFER_ENABLE = "s3.elastic.buffer.enable";
+  public static final boolean ELASTIC_BUFFER_ENABLE_DEFAULT = false;
+
+  public static final String ELASTIC_BUFFER_INIT_CAPACITY = "s3.elastic.buffer.init.capacity";
+  public static final int ELASTIC_BUFFER_INIT_CAPACITY_DEFAULT = 128 * 1024;  // 128KB
+
   private final String name;
 
   private final StorageCommonConfig commonConfig;
@@ -663,6 +673,31 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Width.SHORT,
           "Enable Path Style Access to S3"
       );
+      configDef.define(
+          ELASTIC_BUFFER_ENABLE,
+          Type.BOOLEAN,
+          ELASTIC_BUFFER_ENABLE_DEFAULT,
+          Importance.LOW,
+          "Elastic buffer to staging s3-part for saving memory.",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "Enable elastic buffer to staging s3-part"
+      );
+
+      configDef.define(
+          ELASTIC_BUFFER_INIT_CAPACITY,
+          Type.INT,
+          ELASTIC_BUFFER_INIT_CAPACITY_DEFAULT,
+          atLeast(4096),
+          Importance.LOW,
+          "Elastic buffer initial capacity.",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "Elastic buffer initial capacity"
+      );
+
     }
     return configDef;
   }
@@ -790,6 +825,14 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       return originalsStrings().get(FORMAT_BYTEARRAY_LINE_SEPARATOR_CONFIG);
     }
     return FORMAT_BYTEARRAY_LINE_SEPARATOR_DEFAULT;
+  }
+
+  public boolean getElasticBufferEnable() {
+    return getBoolean(ELASTIC_BUFFER_ENABLE);
+  }
+
+  public int getElasticBufferInitCap() {
+    return getInt(ELASTIC_BUFFER_INIT_CAPACITY);
   }
 
   protected static String parseName(Map<String, String> props) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/ByteBuf.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/ByteBuf.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.storage;
+
+/**
+ * A interface for S3OutputStream to write s3-part.
+ */
+public interface ByteBuf {
+
+  void put(byte b);
+
+  void put(byte[] src, int offset, int length);
+
+  boolean hasRemaining();
+
+  int remaining();
+
+  int position();
+
+  void clear();
+
+  byte[] array();
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/ElasticByteBuffer.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/ElasticByteBuffer.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.storage;
+
+import java.nio.BufferOverflowException;
+
+/**
+ * A elastic byte buffer with a logic size as max size.
+ * The formula to expand: initCapacity * 2 ^ (incrementFactor * N)
+ */
+public class ElasticByteBuffer implements ByteBuf {
+
+  public static final int INCREMENT_FACTOR = 1;
+
+  /* logical capacity */
+  private int capacity;
+
+  /* initial physical capacity  */
+  private int initPhysicalCap;
+
+  /* the next position to write */
+  private int position;
+
+  /* physical buf */
+  private byte[] buf;
+
+  public ElasticByteBuffer(int capacity, int initPhysicalCap) {
+    if (capacity <= 0) {
+      throw new IllegalArgumentException("capacity must greater than zero");
+    }
+
+    if (initPhysicalCap <= 0) {
+      throw new IllegalArgumentException("initial physical capacity must greater than zero");
+    }
+
+    this.capacity = capacity;
+    this.initPhysicalCap = initPhysicalCap;
+
+    initialize();
+  }
+
+  private void initialize() {
+    this.position = 0;
+    int initCapacity = Math.min(this.capacity, this.initPhysicalCap);
+    this.buf = new byte[initCapacity];
+  }
+
+  private void expand() {
+    int currSize = this.buf.length;
+    int calNewSize = currSize << INCREMENT_FACTOR;
+
+    int newSize = 0;
+    if (calNewSize < currSize) {
+      // down overflow
+      newSize = this.capacity;
+    } else {
+      newSize = Math.min(this.capacity, calNewSize);
+    }
+
+    byte[] currBuf = this.buf;
+    this.buf = new byte[newSize];
+    System.arraycopy(currBuf, 0, this.buf, 0, currSize);
+  }
+
+  public void put(byte b) {
+    if (!hasRemaining()) {
+      throw new BufferOverflowException();
+    }
+
+    if (physicalRemaining() <= 0) {
+      // expand physical buf
+      expand();
+    }
+
+    this.buf[this.position] = b;
+    this.position++;
+  }
+
+  public void put(byte[] src, int offset, int length) {
+
+    checkBounds(offset, length, src.length);
+
+    if (!hasRemaining()) {
+      throw new BufferOverflowException();
+    }
+
+    int remainingOffset = offset;
+    int remainingLen = length;
+    while (true) {
+      if (physicalRemaining() <= 0) {
+        // expand physical buf
+        expand();
+      }
+
+      if (physicalRemaining() >= remainingLen) {
+        System.arraycopy(src, remainingOffset, this.buf, this.position, remainingLen);
+        this.position += remainingLen;
+        break;
+      } else {
+        int physicalRemaining = physicalRemaining();
+        System.arraycopy(src, remainingOffset, this.buf, this.position, physicalRemaining);
+        this.position += physicalRemaining;
+        remainingOffset += physicalRemaining;
+        remainingLen -= physicalRemaining;
+      }
+    }
+  }
+
+  static void checkBounds(int off, int len, int size) { // package-private
+    if ((off | len | (off + len) | (size - (off + len))) < 0) {
+      throw new IndexOutOfBoundsException();
+    }
+  }
+
+  public int physicalRemaining() {
+    return this.buf.length - this.position;
+  }
+
+  public boolean hasRemaining() {
+    return capacity > position;
+  }
+
+  public int remaining() {
+    return capacity - position;
+  }
+
+  public int position() {
+    return this.position;
+  }
+
+  public void clear() {
+    if (this.buf.length <= this.initPhysicalCap) {
+      // has not ever expanded, just reset position
+      this.position = 0;
+    } else {
+      initialize();
+    }
+  }
+
+  public final byte[] array() {
+    return this.buf;
+  }
+
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/ElasticByteBuffer.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/ElasticByteBuffer.java
@@ -93,7 +93,7 @@ public class ElasticByteBuffer implements ByteBuf {
 
     checkBounds(offset, length, src.length);
 
-    if (!hasRemaining()) {
+    if (remaining() < length) {
       throw new BufferOverflowException();
     }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -41,7 +41,6 @@ import org.slf4j.LoggerFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -63,7 +62,7 @@ public class S3OutputStream extends PositionOutputStream {
   private final int partSize;
   private final CannedAccessControlList cannedAcl;
   private boolean closed;
-  private ByteBuffer buffer;
+  private ByteBuf buffer;
   private MultipartUpload multiPartUpload;
   private final CompressionType compressionType;
   private final int compressionLevel;
@@ -84,7 +83,15 @@ public class S3OutputStream extends PositionOutputStream {
     this.partSize = conf.getPartSize();
     this.cannedAcl = conf.getCannedAcl();
     this.closed = false;
-    this.buffer = ByteBuffer.allocate(this.partSize);
+
+    final boolean elasticBufEnable = conf.getElasticBufferEnable();
+    if (elasticBufEnable) {
+      final int elasticBufInitialCap = conf.getElasticBufferInitCap();
+      this.buffer = new ElasticByteBuffer(this.partSize, elasticBufInitialCap);
+    } else {
+      this.buffer = new SimpleByteBuf(this.partSize);
+    }
+
     this.progressListener = new ConnectProgressListener();
     this.multiPartUpload = null;
     this.compressionType = conf.getCompressionType();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -59,7 +59,7 @@ public class S3OutputStream extends PositionOutputStream {
   private final int partSize;
   private final CannedAccessControlList cannedAcl;
   private boolean closed;
-  private final ByteBuffer buffer;
+  private final ByteBuf buffer;
   private MultipartUpload multiPartUpload;
   private final CompressionType compressionType;
   private final int compressionLevel;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/SimpleByteBuf.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/SimpleByteBuf.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.storage;
+
+import java.nio.ByteBuffer;
+
+/**
+ * A simple byte buf
+ */
+public class SimpleByteBuf implements ByteBuf {
+
+  private ByteBuffer buffer;
+
+  public SimpleByteBuf(int capacity) {
+    this.buffer = ByteBuffer.allocate(capacity);
+  }
+
+  @Override
+  public void put(byte b) {
+    this.buffer.put(b);
+  }
+
+  @Override
+  public void put(byte[] src, int offset, int length) {
+    this.buffer.put(src, offset, length);
+  }
+
+  @Override
+  public boolean hasRemaining() {
+    return this.buffer.hasRemaining();
+  }
+
+  @Override
+  public int remaining() {
+    return this.buffer.remaining();
+  }
+
+  @Override
+  public int position() {
+    return this.buffer.position();
+  }
+
+  @Override
+  public void clear() {
+    this.buffer.clear();
+  }
+
+  @Override
+  public byte[] array() {
+    return this.buffer.array();
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/ElasticByteBufferTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/ElasticByteBufferTest.java
@@ -1,0 +1,313 @@
+package io.confluent.connect.s3.storage;
+
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang.math.RandomUtils;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.nio.BufferOverflowException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ElasticByteBufferTest {
+
+  public static final int INIT_CAP = 128 * 1024;
+
+  @Rule
+  public ExpectedException exceptionRule = ExpectedException.none();
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testIllegalCapacity1() {
+    ElasticByteBuffer buf = new ElasticByteBuffer(-1, INIT_CAP);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testIllegalCapacity2() {
+    ElasticByteBuffer buf = new ElasticByteBuffer(0, INIT_CAP);
+  }
+
+  @Test
+  public void testLessThanInitCapacityPut1() {
+    ElasticByteBuffer buf = new ElasticByteBuffer(1024, INIT_CAP);
+
+    assertEquals(1024, buf.physicalRemaining());
+    assertEquals(1024, buf.remaining());
+    assertEquals(0, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(1024, buf.array().length);
+
+    buf.put((byte) 0x01);
+    assertEquals(1023, buf.physicalRemaining());
+    assertEquals(1023, buf.remaining());
+    assertEquals(1, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(1024, buf.array().length);
+
+    byte[] randomBytes = RandomStringUtils.randomAlphanumeric(1023).getBytes();
+    for (byte randomByte : randomBytes) {
+      buf.put(randomByte);
+    }
+
+    assertEquals(0, buf.physicalRemaining());
+    assertEquals(0, buf.remaining());
+    assertEquals(1024, buf.position());
+    assertEquals(false, buf.hasRemaining());
+    assertEquals(1024, buf.array().length);
+
+    exceptionRule.expect(BufferOverflowException.class);
+    buf.put((byte) 0x01);
+  }
+
+  @Test
+  public void testLessThanInitCapacityPut2() {
+    ElasticByteBuffer buf = new ElasticByteBuffer(1024, INIT_CAP);
+
+    byte[] randomBytes1 = RandomStringUtils.randomAlphanumeric(4).getBytes();
+    buf.put(randomBytes1, 0, randomBytes1.length);
+
+    assertEquals(1020, buf.physicalRemaining());
+    assertEquals(1020, buf.remaining());
+    assertEquals(4, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(1024, buf.array().length);
+
+    byte[] randomBytes2 = RandomStringUtils.randomAlphanumeric(1020).getBytes();
+    buf.put(randomBytes2, 0, randomBytes2.length);
+
+    assertEquals(0, buf.physicalRemaining());
+    assertEquals(0, buf.remaining());
+    assertEquals(1024, buf.position());
+    assertEquals(false, buf.hasRemaining());
+    assertEquals(1024, buf.array().length);
+
+    byte[] randomBytes3 = RandomStringUtils.randomAlphanumeric(2).getBytes();
+    exceptionRule.expect(BufferOverflowException.class);
+    buf.put(randomBytes3, 0, randomBytes3.length);
+  }
+
+  @Test
+  public void testLessThanInitCapacityClear() {
+    ElasticByteBuffer buf = new ElasticByteBuffer(1024, INIT_CAP);
+
+    byte[] randomBytes1 = RandomStringUtils.randomAlphanumeric(4).getBytes();
+    buf.put(randomBytes1, 0, randomBytes1.length);
+
+    byte[] arrayBeforeClear = buf.array();
+    buf.clear();
+    byte[] arrayAfterClear = buf.array();
+    assertTrue(arrayAfterClear.length == arrayBeforeClear.length);
+    assertTrue(arrayAfterClear == arrayBeforeClear);
+  }
+
+
+  @Test
+  public void testGreaterThanInitCapacityPut1() {
+
+    int cap = 10 * 1024 * 1024;
+    ElasticByteBuffer buf = new ElasticByteBuffer(cap, INIT_CAP);
+
+    assertEquals(INIT_CAP, buf.physicalRemaining());
+    assertEquals(cap, buf.remaining());
+    assertEquals(0, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(INIT_CAP, buf.array().length);
+
+    byte[] randomBytes1 = RandomStringUtils.randomAlphanumeric(INIT_CAP).getBytes();
+    for (byte randomByte : randomBytes1) {
+      buf.put(randomByte);
+    }
+
+    assertEquals(0, buf.physicalRemaining());
+    assertEquals(cap - INIT_CAP, buf.remaining());
+    assertEquals(INIT_CAP, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(INIT_CAP, buf.array().length);
+
+    int testBytesLen1 = 5;
+    byte[] randomBytes2 = RandomStringUtils.randomAlphanumeric(testBytesLen1).getBytes();
+    for (byte randomByte : randomBytes2) {
+      buf.put(randomByte);
+    }
+
+    int exceptNewPhysicalSize = INIT_CAP * 2;
+
+    assertEquals(exceptNewPhysicalSize - (INIT_CAP + testBytesLen1), buf.physicalRemaining());
+    assertEquals(cap - (INIT_CAP + testBytesLen1), buf.remaining());
+    assertEquals(INIT_CAP + testBytesLen1, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(exceptNewPhysicalSize, buf.array().length);
+
+    int remaining = cap - (INIT_CAP + testBytesLen1);
+    byte[] randomBytes3 = RandomStringUtils.randomAlphanumeric(remaining).getBytes();
+    for (byte randomByte : randomBytes3) {
+      buf.put(randomByte);
+    }
+
+    assertEquals(0, buf.physicalRemaining());
+    assertEquals(0, buf.remaining());
+    assertEquals(cap, buf.position());
+    assertEquals(false, buf.hasRemaining());
+    assertEquals(cap, buf.array().length);
+
+    exceptionRule.expect(BufferOverflowException.class);
+    buf.put((byte) 0x01);
+  }
+
+  @Test
+  public void testGreaterThanInitCapacityPut2() {
+    int cap = 10 * 1024 * 1024;
+    ElasticByteBuffer buf = new ElasticByteBuffer(cap, INIT_CAP);
+
+    assertEquals(INIT_CAP, buf.physicalRemaining());
+    assertEquals(cap, buf.remaining());
+    assertEquals(0, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(INIT_CAP, buf.array().length);
+
+    byte[] randomBytes1 = RandomStringUtils.randomAlphanumeric(INIT_CAP).getBytes();
+    buf.put(randomBytes1, 0, randomBytes1.length);
+
+    assertEquals(0, buf.physicalRemaining());
+    assertEquals(cap - INIT_CAP, buf.remaining());
+    assertEquals(INIT_CAP, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(INIT_CAP, buf.array().length);
+
+    int testBytesLen1 = 5;
+    byte[] randomBytes2 = RandomStringUtils.randomAlphanumeric(testBytesLen1).getBytes();
+    buf.put(randomBytes2, 0, randomBytes2.length);
+
+    int exceptNewPhysicalSize = INIT_CAP * 2;
+
+    assertEquals(exceptNewPhysicalSize - (INIT_CAP + testBytesLen1), buf.physicalRemaining());
+    assertEquals(cap - (INIT_CAP + testBytesLen1), buf.remaining());
+    assertEquals(INIT_CAP + testBytesLen1, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(exceptNewPhysicalSize, buf.array().length);
+
+    int remaining = cap - (INIT_CAP + testBytesLen1);
+    byte[] randomBytes3 = RandomStringUtils.randomAlphanumeric(remaining).getBytes();
+    buf.put(randomBytes3, 0, randomBytes3.length);
+
+    assertEquals(0, buf.physicalRemaining());
+    assertEquals(0, buf.remaining());
+    assertEquals(cap, buf.position());
+    assertEquals(false, buf.hasRemaining());
+    assertEquals(cap, buf.array().length);
+
+    exceptionRule.expect(BufferOverflowException.class);
+    buf.put(new byte[] {0x01}, 0, 1);
+  }
+
+  @Test
+  public void testGreaterThanInitCapacityClear() {
+    int cap = 10 * 1024 * 1024;
+    ElasticByteBuffer buf = new ElasticByteBuffer(cap, INIT_CAP);
+
+    byte[] randomBytes1 = RandomStringUtils.randomAlphanumeric(5 * 1024 * 1024).getBytes();
+    buf.put(randomBytes1, 0, randomBytes1.length);
+
+    byte[] arrayBeforeClear = buf.array();
+    buf.clear();
+    byte[] arrayAfterClear = buf.array();
+
+    assertEquals(0, buf.position());
+    assertEquals(true, buf.hasRemaining());
+    assertEquals(INIT_CAP, buf.physicalRemaining());
+    assertEquals(cap, buf.remaining());
+
+    assertEquals(INIT_CAP, arrayAfterClear.length);
+    assertTrue(arrayAfterClear.length < arrayBeforeClear.length);
+    assertTrue(arrayAfterClear != arrayBeforeClear);
+  }
+
+  @Test
+  public void testLessThanInitSizeDataPut1() {
+    int cap = 1024;
+    ElasticByteBuffer buf = new ElasticByteBuffer(cap, INIT_CAP);
+
+    int testBytesLen1 = 4;
+    String data1 = RandomStringUtils.randomAlphanumeric(testBytesLen1);
+    byte[] randomBytes1 = data1.getBytes();
+    for (byte randomByte : randomBytes1) {
+      buf.put(randomByte);
+    }
+
+    assertEquals(data1, new String(buf.array(), 0, buf.position()));
+
+    int testBytesLen2 = 1020;
+    String data2 = RandomStringUtils.randomAlphanumeric(testBytesLen2);
+    byte[] randomBytes2 = data2.getBytes();
+    for (byte randomByte : randomBytes2) {
+      buf.put(randomByte);
+    }
+
+    assertEquals(data1 + data2, new String(buf.array(), 0, buf.position()));
+  }
+
+  @Test
+  public void testLessThanInitSizeDataPut2() {
+    int cap = 1024;
+    ElasticByteBuffer buf = new ElasticByteBuffer(cap, INIT_CAP);
+
+    int testBytesLen1 = 4;
+    String data1 = RandomStringUtils.randomAlphanumeric(testBytesLen1);
+    byte[] randomBytes1 = data1.getBytes();
+    buf.put(randomBytes1, 0, randomBytes1.length);
+
+    assertEquals(data1, new String(buf.array(), 0, buf.position()));
+
+    int testBytesLen2 = 1020;
+    String data2 = RandomStringUtils.randomAlphanumeric(testBytesLen2);
+    byte[] randomBytes2 = data2.getBytes();
+    buf.put(randomBytes2, 0, randomBytes2.length);
+
+    assertEquals(data1 + data2, new String(buf.array(), 0, buf.position()));
+  }
+
+  @Test
+  public void testGreaterThanInitSizeDataPut1() {
+    int cap = 5 * 1024 * 1024;
+    ElasticByteBuffer buf = new ElasticByteBuffer(cap, INIT_CAP);
+
+    int testBytesLen1 = RandomUtils.nextInt(cap);
+    String data1 = RandomStringUtils.randomAlphanumeric(testBytesLen1);
+    byte[] randomBytes1 = data1.getBytes();
+    for (byte randomByte : randomBytes1) {
+      buf.put(randomByte);
+    }
+
+    assertEquals(data1, new String(buf.array(), 0, buf.position()));
+
+    int testBytesLen2 = cap - testBytesLen1;
+    String data2 = RandomStringUtils.randomAlphanumeric(testBytesLen2);
+    byte[] randomBytes2 = data2.getBytes();
+    for (byte randomByte : randomBytes2) {
+      buf.put(randomByte);
+    }
+
+    assertEquals(data1 + data2, new String(buf.array(), 0, buf.position()));
+  }
+
+  @Test
+  public void testGreaterThanInitSizeDataPut2() {
+    int cap = 5 * 1024 * 1024;
+    ElasticByteBuffer buf = new ElasticByteBuffer(cap, INIT_CAP);
+
+    int testBytesLen1 = RandomUtils.nextInt(cap);
+    String data1 = RandomStringUtils.randomAlphanumeric(testBytesLen1);
+    byte[] randomBytes1 = data1.getBytes();
+    buf.put(randomBytes1, 0, randomBytes1.length);
+
+    assertEquals(data1, new String(buf.array(), 0, buf.position()));
+
+    int testBytesLen2 = cap - testBytesLen1;
+    String data2 = RandomStringUtils.randomAlphanumeric(testBytesLen2);
+    byte[] randomBytes2 = data2.getBytes();
+    buf.put(randomBytes2, 0, randomBytes2.length);
+
+    assertEquals(data1 + data2, new String(buf.array(), 0, buf.position()));
+  }
+}


### PR DESCRIPTION
## Problem
Same PR as in: https://github.com/confluentinc/kafka-connect-storage-cloud/pull/320
But rebase on version 10.0.x

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
