### PR TITLE
CCMSG-1531 Support null items within arrays with Parquet writer

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -24,10 +24,12 @@ import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.avro.AvroWriteSupport;
 import org.apache.parquet.hadoop.ParquetFileWriter;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.io.OutputFile;
@@ -36,6 +38,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
 
 public class ParquetRecordWriterProvider implements RecordWriterProvider<S3SinkConnectorConfig> {
   private static final Logger log = LoggerFactory.getLogger(ParquetRecordWriterProvider.class);
@@ -68,16 +72,27 @@ public class ParquetRecordWriterProvider implements RecordWriterProvider<S3SinkC
           try {
             log.info("Opening record writer for: {}", filename);
             org.apache.avro.Schema avroSchema = avroData.fromConnectSchema(schema);
-
             s3ParquetOutputFile = new S3ParquetOutputFile(storage, filename);
-            writer = AvroParquetWriter
-                    .<GenericRecord>builder(s3ParquetOutputFile)
+            AvroParquetWriter.Builder<GenericRecord> builder =
+                AvroParquetWriter.<GenericRecord>builder(s3ParquetOutputFile)
                     .withSchema(avroSchema)
                     .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
                     .withDictionaryEncoding(true)
                     .withCompressionCodec(storage.conf().parquetCompressionCodecName())
-                    .withPageSize(PAGE_SIZE)
-                    .build();
+                    .withPageSize(PAGE_SIZE);
+            if (schemaHasArrayOfOptionalItems(schema, /*seenSchemas=*/null)) {
+              // If the schema contains an array of optional items, then
+              // it is possible that the array may have null items during the
+              // writing process.  In this case, we set a flag so as not to
+              // incur a NullPointerException
+              log.debug(
+                  "Setting \"" + AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE
+                      + "\" to false because the schema contains an array "
+                      + "with optional items"
+              );
+              builder.config(AvroWriteSupport.WRITE_OLD_LIST_STRUCTURE, "false");
+            }
+            writer = builder.build();
           } catch (IOException e) {
             throw new ConnectException(e);
           }
@@ -112,6 +127,38 @@ public class ParquetRecordWriterProvider implements RecordWriterProvider<S3SinkC
         }
       }
     };
+  }
+
+  /**
+   * Check if any schema (or nested schema) is an array of optional items
+   * @param schema The shema to check
+   * @return 'true' if the schema contains an array with optional items.
+   */
+  /* VisibleForTesting */
+  public static boolean schemaHasArrayOfOptionalItems(Schema schema, Set<Schema> seenSchemas) {
+    // First, check for infinitely recursing schemas
+    if (seenSchemas == null) {
+      seenSchemas = new HashSet<>();
+    } else if (seenSchemas.contains(schema)) {
+      return false;
+    }
+    seenSchemas.add(schema);
+    switch (schema.type()) {
+      case STRUCT:
+        for (Field field : schema.fields()) {
+          if (schemaHasArrayOfOptionalItems(field.schema(), seenSchemas)) {
+            return true;
+          }
+        }
+        return false;
+      case MAP:
+        return schemaHasArrayOfOptionalItems(schema.valueSchema(), seenSchemas);
+      case ARRAY:
+        return schema.valueSchema().isOptional()
+            || schemaHasArrayOfOptionalItems(schema.valueSchema(), seenSchemas);
+      default:
+        return false;
+    }
   }
 
   private static class S3ParquetOutputFile implements OutputFile {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
@@ -683,12 +683,12 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
     conf.optionalItems = true;
     conf.nested = new SchemaConfig(
         "nested_schema",
-        /*regularItems=*/true,
-        /*optionalItems=*/true,
-        /*mapRegular=*/false,
-        /*mapOptional=*/false,
-        /*nested=*/null,
-        /*nestedArray=*/null
+        true,
+        true,
+        false,
+        false,
+        null,
+        null
     );
 
     Schema schema = conf.create();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
@@ -207,14 +207,6 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
   }
 
   /**
-   * Tests ParquetRecordWriterProvider::schemaHasArrayOfOptionalItems
-   */
-  @Test
-  public void testOptionalArrayItemCheck() {
-
-  }
-
-  /**
    * Test for parquet writer with null array item(s) arrays
    * @link https://github.com/confluentinc/kafka-connect-storage-cloud/issues/339
    * @throws Exception
@@ -614,6 +606,8 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
   }
 
   /**
+   * Tests ParquetRecordWriterProvider::schemaHasArrayOfOptionalItems()
+   *
    * Test permutations of schemas and schema nesting with and without optional array items
    * somewhere within the schema.
    */

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
@@ -617,11 +617,11 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
       for (int optionalItems = 0; optionalItems < 2; ++optionalItems) {
         for (int mapRegular = 0; mapRegular < 2; ++mapRegular) {
           for (int mapOptional = 0; mapOptional < 2; ++mapOptional) {
-            for (int has_nested = 0; has_nested < 2; ++has_nested) {
-              for (int has_nested_array = 0; has_nested_array < 2; ++has_nested_array) {
+            for (int hasNested = 0; hasNested < 2; ++hasNested) {
+              for (int hasNestedArray = 0; hasNestedArray < 2; ++hasNestedArray) {
                 SchemaConfig conf = new SchemaConfig();
                 SchemaConfig nested = null, nestedArray = null;
-                if (has_nested != 0) {
+                if (hasNested != 0) {
                     // Invert tests so as to hit in isolation
                     nested = new SchemaConfig(
                         "nested_schema",
@@ -633,7 +633,7 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
                         /*nestedArray=*/null
                     );
                 }
-                if (has_nested_array != 0) {
+                if (hasNestedArray != 0) {
                   // Invert tests so as to hit in isolation
                   nestedArray = new SchemaConfig(
                       "array_of_schema",
@@ -698,20 +698,20 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
       // We're going to alternate internal and external array elements as null
       boolean hasString = true;
       for (long offset = 0; offset < size; ++offset) {
-        LinkedList<String> optional_list = new LinkedList<>();
+        LinkedList<String> optionalList = new LinkedList<>();
         // Alternate edge and internal as null items
-        optional_list.add(hasString ? "item-1" : null);
-        optional_list.add(hasString ? null : "item-2");
-        optional_list.add(hasString ? "item-3" : null);
+        optionalList.add(hasString ? "item-1" : null);
+        optionalList.add(hasString ? null : "item-2");
+        optionalList.add(hasString ? "item-3" : null);
         Struct struct = new Struct(schema)
-            .put("optional_items", optional_list)
+            .put("optional_items", optionalList)
             .put("regular_items", ImmutableList.of("reg-1", "reg-2"))
             .put(
                 // Nested struct
                 "nested",
                 new Struct(schema.field("nested").schema())
                     // Nested option string array
-                    .put("optional_items", optional_list.clone())
+                    .put("optional_items", optionalList.clone())
                     // Nested regular string array
                     .put("regular_items", ImmutableList.of("reg-1", "reg-2"))
             );

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
@@ -534,41 +534,41 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
 
   class SchemaConfig {
     public String name;
-    public boolean optional_items = false;
-    public boolean regular_items = false;
-    public boolean map_regular = false;
-    public boolean map_optional = false;
+    public boolean optionalItems = false;
+    public boolean regularItems = false;
+    public boolean mapRegular = false;
+    public boolean mapOptional = false;
     public SchemaConfig nested = null;
-    public SchemaConfig nested_array = null;
+    public SchemaConfig nestedArray = null;
 
     public SchemaConfig() {}
 
     public SchemaConfig(
         String name,
-        boolean regular_items,
-        boolean optional_items,
-        boolean map_regular,
-        boolean map_optional,
+        boolean regularItems,
+        boolean optionalItems,
+        boolean mapRegular,
+        boolean mapOptional,
         SchemaConfig nested,
-        SchemaConfig nested_array
+        SchemaConfig nestedArray
     ) {
       this.name = name;
-      this.optional_items = optional_items;
-      this.regular_items = regular_items;
-      this.map_regular = map_regular;
-      this.map_optional = map_optional;
+      this.optionalItems = optionalItems;
+      this.regularItems = regularItems;
+      this.mapRegular = mapRegular;
+      this.mapOptional = mapOptional;
       this.nested = nested;
-      this.nested_array = nested_array;
+      this.nestedArray = nestedArray;
     }
 
     public boolean hasOptionalItems() {
-      if (optional_items || map_optional) {
+      if (optionalItems || mapOptional) {
         return true;
       }
       if (nested != null && nested.hasOptionalItems()) {
         return true;
       }
-      return nested_array != null && nested_array.hasOptionalItems();
+      return nestedArray != null && nestedArray.hasOptionalItems();
     }
 
     private Schema create() {
@@ -576,19 +576,19 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
       if (StringUtils.isNotBlank(name)) {
         builder.name(name);
       }
-      if (regular_items) {
+      if (regularItems) {
         builder.field("regular_items", SchemaBuilder.array(Schema.STRING_SCHEMA).build());
       }
-      if (optional_items) {
+      if (optionalItems) {
         builder.field("optional_items", SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build());
       }
-      if (map_regular) {
+      if (mapRegular) {
         builder.field("regular_map", SchemaBuilder.map(
             Schema.STRING_SCHEMA,
             SchemaBuilder.array(Schema.STRING_SCHEMA).build()
         ).build());
       }
-      if (map_optional) {
+      if (mapOptional) {
         builder.field("optional_map", SchemaBuilder.map(
             Schema.STRING_SCHEMA,
             SchemaBuilder.array(Schema.OPTIONAL_STRING_SCHEMA).build()
@@ -597,8 +597,8 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
       if (this.nested != null) {
         builder.field("nested", nested.create());
       }
-      if (this.nested_array != null) {
-        builder.field("nested_array", SchemaBuilder.array(nested_array.create()));
+      if (this.nestedArray != null) {
+        builder.field("nested_array", SchemaBuilder.array(nestedArray.create()));
       }
       return builder.build();
     }
@@ -613,55 +613,59 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
    */
   @Test
   public void testSchemaHasArrayOfOptionalItems() {
-    for (int regular_items = 0; regular_items < 2; ++regular_items) {
-      for (int optional_items = 0; optional_items < 2; ++optional_items) {
-        for (int map_regular = 0; map_regular < 2; ++map_regular) {
-          for (int map_optional = 0; map_optional < 2; ++map_optional) {
+    for (int regularItems = 0; regularItems < 2; ++regularItems) {
+      for (int optionalItems = 0; optionalItems < 2; ++optionalItems) {
+        for (int mapRegular = 0; mapRegular < 2; ++mapRegular) {
+          for (int mapOptional = 0; mapOptional < 2; ++mapOptional) {
             for (int has_nested = 0; has_nested < 2; ++has_nested) {
               for (int has_nested_array = 0; has_nested_array < 2; ++has_nested_array) {
                 SchemaConfig conf = new SchemaConfig();
-                SchemaConfig nested = null, nested_array = null;
+                SchemaConfig nested = null, nestedArray = null;
                 if (has_nested != 0) {
                     // Invert tests so as to hit in isolation
                     nested = new SchemaConfig(
                         "nested_schema",
-                        regular_items == 0,
-                        optional_items == 0,
-                        map_regular == 0,
-                        map_optional == 0,
+                        regularItems == 0,
+                        optionalItems == 0,
+                        mapRegular == 0,
+                        mapOptional == 0,
                         /*nested=*/ null,
-                        /*nested_array=*/null
+                        /*nestedArray=*/null
                     );
                 }
                 if (has_nested_array != 0) {
                   // Invert tests so as to hit in isolation
-                  nested_array = new SchemaConfig(
+                  nestedArray = new SchemaConfig(
                       "array_of_schema",
-                      regular_items == 0,
-                      optional_items == 0,
-                      map_regular == 0,
-                      map_optional == 0,
+                      regularItems == 0,
+                      optionalItems == 0,
+                      mapRegular == 0,
+                      mapOptional == 0,
                       /*nested=*/ null,
-                      /*nested_array=*/null
+                      /*nestedArray=*/null
                   );
                 }
                 conf.nested = new SchemaConfig(
                     "nested_schema",
-                    regular_items != 0,
-                    optional_items != 0,
-                    map_regular != 0,
-                    map_optional != 0,
+                    regularItems != 0,
+                    optionalItems != 0,
+                    mapRegular != 0,
+                    mapOptional != 0,
                     nested,
-                    nested_array
+                    nestedArray
                 );
                 Schema schema = conf.create();
                 if (schema.fields().size() == 0) {
                   // Base case of everything is false
                   continue;
                 }
-                boolean has_array_optional = ParquetRecordWriterProvider.schemaHasArrayOfOptionalItems(schema, null);
-                boolean should_have_array_optional = conf.hasOptionalItems();
-                assertEquals(has_array_optional, should_have_array_optional);
+                final boolean hasArrayOptional =
+                    ParquetRecordWriterProvider.schemaHasArrayOfOptionalItems(
+                      schema,
+                      /*seenSchemas=*/null
+                  );
+                final boolean shouldHaveArrayOptional = conf.hasOptionalItems();
+                assertEquals(hasArrayOptional, shouldHaveArrayOptional);
               }
             }
           }
@@ -675,16 +679,16 @@ public class DataWriterParquetTest extends TestWithMockedS3 {
       Set<TopicPartition> partitions
   ) {
     SchemaConfig conf = new SchemaConfig();
-    conf.regular_items = true;
-    conf.optional_items = true;
+    conf.regularItems = true;
+    conf.optionalItems = true;
     conf.nested = new SchemaConfig(
         "nested_schema",
-        /*regular_items=*/true,
-        /*optional_items=*/true,
-        /*map_regular=*/false,
-        /*map_optional=*/false,
+        /*regularItems=*/true,
+        /*optionalItems=*/true,
+        /*mapRegular=*/false,
+        /*mapOptional=*/false,
         /*nested=*/null,
-        /*nested_array=*/null
+        /*nestedArray=*/null
     );
 
     Schema schema = conf.create();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TestWithMockedS3.java
@@ -87,7 +87,9 @@ public class TestWithMockedS3 extends S3SinkConnectorTestBase {
   @Override
   public void tearDown() throws Exception {
     super.tearDown();
-    s3mock.shutdown(); // shutdown the Akka and HTTP frameworks to close all connections
+    if (s3mock != null) {
+      s3mock.shutdown(); // shutdown the Akka and HTTP frameworks to close all connections
+    }
   }
 
   public static List<S3ObjectSummary> listObjects(String bucket, String prefix, AmazonS3 s3) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -96,7 +96,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     format = new AvroFormat(storage);
 
     s3.createBucket(S3_TEST_BUCKET_NAME);
-    assertTrue(s3.doesBucketExist(S3_TEST_BUCKET_NAME));
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
 
     Format<S3SinkConnectorConfig, String> format = new AvroFormat(storage);
     writerProvider = format.getRecordWriterProvider();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -20,7 +20,6 @@ import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_ACCESS_KEY_ID_CO
 import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_SECRET_ACCESS_KEY_CONFIG;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FORMAT_CLASS_CONFIG;
-import static io.confluent.connect.storage.common.StorageCommonConfig.STORE_URL_CONFIG;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
@@ -29,9 +28,7 @@ import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_C
 import static org.junit.Assert.assertTrue;
 
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.AnonymousAWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
-import com.amazonaws.client.builder.AwsClientBuilder.EndpointConfiguration;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.GetObjectRequest;


### PR DESCRIPTION
## Problem

Optional array items may be null.  Parquet writer throws a NullPointerException when it comes across this situation.

Situation is described in detail in this issue:
  https://github.com/confluentinc/kafka-connect-storage-cloud/issues/339

## Solution

If a schema contains an array with optional items (String or otherwise), set the "parquet.avro.write-old-list-structure" flag in the AvroParquetWriter object to 'false', and thus the situation will be correctly handled.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
1. Test to verify that this flag will do as expected for a schema with an optionall array element (some set to null)
2. Test Extensive permutation of optional/non-optional arrays and nesting tests to assure that schemas with/without an array of optional item will be correctly recognized.


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
