### PR TITLE
Generalize the S3 retry mechanism via a simple wrapper class.

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/S3RetriableRecordWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/S3RetriableRecordWriter.java
@@ -1,0 +1,49 @@
+package io.confluent.connect.s3.format;
+
+import io.confluent.connect.s3.storage.IORecordWriter;
+import io.confluent.connect.storage.format.RecordWriter;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.io.IOException;
+
+import static io.confluent.connect.s3.util.S3ErrorUtils.throwConnectException;
+
+/**
+ * Wrapper class which may convert an IOException ito either a ConnectException
+ * or a RetriableException depending upon whether the exception is "retriable"
+ * as determined within `throwConnectException()`.
+ */
+public class S3RetriableRecordWriter implements RecordWriter {
+  private IORecordWriter writer;
+
+  public S3RetriableRecordWriter(IORecordWriter writer) {
+    this.writer = writer;
+  }
+
+  @Override
+  public void write(SinkRecord sinkRecord) {
+    try {
+      writer.write(sinkRecord);
+    } catch (IOException e) {
+      throwConnectException(e);
+    }
+  }
+
+  @Override
+  public void commit() {
+    try {
+      writer.commit();
+    } catch (IOException e) {
+      throwConnectException(e);
+    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      writer.close();
+    } catch (IOException e) {
+      throwConnectException(e);
+    }
+  }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -22,7 +22,6 @@ import org.apache.avro.file.CodecFactory;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -111,7 +111,7 @@ public class AvroRecordWriterProvider extends RecordViewSetter
         try {
           writer.close();
         } catch (IOException e) {
-          throw new ConnectException(e);
+          throwConnectException(e);
         }
       }
     };

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -20,7 +20,9 @@ import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.confluent.connect.s3.storage.IORecordWriter;
 import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
+import io.confluent.connect.s3.format.S3RetriableRecordWriter;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -64,26 +66,26 @@ public class JsonRecordWriterProvider extends RecordViewSetter
   @Override
   public RecordWriter getRecordWriter(final S3SinkConnectorConfig conf, final String filename) {
     try {
-      return new RecordWriter() {
-        final String adjustedFilename = getAdjustedFilename(recordView, filename, getExtension());
-        final S3OutputStream s3out = storage.create(adjustedFilename, true, JsonFormat.class);
-        final OutputStream s3outWrapper = s3out.wrapForCompression();
-        final JsonGenerator writer = mapper.getFactory()
-                                         .createGenerator(s3outWrapper)
-                                         .setRootValueSeparator(null);
+      return new S3RetriableRecordWriter(
+        new IORecordWriter() {
+          final String adjustedFilename = getAdjustedFilename(recordView, filename, getExtension());
+          final S3OutputStream s3out = storage.create(adjustedFilename, true, JsonFormat.class);
+          final OutputStream s3outWrapper = s3out.wrapForCompression();
+          final JsonGenerator writer = mapper.getFactory()
+            .createGenerator(s3outWrapper)
+            .setRootValueSeparator(null);
 
-        @Override
-        public void write(SinkRecord record) {
-          log.trace("Sink record with view {}: {}", recordView, record);
-          // headers need to be enveloped for json format
-          boolean envelop = recordView instanceof HeaderRecordView;
-          try {
+          @Override
+          public void write(SinkRecord record) throws IOException {
+            log.trace("Sink record with view {}: {}", recordView, record);
+            // headers need to be enveloped for json format
+            boolean envelop = recordView instanceof HeaderRecordView;
             Object value = recordView.getView(record, envelop);
             if (value instanceof Struct) {
               byte[] rawJson = converter.fromConnectData(
-                  record.topic(),
-                  recordView.getViewSchema(record, envelop),
-                  value
+                record.topic(),
+                recordView.getViewSchema(record, envelop),
+                value
               );
               s3outWrapper.write(rawJson);
               s3outWrapper.write(LINE_SEPARATOR_BYTES);
@@ -91,33 +93,23 @@ public class JsonRecordWriterProvider extends RecordViewSetter
               writer.writeObject(value);
               writer.writeRaw(LINE_SEPARATOR);
             }
-          } catch (IOException e) {
-            throwConnectException(e);
           }
-        }
 
-        @Override
-        public void commit() {
-          try {
+          @Override
+          public void commit() throws IOException {
             // Flush is required here, because closing the writer will close the underlying S3
             // output stream before committing any data to S3.
             writer.flush();
             s3out.commit();
             s3outWrapper.close();
-          } catch (IOException e) {
-            throwConnectException(e);
           }
-        }
 
-        @Override
-        public void close() {
-          try {
+          @Override
+          public void close() throws IOException {
             writer.close();
-          } catch (IOException e) {
-            throwConnectException(e);
           }
         }
-      };
+      );
     } catch (IOException e) {
       throwConnectException(e);
       // compiler can't see that the above method is always throwing an exception,

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
 import org.apache.kafka.connect.data.Struct;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.JsonConverter;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -115,7 +115,7 @@ public class JsonRecordWriterProvider extends RecordViewSetter
           try {
             writer.close();
           } catch (IOException e) {
-            throw new ConnectException(e);
+            throwConnectException(e);
           }
         }
       };

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -29,7 +29,6 @@ import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetFileWriter;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -104,7 +104,7 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
             writer.close();
           }
         } catch (IOException e) {
-          throw new ConnectException(e);
+          throwConnectException(e);
         }
       }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/IORecordWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/IORecordWriter.java
@@ -1,0 +1,17 @@
+package io.confluent.connect.s3.storage;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.io.IOException;
+
+/**
+ * Interface which duplicates RecordWriter, yet with
+ * IOException throwing signatures.
+ */
+public interface IORecordWriter {
+  void write(SinkRecord var1) throws IOException;
+
+  void close() throws IOException;
+
+  void commit() throws IOException;
+}


### PR DESCRIPTION
## Problem

Consolidte the catch/rethrow logic for AWS retriable exceptions by wrapping the anonymous format classes as they are created.  Wrapper is intentionally as close as possible to the call/throw sites rather than up another level (or more) in KeyValueHeaderRecordWriterProvider.

No behavioral changes should occur.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
