### PR TITLE
use lastIndexOf for deriving adjusted filename and also added tests f…

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
@@ -32,7 +32,7 @@ public class Utils {
   public static String getAdjustedFilename(RecordView recordView, String filename,
       String initialExtension) {
     if (filename.endsWith(initialExtension)) {
-      int index = filename.indexOf(initialExtension);
+      int index = filename.lastIndexOf(initialExtension);
       return filename.substring(0, index) + recordView.getExtension() + initialExtension;
     } else {
       // filename is already stripped

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/UtilsTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/UtilsTest.java
@@ -15,6 +15,7 @@ public class UtilsTest {
 
   private static List<String> givenFilenames = new ArrayList<>(Arrays.asList(
       "x",
+      "avro",
       "x.avro",
       "asdf.avro",
       "keys.avro",
@@ -31,6 +32,7 @@ public class UtilsTest {
   public void getAdjustedFilenameForValues() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.avro",
+        "avro.avro",
         "x.avro",
         "asdf.avro",
         "keys.avro",
@@ -53,6 +55,7 @@ public class UtilsTest {
   public void getAdjustedFilenameForKeys() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.keys.avro",
+        "avro.keys.avro",
         "x.keys.avro",
         "asdf.keys.avro",
         "keys.keys.avro",
@@ -75,6 +78,7 @@ public class UtilsTest {
   public void getAdjustedFilenameForHeaders() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.headers.avro",
+        "avro.headers.avro",
         "x.headers.avro",
         "asdf.headers.avro",
         "keys.headers.avro",

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/UtilsTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/UtilsTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 public class UtilsTest {
 
   private static List<String> givenFilenames = new ArrayList<>(Arrays.asList(
+      "x",
       "x.avro",
       "asdf.avro",
       "keys.avro",
@@ -22,12 +23,14 @@ public class UtilsTest {
       "header.avro",
       "sample-filename.avro",
       "sample.filename.avro",
-      "sample.file.name.avro"
+      "sample.file.name.avro",
+      "sample.file.avro.RawEvent.avro"
   ));
 
   @Test
   public void getAdjustedFilenameForValues() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
+        "x.avro",
         "x.avro",
         "asdf.avro",
         "keys.avro",
@@ -36,7 +39,8 @@ public class UtilsTest {
         "header.avro",
         "sample-filename.avro",
         "sample.filename.avro",
-        "sample.file.name.avro"
+        "sample.file.name.avro",
+        "sample.file.avro.RawEvent.avro"
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
@@ -49,6 +53,7 @@ public class UtilsTest {
   public void getAdjustedFilenameForKeys() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.keys.avro",
+        "x.keys.avro",
         "asdf.keys.avro",
         "keys.keys.avro",
         "key.keys.avro",
@@ -56,7 +61,8 @@ public class UtilsTest {
         "header.keys.avro",
         "sample-filename.keys.avro",
         "sample.filename.keys.avro",
-        "sample.file.name.keys.avro"
+        "sample.file.name.keys.avro",
+        "sample.file.avro.RawEvent.keys.avro"
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
@@ -69,6 +75,7 @@ public class UtilsTest {
   public void getAdjustedFilenameForHeaders() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.headers.avro",
+        "x.headers.avro",
         "asdf.headers.avro",
         "keys.headers.avro",
         "key.headers.avro",
@@ -76,7 +83,8 @@ public class UtilsTest {
         "header.headers.avro",
         "sample-filename.headers.avro",
         "sample.filename.headers.avro",
-        "sample.file.name.headers.avro"
+        "sample.file.name.headers.avro",
+        "sample.file.avro.RawEvent.headers.avro"
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
@@ -106,5 +114,4 @@ public class UtilsTest {
       assertEquals(expectedFilenames.get(i), adjustedFilename);
     }
   }
-
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/UtilsTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/UtilsTest.java
@@ -14,8 +14,6 @@ import org.junit.Test;
 public class UtilsTest {
 
   private static List<String> givenFilenames = new ArrayList<>(Arrays.asList(
-      "x",
-      "avro",
       "x.avro",
       "asdf.avro",
       "keys.avro",
@@ -25,14 +23,16 @@ public class UtilsTest {
       "sample-filename.avro",
       "sample.filename.avro",
       "sample.file.name.avro",
-      "sample.file.avro.RawEvent.avro"
+      "sample.file.avro.RawEvent.avro",
+      "x",
+      "avro",
+      ".avro",
+      "fooavrobar.txt"
   ));
 
   @Test
   public void getAdjustedFilenameForValues() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
-        "x.avro",
-        "avro.avro",
         "x.avro",
         "asdf.avro",
         "keys.avro",
@@ -42,7 +42,11 @@ public class UtilsTest {
         "sample-filename.avro",
         "sample.filename.avro",
         "sample.file.name.avro",
-        "sample.file.avro.RawEvent.avro"
+        "sample.file.avro.RawEvent.avro",
+        "x.avro",
+        "avro.avro",
+        ".avro",
+        "fooavrobar.txt.avro"
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
@@ -55,8 +59,6 @@ public class UtilsTest {
   public void getAdjustedFilenameForKeys() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.keys.avro",
-        "avro.keys.avro",
-        "x.keys.avro",
         "asdf.keys.avro",
         "keys.keys.avro",
         "key.keys.avro",
@@ -65,7 +67,11 @@ public class UtilsTest {
         "sample-filename.keys.avro",
         "sample.filename.keys.avro",
         "sample.file.name.keys.avro",
-        "sample.file.avro.RawEvent.keys.avro"
+        "sample.file.avro.RawEvent.keys.avro",
+        "x.keys.avro",
+        "avro.keys.avro",
+        ".keys.avro",
+        "fooavrobar.txt.keys.avro"
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {
@@ -78,8 +84,6 @@ public class UtilsTest {
   public void getAdjustedFilenameForHeaders() {
     List<String> expectedFilenames = new ArrayList<>(Arrays.asList(
         "x.headers.avro",
-        "avro.headers.avro",
-        "x.headers.avro",
         "asdf.headers.avro",
         "keys.headers.avro",
         "key.headers.avro",
@@ -88,7 +92,11 @@ public class UtilsTest {
         "sample-filename.headers.avro",
         "sample.filename.headers.avro",
         "sample.file.name.headers.avro",
-        "sample.file.avro.RawEvent.headers.avro"
+        "sample.file.avro.RawEvent.headers.avro",
+        "x.headers.avro",
+        "avro.headers.avro",
+        ".headers.avro",
+        "fooavrobar.txt.headers.avro"
     ));
 
     for (int i = 0; i < expectedFilenames.size(); i++) {


### PR DESCRIPTION
…or case where extension is not part of filename

## Problem
`sample.file.avro.RawEvent.avro` was giving `sample.file.keys.avro` instead of `sample.file.avro.RawEvent.keys.avro` for keys file name.

## Solution
use `lastIndexOf` instead of `indexOf`

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
