### PR TITLE
Retry AWS Failures for Multipart Uploads

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -168,7 +168,7 @@ public class S3OutputStream extends PositionOutputStream {
       log.debug("Upload complete for bucket '{}' key '{}'", bucket, key);
     } catch (IOException e) {
       log.error("Multipart upload failed to complete for bucket '{}' key '{}'", bucket, key);
-      throw new ConnectException(
+      throw new IOException(
           String.format("Multipart upload failed to complete: %s", e.getMessage())
       );
     } finally {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
@@ -41,12 +41,12 @@ public class S3OutputStreamTest extends S3SinkConnectorTestBase {
     e.setErrorType(ErrorType.Service);
 
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(e);
-    assertThrows("Multipart upload failed to complete.", ConnectException.class, () -> stream.commit());
+    assertThrows("Multipart upload failed to complete.", IOException.class, () -> stream.commit());
   }
 
   @Test
   public void testPropagateOtherRetriableS3Exceptions() {
     when(s3Mock.initiateMultipartUpload(any())).thenThrow(new AmazonClientException("this is an other s3 exception"));
-    assertThrows("Multipart upload failed to complete.", ConnectException.class, () -> stream.commit());
+    assertThrows("Multipart upload failed to complete.", IOException.class, () -> stream.commit());
   }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamTest.java
@@ -10,6 +10,7 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.services.s3.AmazonS3;
 import io.confluent.connect.s3.S3SinkConnectorTestBase;
+import java.io.IOException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
## Problem
https://github.com/confluentinc/kafka-connect-storage-cloud/issues/411

IOExceptions during multipart uploads should be retried.

We see random failures on multipart uploads fairly regularly, and a single issue puts the connector task in a FAILED state when we do.

## Solution

When an IOException is caught during a multipart upload, also throw an IOException.  The unit test method names (`testPropagateRetriableS3Exceptions()` and  `testPropagateOtherRetriableS3Exceptions()`) already note that this error should be retriable.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
n/a

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan

I would like to merge this change to master.