### PR TITLE
Allow string match of formatting file extension to exist in the topic name (or elsewhere in the file besides the end)

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -157,6 +157,12 @@
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.20.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -211,7 +211,7 @@ public class S3SinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) throws ConnectException {
-     for (SinkRecord record : records) {
+    for (SinkRecord record : records) {
       String topic = record.topic();
       int partition = record.kafkaPartition();
       TopicPartition tp = new TopicPartition(topic, partition);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.s3;
 
 import com.amazonaws.AmazonClientException;
+import com.google.common.annotations.VisibleForTesting;
 import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -160,7 +161,8 @@ public class S3SinkTask extends SinkTask {
     return formatClass.getConstructor(S3Storage.class).newInstance(storage);
   }
 
-  private RecordWriterProvider<S3SinkConnectorConfig> newRecordWriterProvider(
+  @VisibleForTesting
+  public RecordWriterProvider<S3SinkConnectorConfig> newRecordWriterProvider(
       S3SinkConnectorConfig config)
       throws ClassNotFoundException, InvocationTargetException, InstantiationException,
       NoSuchMethodException, IllegalAccessException {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -211,7 +211,7 @@ public class S3SinkTask extends SinkTask {
 
   @Override
   public void put(Collection<SinkRecord> records) throws ConnectException {
-    for (SinkRecord record : records) {
+     for (SinkRecord record : records) {
       String topic = record.topic();
       int partition = record.kafkaPartition();
       TopicPartition tp = new TopicPartition(topic, partition);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -70,9 +70,8 @@ public class KeyValueHeaderRecordWriterProvider
     // Each provider will add its own extension. The filename comes in with the value file format,
     // e.g. filename.avro, but when the format class is different for the key or the headers the
     // extension needs to be removed.
-    int extensionIndex = filename.indexOf(valueProvider.getExtension());
-    String strippedFilename = extensionIndex > -1
-        ? filename.substring(0, extensionIndex)
+    String strippedFilename = filename.endsWith(valueProvider.getExtension())
+        ? filename.substring(0, filename.length() - valueProvider.getExtension().length())
         : filename;
 
     RecordWriter valueWriter = valueProvider.getRecordWriter(conf, strippedFilename);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -92,22 +92,10 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     System.setProperty(SkipMd5CheckStrategy.DISABLE_GET_OBJECT_MD5_VALIDATION_PROPERTY, "true");
   }
 
-  //
-  // -DataWriterTestBase
-  //
   @Override
   protected String getFileExtension() {
     return EXTENSION;
   }
-
-  @Override
-  protected List<SinkRecord> createGenericRecords(int count, long firstOffset) {
-    return createRecordsNoVersion(count, firstOffset);
-  }
-  //
-  // DataWriterTestBase-
-  //
-
 
   //@Before should be omitted in order to be able to add properties per test.
   public void setUpWithCommitException() throws Exception {
@@ -850,6 +838,11 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
       }
     }
     return sinkRecords;
+  }
+
+  @Override
+  protected List<SinkRecord> createGenericRecords(int count, long firstOffset) {
+    return createRecordsNoVersion(count, firstOffset);
   }
 
   protected List<SinkRecord> createRecordsNoVersion(int size, long startOffset) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
@@ -49,40 +49,10 @@ public class DataWriterByteArrayTest extends DataWriterTestBase<ByteArrayFormat>
     super(ByteArrayFormat.class);
   }
 
-  //
-  // -DataWriterTestBase
-  //
   @Override
   protected String getFileExtension() {
     return DEFAULT_EXTENSION;
   }
-
-  @Override
-  protected List<SinkRecord> createGenericRecords(int count, long firstOffset) {
-    return createByteArrayRecordsWithoutSchema(
-        count * context.assignment().size(),
-        firstOffset,
-        context.assignment()
-    );
-  }
-
-  @Override
-  protected void verify(
-      List<SinkRecord> sinkRecords,
-      long[] validOffsets,
-      Set<TopicPartition> partitions
-  ) throws IOException {
-    verify(
-        sinkRecords,
-        validOffsets,
-        partitions,
-        DEFAULT_EXTENSION
-    );
-  }
-  //
-  // DataWriterTestBase-
-  //
-
 
   @Override
   protected Map<String, String> createProps() {
@@ -239,6 +209,29 @@ public class DataWriterByteArrayTest extends DataWriterTestBase<ByteArrayFormat>
       byte[] expectedBytes = (byte[]) expectedRecord.value();
       assertArrayEquals(expectedBytes, bytes);
     }
+  }
+
+  @Override
+  protected List<SinkRecord> createGenericRecords(int count, long firstOffset) {
+    return createByteArrayRecordsWithoutSchema(
+        count * context.assignment().size(),
+        firstOffset,
+        context.assignment()
+    );
+  }
+
+  @Override
+  protected void verify(
+      List<SinkRecord> sinkRecords,
+      long[] validOffsets,
+      Set<TopicPartition> partitions
+  ) throws IOException {
+    verify(
+        sinkRecords,
+        validOffsets,
+        partitions,
+        DEFAULT_EXTENSION
+    );
   }
 
   protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
@@ -58,34 +58,10 @@ public class DataWriterJsonTest extends DataWriterTestBase<JsonFormat> {
     return props;
   }
 
-  //
-  // -DataWriterTestBase
-  //
   @Override
   protected String getFileExtension() {
     return EXTENSION;
   }
-
-  @Override
-  protected List<SinkRecord> createGenericRecords(int count, long firstOffset) {
-    return createJsonRecordsWithoutSchema(
-        count * context.assignment().size(),
-        firstOffset,
-        context.assignment()
-    );
-  }
-
-  @Override
-  protected void verify(
-      List<SinkRecord> sinkRecords,
-      long[] validOffsets,
-      Set<TopicPartition> partitions
-  ) throws IOException {
-    verify(sinkRecords, validOffsets, partitions, EXTENSION);
-  }
-  //
-  // DataWriterTestBase-
-  //
 
   //@Before should be omitted in order to be able to add properties per test.
   public void setUp() throws Exception {
@@ -261,6 +237,24 @@ public class DataWriterJsonTest extends DataWriterTestBase<JsonFormat> {
       }
       assertEquals(expectedValue, jsonRecord);
     }
+  }
+
+  @Override
+  protected List<SinkRecord> createGenericRecords(int count, long firstOffset) {
+    return createJsonRecordsWithoutSchema(
+        count * context.assignment().size(),
+        firstOffset,
+        context.assignment()
+    );
+  }
+
+  @Override
+  protected void verify(
+      List<SinkRecord> sinkRecords,
+      long[] validOffsets,
+      Set<TopicPartition> partitions
+  ) throws IOException {
+    verify(sinkRecords, validOffsets, partitions, EXTENSION);
   }
 
   protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
@@ -65,37 +65,17 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     super(ParquetFormat.class);
   }
 
-  //
-  // -DataWriterTestBase
-  //
-  @Override
-  protected String getFileExtension() {
-    return EXTENSION;
-  }
-
-  @Override
-  protected List<SinkRecord> createGenericRecords(int count, long firstOffset) {
-    return createRecords(count, firstOffset);
-  }
-
-  @Override
-  protected void verify(
-      List<SinkRecord> sinkRecords,
-      long[] validOffsets,
-      Set<TopicPartition> partitions
-  ) throws IOException {
-    verify(sinkRecords, validOffsets, partitions, false);
-  }
-  //
-  // DataWriterTestBase-
-  //
-
   @Override
   protected Map<String, String> createProps() {
     Map<String, String> props = super.createProps();
     props.putAll(localProps);
     props.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ParquetFormat.class.getName());
     return props;
+  }
+
+  @Override
+  protected String getFileExtension() {
+    return EXTENSION;
   }
 
   @After
@@ -634,6 +614,20 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
               recordNoVersion, offset));
     }
     return sinkRecords;
+  }
+
+  @Override
+  protected List<SinkRecord> createGenericRecords(int count, long firstOffset) {
+    return createRecords(count, firstOffset);
+  }
+
+  @Override
+  protected void verify(
+      List<SinkRecord> sinkRecords,
+      long[] validOffsets,
+      Set<TopicPartition> partitions
+  ) throws IOException {
+    verify(sinkRecords, validOffsets, partitions, false);
   }
 
   protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, String extension) throws IOException {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
@@ -644,11 +644,6 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     verify(sinkRecords, validOffsets, Collections.singleton(new TopicPartition(TOPIC, PARTITION)), false);
   }
 
-//  protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions)
-//          throws IOException {
-//    verify(sinkRecords, validOffsets, partitions, false);
-//  }
-
   protected void verify(List<SinkRecord> sinkRecords, long[] validOffsets, Set<TopicPartition> partitions,
                         boolean skipFileListing)
           throws IOException {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterTestBase.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterTestBase.java
@@ -60,9 +60,6 @@ public abstract class DataWriterTestBase<
   protected FORMAT format;
   private final Class<FORMAT> clazz;
 
-  //
-  // -DataWriterTestBase
-  //
   /**
    * Return the default file extension
    *
@@ -116,9 +113,6 @@ public abstract class DataWriterTestBase<
   protected DataWriterTestBase(final Class<FORMAT> clazz) {
     this.clazz = clazz;
   }
-  //
-  // DataWriterTestBase-
-  //
 
   //@Before should be omitted in order to be able to add properties per test.
   public void setUp() throws Exception {
@@ -161,14 +155,6 @@ public abstract class DataWriterTestBase<
     }
     return expectedFiles;
   }
-
-//  protected List<String> getExpectedFiles(long[] validOffsets, Collection<TopicPartition> partitions) {
-//    List<String> expectedFiles = new ArrayList<>();
-//    for (TopicPartition tp : partitions) {
-//      expectedFiles.addAll(getExpectedFiles(validOffsets, tp, getFileExtension()));
-//    }
-//    return expectedFiles;
-//  }
 
   protected void verifyFileListing(List<String> expectedFiles) throws IOException {
     List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterTestBase.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterTestBase.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright 2017 Confluent Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.confluent.connect.s3;
+
+import com.amazonaws.services.s3.AmazonS3;
+import io.confluent.connect.s3.format.KeyValueHeaderRecordWriterProvider;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.s3.util.FileUtils;
+import io.confluent.connect.storage.common.StorageCommonConfig;
+import io.confluent.connect.storage.format.Format;
+import io.confluent.connect.storage.format.RecordWriter;
+import io.confluent.connect.storage.format.RecordWriterProvider;
+import io.confluent.connect.storage.partitioner.DefaultPartitioner;
+import io.confluent.connect.storage.partitioner.Partitioner;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.powermock.api.mockito.PowerMockito;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public abstract class DataWriterTestBase<
+    FORMAT extends Format<S3SinkConnectorConfig, String>
+  > extends TestWithMockedS3 {
+
+  protected static final String ZERO_PAD_FMT = "%010d";
+
+  protected S3Storage storage;
+  protected AmazonS3 s3;
+  protected Partitioner<?> partitioner;
+  protected S3SinkTask task;
+  protected Map<String, String> localProps = new HashMap<>();
+
+  // The format class
+  protected FORMAT format;
+  private final Class<FORMAT> clazz;
+
+  //
+  // -DataWriterTestBase
+  //
+  /**
+   * Return the default file extension
+   *
+   * @return The default file extension
+   */
+  protected abstract String getFileExtension();
+
+  /**
+   * Perform a simple verify that the S3 bucket has the given records (and only the given records)
+   *
+   * @param sinkRecords Sink records to verify ewxist on S3 storage
+   * @param validOffsets List of valid offsets for these recores
+   *
+   * @throws IOException Thrown upon an IO exception,m such as S3 unreachable
+   */
+  protected abstract void verify(List<SinkRecord> sinkRecords, long[] validOffsets) throws IOException;
+
+  /**
+   * Create a generic list of records, usually for purposes other than validating the
+   * correctness of the records' structure themselves.  We don't care whether they do or don't
+   * have a schema, for instance -- just that we can verify that they are records with some
+   * comparable value for correctness validation purposes.
+   *
+   * @param count Number of records to create
+   * @param firstOffset First valid offset for these records
+   *
+   * @return A list of the newly-created records
+   */
+  protected abstract List<SinkRecord> createGenericRecords(int count, long firstOffset);
+
+  /**
+   * Return the S3 "directory" that a given topic and partition number are expected to
+   * reside.
+   * @param topic The topic of the records
+   * @param partition The partition number
+   *
+   * @return A string representing the S3 "directory"
+   */
+  protected abstract String getDirectory(String topic, int partition);
+
+  /**
+   * Constructor
+   *
+   * @param clazz  A Class<Format type> object for the purpose of creating
+   *               a new format object.
+   */
+  protected DataWriterTestBase(final Class<FORMAT> clazz) {
+    this.clazz = clazz;
+  }
+  //
+  // DataWriterTestBase-
+  //
+
+  //@Before should be omitted in order to be able to add properties per test.
+  public void setUp() throws Exception {
+    super.setUp();
+
+    s3 = PowerMockito.spy(newS3Client(connectorConfig));
+
+    storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3);
+
+    partitioner = new DefaultPartitioner<>();
+    partitioner.configure(parsedConfig);
+    format = clazz.getDeclaredConstructor(S3Storage.class).newInstance(storage);
+    assertEquals(format.getClass().getName(), clazz.getName());
+
+    s3.createBucket(S3_TEST_BUCKET_NAME);
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
+  }
+
+  /**
+   *
+   * @param topicDir
+   * @throws Exception
+   */
+  protected void testCorrectRecordWriterHelper(
+      final String topicDir
+  ) throws Exception {
+    localProps.put(StorageCommonConfig.TOPICS_DIR_CONFIG, topicDir);
+    setUp();
+
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+
+    RecordWriterProvider<S3SinkConnectorConfig> keyValueRecordWriterProvider =
+        task.newRecordWriterProvider(connectorConfig);
+    assertEquals(keyValueRecordWriterProvider.getExtension(), getFileExtension());
+    assertThat(keyValueRecordWriterProvider).isInstanceOf(KeyValueHeaderRecordWriterProvider.class);
+    KeyValueHeaderRecordWriterProvider kvProvider =
+        (KeyValueHeaderRecordWriterProvider)keyValueRecordWriterProvider;
+
+    List<SinkRecord> records = createGenericRecords(6, 1);
+    int offset = 0;
+    for (SinkRecord record : records) {
+      TopicPartition tp = new TopicPartition(record.topic(), record.kafkaPartition());
+      String fileKey = FileUtils.fileKeyToCommit(
+          topicsDir,
+          getDirectory(tp.topic(), tp.partition()),
+          tp,
+          offset++,
+          getFileExtension(),
+          ZERO_PAD_FMT
+      );
+      RecordWriter actualRecordWriterProvider =
+          kvProvider.getRecordWriter(connectorConfig, fileKey);
+      actualRecordWriterProvider.write(record);
+      actualRecordWriterProvider.commit();
+      actualRecordWriterProvider.close();
+    }
+
+    long[] validOffsets = {0, 1, 2, 3, 4, 5, 6};
+    verify(records, validOffsets);
+  }
+
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -60,9 +60,6 @@ import static org.powermock.api.easymock.PowerMock.verifyAll;
 @PowerMockIgnore({"io.findify.s3mock.*", "akka.*", "javax.*", "org.xml.*", "com.sun.org.apache.xerces.*"})
 public class S3SinkTaskTest extends DataWriterAvroTest {
 
-  private static final String ZERO_PAD_FMT = "%010d";
-  private final String extension = ".avro";
-
   //@Before should be omitted in order to be able to add properties per test.
   public void setUp() throws Exception {
     super.setUp();
@@ -174,7 +171,7 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
     // Upload partial file.
     List<SinkRecord> sinkRecords = createRecords(2);
     byte[] partialData = AvroUtils.putRecords(sinkRecords, format.getAvroData());
-    String fileKey = FileUtils.fileKeyToCommit(topicsDir, getDirectory(), TOPIC_PARTITION, 0, extension, ZERO_PAD_FMT);
+    String fileKey = FileUtils.fileKeyToCommit(topicsDir, getDirectory(), TOPIC_PARTITION, 0, EXTENSION, ZERO_PAD_FMT);
     s3.putObject(S3_TEST_BUCKET_NAME, fileKey, new ByteArrayInputStream(partialData), null);
 
     // Accumulate rest of the records.

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -20,10 +20,8 @@ import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.confluent.common.utils.IntegrationTest;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
@@ -214,6 +212,24 @@ public abstract class BaseConnectorIT {
   protected boolean fileNamesValid(String bucketName, List<String> expectedFiles) {
     List<String> actualFiles = getBucketFileNames(bucketName);
     return expectedFiles.equals(actualFiles);
+  }
+
+  /**
+   * Check if all of the expected namings are in the bucket and that the bucket has extactly
+   * the specified number of files.
+   *
+   * @param bucketName    the name of the bucket with the files
+   * @param filesToCheck the list of expected filenames for exact comparison
+   * @param expectedBucketFileCount the total number of keys (matching or unmatching) expected in the bucket
+   * @return whether all the expected values are in the bucket
+   */
+  protected boolean fileNamesBoundedSubset(
+          String bucketName,
+          Collection<String> filesToCheck,
+          int expectedBucketFileCount
+  ) {
+    Set<String> actualFiles = new HashSet<>(getBucketFileNames(bucketName));
+    return actualFiles.size() == expectedBucketFileCount && actualFiles.containsAll(filesToCheck);
   }
 
   /**

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -21,23 +21,21 @@ import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.confluent.common.utils.IntegrationTest;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.test.TestUtils;
-import org.assertj.core.api.ListAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Category(IntegrationTest.class)
 public abstract class BaseConnectorIT {
@@ -217,8 +215,7 @@ public abstract class BaseConnectorIT {
    */
   protected void assertFileNamesValid(String bucketName, List<String> expectedFiles) {
     List<String> actualFiles = getBucketFileNames(bucketName);
-    ListAssert<String> listAssert = new ListAssert<>(actualFiles);
-    listAssert.containsExactlyInAnyOrderElementsOf(expectedFiles);
+    assertThat(actualFiles).containsExactlyInAnyOrderElementsOf(expectedFiles);
   }
 
   /**

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -20,7 +20,6 @@ import com.amazonaws.services.s3.model.ListObjectsV2Request;
 import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.confluent.common.utils.IntegrationTest;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -220,7 +220,7 @@ public abstract class BaseConnectorIT {
   }
 
   /**
-   * Check if all of the expected namings are in the bucket and that the bucket has extactly
+   * Check if all of the expected namings are in the bucket and that the bucket has exactly
    * the specified number of files.
    *
    * @param bucketName    the name of the bucket with the files

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -32,6 +32,7 @@ import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;
 import org.apache.kafka.connect.util.clusters.EmbeddedConnectCluster;
 import org.apache.kafka.test.TestUtils;
+import org.assertj.core.api.ListAssert;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.experimental.categories.Category;
@@ -214,27 +215,10 @@ public abstract class BaseConnectorIT {
    * @param expectedFiles the list of expected filenames for exact comparison
    * @return whether all the files in the bucket match the expected values
    */
-  protected boolean fileNamesValid(String bucketName, List<String> expectedFiles) {
+  protected void assertFileNamesValid(String bucketName, List<String> expectedFiles) {
     List<String> actualFiles = getBucketFileNames(bucketName);
-    return expectedFiles.equals(actualFiles);
-  }
-
-  /**
-   * Check if all of the expected namings are in the bucket and that the bucket has exactly
-   * the specified number of files.
-   *
-   * @param bucketName    the name of the bucket with the files
-   * @param filesToCheck the list of expected filenames for exact comparison
-   * @param expectedBucketFileCount the total number of keys (matching or unmatching) expected in the bucket
-   * @return whether all the expected values are in the bucket
-   */
-  protected boolean fileNamesBoundedSubset(
-          String bucketName,
-          Collection<String> filesToCheck,
-          int expectedBucketFileCount
-  ) {
-    Set<String> actualFiles = new HashSet<>(getBucketFileNames(bucketName));
-    return actualFiles.size() == expectedBucketFileCount && actualFiles.containsAll(filesToCheck);
+    ListAssert<String> listAssert = new ListAssert<>(actualFiles);
+    listAssert.containsExactlyInAnyOrderElementsOf(expectedFiles);
   }
 
   /**

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -21,7 +21,13 @@ import com.amazonaws.services.s3.model.ListObjectsV2Result;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import io.confluent.common.utils.IntegrationTest;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.connect.runtime.AbstractStatus;
 import org.apache.kafka.connect.runtime.rest.entities.ConnectorStateInfo;

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -227,8 +227,8 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
    * @throws Throwable
    */
   private void testBasicRecordsWrittenWithExtInTopic(String expectedFileExtension) throws Throwable {
-    //final String topicNameWithExt = "my." + expectedFileExtension + ".topic." + expectedFileExtension;
-    final String topicNameWithExt = "OtherTopic";
+    final String topicNameWithExt = "my." + expectedFileExtension + ".topic." + expectedFileExtension;
+    //final String topicNameWithExt = "OtherTopic";
 
     // Add an extra topic with this extension inside of the name
     // Use a TreeSet for test determinism

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -669,7 +669,7 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
     int lastDot = fileName.lastIndexOf('.');
     if (lastDot < 0) {
       // no extension
-      throw new RuntimeException("Could not parse extension from filename: " + S3FileKey);
+      throw new RuntimeException("Could not parse extension from filename: " + s3FileKey);
     }
 
     return fileName.substring(lastDot + 1);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -652,11 +652,11 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
    * <p>
    * ex.: /topics/s3_topic/partition=97/s3_topic+97+0000000001.avro
    *
-   * @param S3FileKey the object file key
+   * @param s3FileKey the object file key
    * @return the extension, may be .avro, .json, or .snappy.parquet,
    */
-  private static String getExtensionFromKey(String S3FileKey) {
-    String[] pathTokens = S3FileKey.split("/");
+  private static String getExtensionFromKey(String s3FileKey) {
+    String[] pathTokens = s3FileKey.split("/");
     // The last one is (presumably) the file name
     String fileName = pathTokens[pathTokens.length - 1];
     // The extension ".snappy.parquet" is a special case of a two-dot

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -229,7 +229,9 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
   }
 
   /**
-   * Test that topics which have ".{expectedFileExtension}" in them are processed
+   * Test that the expected records are written for a given file extension
+   * Optionally, test that topics which have "*.{expectedFileExtension}*" in them are processed
+   * and written.
    * @param expectedFileExtension The file extension to test against
    * @param addExtensionInTopic Add a topic to to the test which contains the extension
    * @throws Throwable

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -190,42 +190,42 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
   public void testBasicRecordsWrittenAvro() throws Throwable {
     //add test specific props
     props.put(FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
-    testBasicRecordsWritten(AVRO_EXTENSION, /*addExtensionInTopic=*/false);
+    testBasicRecordsWritten(AVRO_EXTENSION, false);
   }
 
   @Test
   public void testBasicRecordsWrittenParquet() throws Throwable {
     //add test specific props
     props.put(FORMAT_CLASS_CONFIG, ParquetFormat.class.getName());
-    testBasicRecordsWritten(PARQUET_EXTENSION, /*addExtensionInTopic=*/false);
+    testBasicRecordsWritten(PARQUET_EXTENSION, false);
   }
 
   @Test
   public void testBasicRecordsWrittenJson() throws Throwable {
     //add test specific props
     props.put(FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
-    testBasicRecordsWritten(JSON_EXTENSION, /*addExtensionInTopic=*/false);
+    testBasicRecordsWritten(JSON_EXTENSION, false);
   }
 
   @Test
   public void testFilesWrittenToBucketAvroWithExtInTopic() throws Throwable {
     //add test specific props
     props.put(FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
-    testBasicRecordsWritten(AVRO_EXTENSION, /*addExtensionInTopic=*/true);
+    testBasicRecordsWritten(AVRO_EXTENSION, true);
   }
 
   @Test
   public void testFilesWrittenToBucketParquetWithExtInTopic() throws Throwable {
     //add test specific props
     props.put(FORMAT_CLASS_CONFIG, ParquetFormat.class.getName());
-    testBasicRecordsWritten(PARQUET_EXTENSION, /*addExtensionInTopic=*/true);
+    testBasicRecordsWritten(PARQUET_EXTENSION, true);
   }
 
   @Test
   public void testFilesWrittenToBucketJsonWithExtInTopic() throws Throwable {
     //add test specific props
     props.put(FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
-    testBasicRecordsWritten(JSON_EXTENSION, /*addExtensionInTopic=*/true);
+    testBasicRecordsWritten(JSON_EXTENSION, true);
   }
 
   /**

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -51,7 +51,15 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -265,19 +273,19 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
 
     for (String thisTopicName : topicNames) {
       List<String> expectedTopicFilenames = getExpectedFilenames(
-              thisTopicName,
-              TOPIC_PARTITION,
-              FLUSH_SIZE_STANDARD,
-              NUM_RECORDS_INSERT,
-              expectedFileExtension
+          thisTopicName,
+          TOPIC_PARTITION,
+          FLUSH_SIZE_STANDARD,
+          NUM_RECORDS_INSERT,
+          expectedFileExtension
       );
       // The total number of files allowed in the bucket is number of topics * # produced for each
       // All topics should have produced the same number of files, so this check should hold
       // for all iterations.
       assertTrue(fileNamesBoundedSubset(
-              TEST_BUCKET_NAME,
-              expectedTopicFilenames,
-              expectedTotalFileCount
+          TEST_BUCKET_NAME,
+          expectedTopicFilenames,
+          expectedTotalFileCount
       ));
     }
     // Now check that all files created by the sink have the contents that were sent
@@ -413,13 +421,13 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
 
   private SinkRecord getSampleTopicRecord(String topicName, Schema recordValueSchema, Struct recordValueStruct ) {
     return new SinkRecord(
-            topicName,
-            TOPIC_PARTITION,
-            Schema.STRING_SCHEMA,
-            "key",
-            recordValueSchema,
-            recordValueStruct,
-            DEFAULT_OFFSET
+        topicName,
+        TOPIC_PARTITION,
+        Schema.STRING_SCHEMA,
+        "key",
+        recordValueSchema,
+        recordValueStruct,
+        DEFAULT_OFFSET
     );
   }
 


### PR DESCRIPTION
Moving from this PR in forked repo:  https://github.com/confluentinc/kafka-connect-storage-cloud/pull/464

Generalize the DataWriterXXXTest unit test classes, moving much of the common code into a base class DataWriterTestBase in order to reduce redundancy as well as simplify doing unit tests of the issue being fixed in this PR.

No significant logic changes for the movement to base class, largely just cut+paste.

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
