### PR TITLE
Add 'keep' option to 'behavior.on.null.values' config

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -587,7 +587,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           BehaviorOnNullValues.VALIDATOR,
           Importance.LOW,
           "How to handle records with a null value (i.e. Kafka tombstone records)."
-              + " Valid options are 'ignore' and 'fail'.",
+              + " Valid options are 'ignore', 'fail', and 'keep'",
           group,
           ++orderInGroup,
           Width.SHORT,
@@ -1079,7 +1079,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public enum BehaviorOnNullValues {
     IGNORE,
-    FAIL;
+    FAIL,
+    KEEP;
 
     public static final ConfigDef.Validator VALIDATOR = new ConfigDef.Validator() {
       private final ConfigDef.ValidString validator = ConfigDef.ValidString.in(names());

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -257,7 +257,8 @@ public class S3SinkTask extends SinkTask {
             record.kafkaOffset()
         );
         return true;
-      } else {
+      } else if (connectorConfig.nullValueBehavior()
+          .equalsIgnoreCase(BehaviorOnNullValues.FAIL.toString())) {
         throw new ConnectException("Null valued records are not writeable with current "
             + S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG + " 'settings.");
       }


### PR DESCRIPTION
## Problem

Currently the `behavior.on.null.values` config option allows for two options: `ignore` and `fail`.  This means that null valued tombstone messages are either dropped from the output stream or cause the connector to fail.

While the this condition can be reported via a `ErrantRecordReporter` and dumped to another output target, such as a DLQ, this is less convenient in some cases than having the null record appear inline in the primary output file and pushes the complexity of handling deletion events to each distinct consumer of the output content.

The built in output formats don't currently support this output style and may be difficult to make compatible with allowing nulls in a backwards compatible manner.  However, consider a custom `Format` and `RecordWriter` that emits fully wrapped copies of the entire message structure with a format of:

```
{
  "key": <base64 encoded key>,
  "headers": { ... },
  "value": <base64 encoded value>,
  "timestamp": ...
  ...
}
```

(or more specifically in our case, encoded as CBOR: https://github.com/NextDeveloperTeam/kafka-connect-s3-cbor)

With such a format, it's trivial and natural to encode a tombstone/null-valued record as `"value": null`.  Consumers of these output files can add "simple" `if value == null` style checks to detect if the record is a tombstone and handle accordingly in a streaming manner, instead of having to separately load a list of deleted records from some other location and handle an unbounded number of potential tombstone records (which can exceed memory limits, etc of the consumer).

## Solution

The solution is rather straightforward: add a new config option, `keep`, that passes the record through to the configured writer instead of dropping the message or failing the connector.

##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

## Test Strategy

##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
N/A
