### PR TITLE
CC-14987: Fix serialization when headers.format.class is json

### DIFF
--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -1435,11 +1435,11 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   }
 
   private List<String> getS3FileListHeaders(List<S3ObjectSummary> summaries) {
-    return getS3FileListFilter(summaries, ".headers");
+    return getS3FileListFilter(summaries, RecordElement.HEADERS.name().toLowerCase());
   }
 
   private List<String> getS3FileListKeys(List<S3ObjectSummary> summaries) {
-    return getS3FileListFilter(summaries, ".keys.avro");
+    return getS3FileListFilter(summaries, RecordElement.KEYS.name().toLowerCase());
   }
 
   // filter for keys or headers


### PR DESCRIPTION
## Problem
Using the configs below results in a serialization exception. 
```
"store.kafka.headers": "true",
"headers.format.class": "io.confluent.connect.s3.format.json.JsonFormat"
```
Error
```
Caused by: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.apache.kafka.connect.data.Struct and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: java.util.ArrayList[0])
	at com.fasterxml.jackson.databind.exc.InvalidDefinitionException.from(InvalidDefinitionException.java:77)
	at com.fasterxml.jackson.databind.SerializerProvider.reportBadDefinition(SerializerProvider.java:1191)
```

Reported in https://github.com/confluentinc/kafka-connect-storage-cloud/issues/413.

**Root Cause** 
The non-empty header array is attempted to be written with the Json writer that expects a different format. 

## Solution

Envelop the header array in a struct so that it can be written without a serialization issue. The data is enveloped by setting the flag `true` in: `recordView.getView(record, true);` and `recordView.getViewSchema(record, true);`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Backporting to `10.0.x` where header feature was added. 