### PR TITLE
Close only requested partitions

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -287,14 +287,18 @@ public class S3SinkTask extends SinkTask {
 
   @Override
   public void close(Collection<TopicPartition> partitions) {
-    for (TopicPartition tp : topicPartitionWriters.keySet()) {
+    for (TopicPartition tp : partitions) {
       try {
-        topicPartitionWriters.get(tp).close();
+		TopicPartitionWriter writer = topicPartitionWriters.get(tp);
+		// Check for case writer has been closed.
+		if (writer != null) {
+			writer.close();
+			topicPartitionWriters.remove(tp);
+		}
       } catch (ConnectException e) {
         log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
       }
     }
-    topicPartitionWriters.clear();
   }
 
   @Override


### PR DESCRIPTION
Closing other partitions may look safe, but some partitions can in
theory remain closed even if they should be open.

For example topics-partitions A-0, A-1, B-0, B-1 may be assigned to two
tasks (first would have A-0,B-0; second A-1,B-1). When a new task comes,
it may be decided it gets B-0.
The first task calls close([B-0]); open([]) so that B-0 is handled by
the new task. First task should still be able to handle A-0.

Besides this solution, we could also open all assigned topics-partitions
on every open() call. That would work, but it's not the most effective
way.

## Problem
Rebalances between multiple tasks may fail with NullPointerException because the appropriate topic-partition is not open.

## Solution
Do not close topic-partition combinations that were not requested

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?
N/A

## Test Strategy

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [x] System tests
- [x] Manual tests

(Unit/integration tests were not done as I don't have machines to test it on and don't know how to run just unit tests)