### PR TITLE
Introduces the concept for source topic in the TopicPartitionWritter

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -60,6 +60,8 @@ public class TopicPartitionWriter {
   private final Map<String, RecordWriter> writers;
   private final Map<String, Schema> currentSchemas;
   private final TopicPartition tp;
+  private TopicPartition sourceTp = null;
+  private boolean isTransformedPartition = false;
   private final S3Storage storage;
   private final Partitioner<?> partitioner;
   private final TimestampExtractor timestampExtractor;
@@ -168,6 +170,11 @@ public class TopicPartitionWriter {
 
     // Initialize scheduled rotation timer if applicable
     setNextScheduledRotation();
+  }
+
+  public void setSourceTopicPartition(TopicPartition tp) {
+    this.sourceTp = tp;
+    this.isTransformedPartition = true;
   }
 
   private enum State {
@@ -478,12 +485,20 @@ public class TopicPartitionWriter {
 
   private void pause() {
     log.trace("Pausing writer for topic-partition '{}'", tp);
-    context.pause(tp);
+    if (isTransformedPartition) {
+      context.pause(sourceTp);
+    } else {
+      context.pause(tp);
+    }
   }
 
   private void resume() {
     log.trace("Resuming writer for topic-partition '{}'", tp);
-    context.resume(tp);
+    if (isTransformedPartition) {
+      context.resume(sourceTp);
+    } else {
+      context.resume(tp);
+    }
   }
 
   private RecordWriter newWriter(SinkRecord record, String encodedPartition)


### PR DESCRIPTION
Whenever the destination topic is modified by any transformer, we loose the
hability to pause the original source topic, therefore it also checks against
isTransformedTopic when pausing/resuming topics during writes/flushes using the
record's original topic/partition.

This should fix any transform NPE that's happening.

## Problem


## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
