### PR TITLE
Disabled concurrent jobs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,4 +4,5 @@ common {
   upstreamProjects = 'confluentinc/kafka-connect-storage-common'
   nodeLabel = 'docker-debian-jdk8'
   pintMerge = true
+  disableConcurrentBuilds = true
 }


### PR DESCRIPTION
Capping in branches 5.2.x through 6.0.x the number of concurrent Jenkins jobs running down to just 2 (one running, all others queued) in order to reduce the impact of releases has on Jenkins (To cap the “Jenkins Build Storm” after releases are finalized and bumped to the next version every quarter). This change will save a lot of Jenkins build resources.