### PR TITLE
CCMSG-1582 set the next scheduled rotation duration even if there are…

### DIFF
--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -600,6 +600,99 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   }
 
   @Test
+  public void testWriteRecordsAfterCurrentScheduleRotationExpiryShouldGoToSameFile()
+          throws Exception {
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(
+            S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
+            String.valueOf(TimeUnit.HOURS.toMillis(1))
+    );
+    localProps.put(
+            S3SinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG,
+            String.valueOf(TimeUnit.MINUTES.toMillis(10))
+    );
+    setUp();
+
+    // Define the partitioner
+    TimeBasedPartitioner<?> partitioner = new TimeBasedPartitioner<>();
+    parsedConfig.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.DAYS.toMillis(1));
+    parsedConfig.put(
+            PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockedWallclockTimestampExtractor.class.getName());
+    partitioner.configure(parsedConfig);
+
+    MockTime time = ((MockedWallclockTimestampExtractor) partitioner.getTimestampExtractor()).time;
+
+    // Bring the clock to present.
+    time.sleep(SYSTEM.milliseconds());
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+            TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time, null);
+
+    // sleep for 11 minutes after startup
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+    //nextScheduledRotation should be reset
+    topicPartitionWriter.write();
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 3, 6);
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records.subList(0, 3), key, schema);
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // No records written to S3
+    topicPartitionWriter.write();
+    long timestampFirst = time.milliseconds();
+
+    // 11 minutes
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+    // Records are written due to scheduled rotation
+    topicPartitionWriter.write();
+
+    //simulate idle loop and kafka calling put with no records
+    for (int i = 0; i < 5; i++) {
+      // sleep for 11 minutes after startup
+      time.sleep(TimeUnit.MINUTES.toMillis(11));
+      //nextScheduledRotation should be reset
+      topicPartitionWriter.write();
+    }
+
+    sinkRecords = createSinkRecords(records.subList(3, 6), key, schema, 3);
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // More records later
+    topicPartitionWriter.write();
+    long timestampLater = time.milliseconds();
+
+    // 11 minutes later, another scheduled rotation
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+
+    // Again the records are written due to scheduled rotation
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    String encodedPartitionFirst = getTimebasedEncodedPartition(timestampFirst);
+    String encodedPartitionLater = getTimebasedEncodedPartition(timestampLater);
+
+    String dirPrefixFirst = partitioner.generatePartitionedPath(TOPIC, encodedPartitionFirst);
+    List<String> expectedFiles = new ArrayList<>();
+    for (int i : new int[]{0}) {
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, extension,
+              ZERO_PAD_FMT));
+    }
+
+    String dirPrefixLater = partitioner.generatePartitionedPath(TOPIC, encodedPartitionLater);
+    for (int i : new int[]{3}) {
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefixLater, TOPIC_PARTITION, i, extension,
+              ZERO_PAD_FMT));
+    }
+    verify(expectedFiles, 3, schema, records);
+  }
+
+  @Test
   public void testWriteRecordTimeBasedPartitionWallclockMockedWithScheduleRotation()
       throws Exception {
     localProps.put(FLUSH_SIZE_CONFIG, "1000");


### PR DESCRIPTION
… no records in buffer and time has passed

## Problem
If there are no records in the buffer and no open files and 1000 new records are pushed to a topic at the same time then should these 1000 records be part of a single new file.
Currently, the task creates 2 new files (1 with 1st record and another with rest of the 999 records). This happens because we reset the `nextScheduledRotation` only if we have records to commit.

## Solution

We should reset the `nextScheduledRotation` even if there are no records to commit and time has passed

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [X] 
- [ ] no

##### If yes, where?
GCS and AzureBlob sink connector

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X ] Unit tests
- [X] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
