### PR TITLE
CCMSG-1582 Fix bug that generates a small files when scheduled rotation has expired

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -182,6 +182,8 @@ public class TopicPartitionWriter {
       failureTime = -1;
     }
 
+    resetExpiredScheduledRotationIfNoPendingRecords(now);
+
     while (!buffer.isEmpty()) {
       try {
         executeState(now);
@@ -306,6 +308,12 @@ public class TopicPartitionWriter {
     }
   }
 
+  private void resetExpiredScheduledRotationIfNoPendingRecords(long now) {
+    if (recordCount == 0 && shouldApplyScheduledRotation(now)) {
+      setNextScheduledRotation();
+    }
+  }
+
   public void close() throws ConnectException {
     log.debug("Closing TopicPartitionWriter {}", tp);
     for (RecordWriter writer : writers.values()) {
@@ -364,14 +372,18 @@ public class TopicPartitionWriter {
     );
 
     log.trace(
-        "Checking rotation on time with recordCount '{}' and encodedPartition '{}'",
+        "Checking rotation on time for topic-partition '{}' "
+            + "with recordCount '{}' and encodedPartition '{}'",
+        tp,
         recordCount,
         encodedPartition
     );
 
     log.trace(
-        "Should apply periodic time-based rotation (rotateIntervalMs: '{}', baseRecordTimestamp: "
+        "Should apply periodic time-based rotation for topic-partition '{}':"
+            + " (rotateIntervalMs: '{}', baseRecordTimestamp: "
             + "'{}', timestamp: '{}', encodedPartition: '{}', currentEncodedPartition: '{}')? {}",
+        tp,
         rotateIntervalMs,
         baseRecordTimestamp,
         recordTimestamp,
@@ -379,17 +391,22 @@ public class TopicPartitionWriter {
         currentEncodedPartition,
         periodicRotation
     );
+    return periodicRotation || shouldApplyScheduledRotation(now);
+  }
 
+  private boolean shouldApplyScheduledRotation(long now) {
     boolean scheduledRotation = rotateScheduleIntervalMs > 0 && now >= nextScheduledRotation;
     log.trace(
-        "Should apply scheduled rotation: (rotateScheduleIntervalMs: '{}', nextScheduledRotation:"
+        "Should apply scheduled rotation for topic-partition '{}':"
+            + " (rotateScheduleIntervalMs: '{}', nextScheduledRotation:"
             + " '{}', now: '{}')? {}",
+        tp,
         rotateScheduleIntervalMs,
         nextScheduledRotation,
         now,
         scheduledRotation
     );
-    return periodicRotation || scheduledRotation;
+    return scheduledRotation;
   }
 
   private void setNextScheduledRotation() {
@@ -402,8 +419,13 @@ public class TopicPartitionWriter {
       );
       if (log.isDebugEnabled()) {
         log.debug(
-            "Update scheduled rotation timer. Next rotation for {} will be at {}",
+            "Update scheduled rotation timer for topic-partition '{}': "
+                + "(rotateScheduleIntervalMs: '{}', nextScheduledRotation: '{}', now: '{}'). "
+                + "Next rotation will be at {}",
             tp,
+            rotateScheduleIntervalMs,
+            nextScheduledRotation,
+            now,
             new DateTime(nextScheduledRotation).withZone(timeZone).toString()
         );
       }
@@ -412,8 +434,9 @@ public class TopicPartitionWriter {
 
   private boolean rotateOnSize() {
     boolean messageSizeRotation = recordCount >= flushSize;
-    log.trace(
-        "Should apply size-based rotation (count {} >= flush size {})? {}",
+    log.trace("Should apply size-based rotation for topic-partition '{}':"
+            + " (count {} >= flush size {})? {}",
+        tp,
         recordCount,
         flushSize,
         messageSizeRotation

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -561,6 +561,167 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   }
 
   @Test
+  public void testWriteRecordsAfterScheduleRotationExpiryButNoResetShouldGoToSameFile()
+      throws Exception {
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.HOURS.toMillis(1))
+    );
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.MINUTES.toMillis(10))
+    );
+    setUp();
+
+    // Define the partitioner
+    TimeBasedPartitioner<?> partitioner = new TimeBasedPartitioner<>();
+    parsedConfig.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.DAYS.toMillis(1));
+    parsedConfig.put(
+        PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
+        MockedWallclockTimestampExtractor.class.getName());
+    partitioner.configure(parsedConfig);
+
+    MockTime time = ((MockedWallclockTimestampExtractor) partitioner.getTimestampExtractor()).time;
+
+    // Bring the clock to present.
+    time.sleep(SYSTEM.milliseconds());
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time,
+        null);
+
+    // sleep for 11 minutes after startup
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+
+    //send new records after ScheduleRotation is expired but not reset
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 3, 6);
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records.subList(0, 3), key, schema);
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // No records written to S3
+    topicPartitionWriter.write();
+    // 11 minutes
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+    // Records are written due to scheduled rotation
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+    long timestampFirst = time.milliseconds();
+
+    String encodedPartitionFirst = getTimebasedEncodedPartition(timestampFirst);
+
+    String dirPrefixFirst = partitioner.generatePartitionedPath(TOPIC, encodedPartitionFirst);
+    List<String> expectedFiles = new ArrayList<>();
+    for (int i : new int[]{0}) {
+      expectedFiles
+          .add(FileUtils.fileKeyToCommit(topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, extension,
+              ZERO_PAD_FMT));
+    }
+    verify(expectedFiles, 3, schema, records);
+  }
+
+  @Test
+  public void testWriteRecordsAfterCurrentScheduleRotationExpiryShouldGoToSameFile()
+      throws Exception {
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.HOURS.toMillis(1))
+    );
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.MINUTES.toMillis(10))
+    );
+    setUp();
+
+    // Define the partitioner
+    TimeBasedPartitioner<?> partitioner = new TimeBasedPartitioner<>();
+    parsedConfig.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.DAYS.toMillis(1));
+    parsedConfig.put(
+        PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG,
+        MockedWallclockTimestampExtractor.class.getName());
+    partitioner.configure(parsedConfig);
+
+    MockTime time = ((MockedWallclockTimestampExtractor) partitioner.getTimestampExtractor()).time;
+
+    // Bring the clock to present.
+    time.sleep(SYSTEM.milliseconds());
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time,
+        null);
+
+    // sleep for 11 minutes after startup
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+
+    topicPartitionWriter.write();
+    //send records after nextScheduledRotation is reset by topicPartitionWriter.write()
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 3, 6);
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records.subList(0, 3), key, schema);
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // No records written to S3
+    topicPartitionWriter.write();
+    long timestampFirst = time.milliseconds();
+
+    // 11 minutes
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+    // Records are written due to scheduled rotation
+    topicPartitionWriter.write();
+
+    //simulate idle loop and kafka calling put with no records
+    for (int i = 0; i < 5; i++) {
+      // sleep for 11 minutes after startup
+      time.sleep(TimeUnit.MINUTES.toMillis(11));
+      //nextScheduledRotation should be reset
+      topicPartitionWriter.write();
+    }
+
+    sinkRecords = createSinkRecords(records.subList(3, 6), key, schema, 3);
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // More records later
+    topicPartitionWriter.write();
+    long timestampLater = time.milliseconds();
+
+    // 11 minutes later, another scheduled rotation
+    time.sleep(TimeUnit.MINUTES.toMillis(11));
+
+    // Again the records are written due to scheduled rotation
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    String encodedPartitionFirst = getTimebasedEncodedPartition(timestampFirst);
+    String encodedPartitionLater = getTimebasedEncodedPartition(timestampLater);
+
+    String dirPrefixFirst = partitioner.generatePartitionedPath(TOPIC, encodedPartitionFirst);
+    List<String> expectedFiles = new ArrayList<>();
+    for (int i : new int[]{0}) {
+      expectedFiles
+          .add(FileUtils.fileKeyToCommit(topicsDir, dirPrefixFirst, TOPIC_PARTITION, i, extension,
+              ZERO_PAD_FMT));
+    }
+
+    String dirPrefixLater = partitioner.generatePartitionedPath(TOPIC, encodedPartitionLater);
+    for (int i : new int[]{3}) {
+      expectedFiles
+          .add(FileUtils.fileKeyToCommit(topicsDir, dirPrefixLater, TOPIC_PARTITION, i, extension,
+              ZERO_PAD_FMT));
+    }
+    verify(expectedFiles, 3, schema, records);
+  }
+
+  @Test
   public void testWriteRecordTimeBasedPartitionWallclockMockedWithScheduleRotation()
       throws Exception {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -563,7 +563,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testWriteRecordsAfterScheduleRotationExpiryButNoResetShouldGoToSameFile()
       throws Exception {
-    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.HOURS.toMillis(1))
@@ -588,8 +588,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     time.sleep(SYSTEM.milliseconds());
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time,
-        null);
+        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context, time);
 
     // sleep for 11 minutes after startup
     time.sleep(TimeUnit.MINUTES.toMillis(11));
@@ -627,7 +626,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @Test
   public void testWriteRecordsAfterCurrentScheduleRotationExpiryShouldGoToSameFile()
       throws Exception {
-    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "1000");
     localProps.put(
         S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
         String.valueOf(TimeUnit.HOURS.toMillis(1))
@@ -652,8 +651,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     time.sleep(SYSTEM.milliseconds());
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time,
-        null);
+        TOPIC_PARTITION, writerProvider, partitioner, connectorConfig, context, time);
 
     // sleep for 11 minutes after startup
     time.sleep(TimeUnit.MINUTES.toMillis(11));


### PR DESCRIPTION
## Problem
If there are no records in the buffer and no open files and 1000 new records are pushed to a topic at the same time then should these 1000 records be part of a single new file.
Currently, the task creates 2 new files (1 with 1st record and another with rest of the 999 records). This happens because we use the arrival of first record to determine that scheduled rotation has expired and reset the nextScheduledRotation causing a record with 1 file to roll.

## Solution
We should reset the nextScheduledRotation even if there are no records to commit and time has passed.

Merging https://github.com/confluentinc/kafka-connect-storage-cloud/pull/468 to 5.4.x here

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ X] yes
- [ ] no

##### If yes, where?
5.5.x, 10.0.x branches
GCS and AzureBlob sink connector



## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [X] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
