### PR TITLE
fix: removed x-amz-server-side-encryption to get SEE-C working

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -195,19 +195,10 @@ public class S3OutputStream extends PositionOutputStream {
     super.close();
   }
 
-  private ObjectMetadata newObjectMetadata() {
-    ObjectMetadata meta = new ObjectMetadata();
-    if (StringUtils.isNotBlank(ssea)) {
-      meta.setSSEAlgorithm(ssea);
-    }
-    return meta;
-  }
-
   private MultipartUpload newMultipartUpload() throws IOException {
     InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(
         bucket,
-        key,
-        newObjectMetadata()
+        key
     ).withCannedACL(cannedAcl);
 
     if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)


### PR DESCRIPTION
## Problem
SSE-C is not working due to ```x-amz-server-side-encryption``` header. See  #389 .

## Solution
Simple fix, just remove that header. S3 just do not support having  ```x-amz-server-side-encryption``` and ```x-amz-server-side-encryption-customer-algorithm``` set at the same time


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [X] yes
- [ ] no

## Test Strategy
I tested it in v5.5.7 that is the version that I am using in my cluster, but it is the same for all versions.