### PR TITLE
MINOR: Remove unused dependency on kafka-connect-storage-hive in the 5.2.x release branch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,10 +108,6 @@
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
-            <artifactId>kafka-connect-storage-hive</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-partitioner</artifactId>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
This package is not used but bring in several transitive deps

## Solution
We should remove and align with more recent branches. 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Applies only to 5.2.x