### PR TITLE
Remove toString() call in trace log

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -82,7 +82,7 @@ public class ParquetRecordWriterProvider implements RecordWriterProvider<S3SinkC
             throw new ConnectException(e);
           }
         }
-        log.trace("Sink record: {}", record.toString());
+        log.trace("Sink record: {}", record);
         Object value = avroData.fromConnectData(schema, record.value());
         try {
           writer.write((GenericRecord) value);


### PR DESCRIPTION
## Problem
https://github.com/confluentinc/kafka-connect-storage-cloud/issues/449

This `toString()` is hurting performance when using the S3 sink with the Parquet output format.

## Solution

Just remove the `toString()`. it's not necesary.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

Running this manually, performance is improved.

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 

This only applies to the `5.5.x` line. The equivalent code in `master` looks like it was fixed when other new features were implemented 
