### PR TITLE
Fix regions list being one item of a list

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -853,7 +853,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   private static class RegionRecommender implements ConfigDef.Recommender {
     @Override
     public List<Object> validValues(String name, Map<String, Object> connectorConfigs) {
-      return Collections.singletonList(RegionUtils.getRegions());
+      return new ArrayList<>(RegionUtils.getRegions());
     }
 
     @Override


### PR DESCRIPTION
## Problem

validValues() returns singleton list of a list of 27 regions, making the single-selectable item a list of 27 items. It is impossible to set a region in CP due to this.

![image](https://user-images.githubusercontent.com/11234557/157132902-efeb0768-3b14-4843-a615-6f8d9504c030.png)

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
