### PR TITLE
CCMSG-1833 Remove the logging of sink record in TRACE message 

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -28,6 +28,7 @@ import io.confluent.connect.storage.format.RecordWriterProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -89,7 +90,8 @@ public class KeyValueHeaderRecordWriterProvider
         // keyWriter != null means writing keys is turned on
         if (keyWriter != null && sinkRecord.key() == null) {
           throw new DataException(
-              String.format("Key cannot be null for SinkRecord. Topic: %s", sinkRecord.topic())
+              String.format("Key cannot be null for SinkRecord: %s",
+                  sinkRecordToLoggableString(sinkRecord))
           );
         }
 
@@ -97,7 +99,8 @@ public class KeyValueHeaderRecordWriterProvider
         if (headerWriter != null
             && (sinkRecord.headers() == null || sinkRecord.headers().isEmpty())) {
           throw new DataException(
-              String.format("Headers cannot be null for SinkRecord. Topic: %s", sinkRecord.topic())
+              String.format("Headers cannot be null for SinkRecord: %s",
+                  sinkRecordToLoggableString(sinkRecord))
           );
         }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/avro/AvroRecordWriterProvider.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.s3.format.avro;
 
 import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
+import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 
 import io.confluent.connect.s3.storage.IORecordWriter;
 import io.confluent.connect.s3.format.S3RetriableRecordWriter;
@@ -76,7 +77,8 @@ public class AvroRecordWriterProvider extends RecordViewSetter
               writer.setCodec(CodecFactory.fromString(conf.getAvroCodec()));
               writer.create(avroSchema, s3out);
             }
-            log.trace("Sink record with view {}: {}", recordView, record);
+            log.trace("Sink record with view {}: {}", recordView,
+                sinkRecordToLoggableString(record));
             Object value = avroData.fromConnectData(schema, recordView.getView(record, false));
             // AvroData wraps primitive types so their schema can be included. We need to unwrap
             // NonRecordContainers to just their value to properly handle these types

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/bytearray/ByteArrayRecordWriterProvider.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.s3.format.bytearray;
 
 import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
+import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.storage.IORecordWriter;
@@ -68,7 +69,8 @@ public class ByteArrayRecordWriterProvider extends RecordViewSetter
 
           @Override
           public void write(SinkRecord record) throws IOException {
-            log.trace("Sink record with view {}: {}", recordView, record);
+            log.trace("Sink record with view {}: {}", recordView,
+                sinkRecordToLoggableString(record));
             byte[] bytes = converter.fromConnectData(record.topic(),
                 recordView.getViewSchema(record, false), recordView.getView(record, false));
             s3outWrapper.write(bytes);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonRecordWriterProvider.java
@@ -17,6 +17,7 @@ package io.confluent.connect.s3.format.json;
 
 import static io.confluent.connect.s3.util.S3ErrorUtils.throwConnectException;
 import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
+import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -78,7 +79,8 @@ public class JsonRecordWriterProvider extends RecordViewSetter
 
             @Override
             public void write(SinkRecord record) throws IOException {
-              log.trace("Sink record with view {}: {}", recordView, record);
+              log.trace("Sink record with view {}: {}", recordView,
+                  sinkRecordToLoggableString(record));
               // headers need to be enveloped for json format
               boolean envelop = recordView instanceof HeaderRecordView;
               Object value = recordView.getView(record, envelop);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/parquet/ParquetRecordWriterProvider.java
@@ -18,6 +18,7 @@
 package io.confluent.connect.s3.format.parquet;
 
 import static io.confluent.connect.s3.util.Utils.getAdjustedFilename;
+import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 
 import io.confluent.connect.avro.AvroData;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
@@ -100,7 +101,8 @@ public class ParquetRecordWriterProvider extends RecordViewSetter
               }
               writer = builder.build();
             }
-            log.trace("Sink record with view {}: {}", recordView, record);
+            log.trace("Sink record with view {}: {}", recordView,
+                sinkRecordToLoggableString(record));
             Object value = avroData.fromConnectData(schema, recordView.getView(record, true));
             writer.write((GenericRecord) value);
           }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
@@ -41,6 +41,12 @@ public class Utils {
     }
   }
 
+  /**
+   * Returns a safe string representation of the sink record that can be logged in the logs.
+   *
+   * @param sinkRecord the record
+   * @return the safe string representation that can be logged
+   */
   public static String sinkRecordToLoggableString(SinkRecord sinkRecord) {
     return "SinkRecord{kafkaOffset=" + sinkRecord.kafkaOffset() + ", topic='" + sinkRecord.topic()
         + "', kafkaPartition=" + sinkRecord.kafkaPartition() + "} ";

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/Utils.java
@@ -17,6 +17,7 @@
 package io.confluent.connect.s3.util;
 
 import io.confluent.connect.s3.format.RecordView;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 public class Utils {
 
@@ -40,4 +41,8 @@ public class Utils {
     }
   }
 
+  public static String sinkRecordToLoggableString(SinkRecord sinkRecord) {
+    return "SinkRecord{kafkaOffset=" + sinkRecord.kafkaOffset() + ", topic='" + sinkRecord.topic()
+        + "', kafkaPartition=" + sinkRecord.kafkaPartition() + "} ";
+  }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -85,6 +85,7 @@ import io.confluent.connect.storage.partitioner.TimestampExtractor;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
 import static io.confluent.connect.storage.partitioner.PartitionerConfig.PARTITION_FIELD_NAME_CONFIG;
 import static org.apache.kafka.common.utils.Time.SYSTEM;
@@ -1104,7 +1105,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, null,
         Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, sampleHeaders());
 
-    String exceptionMessage = String.format("Key cannot be null for SinkRecord. Topic: %s", faultyRecord.topic());
+    String exceptionMessage = String.format("Key cannot be null for SinkRecord: %s", sinkRecordToLoggableString(faultyRecord));
     testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false, false);
     tearDown(); // clear mock S3 port for follow up test
     // test with faulty being first in batch
@@ -1118,7 +1119,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
         Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, Collections.emptyList());
 
-    String exceptionMessage = String.format("Headers cannot be null for SinkRecord. Topic: %s", faultyRecord.topic());
+    String exceptionMessage = String.format("Headers cannot be null for SinkRecord: %s", sinkRecordToLoggableString(faultyRecord));
     testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false, false);
     tearDown(); // clear mock S3 port for follow up test
     // test with faulty being first in batch
@@ -1132,7 +1133,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     SinkRecord faultyRecord = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, "key",
         Schema.STRING_SCHEMA, recordValue, kafkaOffset, 0L, TimestampType.NO_TIMESTAMP_TYPE, null);
 
-    String exceptionMessage = String.format("Headers cannot be null for SinkRecord. Topic: %s", faultyRecord.topic());
+    String exceptionMessage = String.format("Headers cannot be null for SinkRecord: %s", sinkRecordToLoggableString(faultyRecord));
     testExceptionReportedToDLQ(faultyRecord, DataException.class, exceptionMessage, false, false);
     tearDown(); // clear mock S3 port for follow up test
     // test with faulty being first in batch


### PR DESCRIPTION
## Problem
SinkRecord was being logged in TRACE message exposing confidential data

## Solution
only log the topic+partition+offset for the record instead of contents

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
