### PR TITLE
Fix build by removing pinning of confluent-log4j dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -185,7 +185,7 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>confluent-log4j</artifactId>
-            <version>${confluent-log4j.version}</version>
+            <version>${confluent.log4j.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -183,12 +183,6 @@
             <artifactId>json-smart</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.confluent</groupId>
-            <artifactId>confluent-log4j</artifactId>
-            <version>${confluent.log4j.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.4</version>


### PR DESCRIPTION
## Problem
Build failing due to confluent-log4j was removed from `common` (https://github.com/confluentinc/common/pull/451). 

## Solution
confluent-log4j is already pinned in storage-common (https://github.com/confluentinc/kafka-connect-storage-common/blob/1b29e67590ffa74574b0ce7eef5e238ccb14f1e6/pom.xml#L73) 

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
Other connectors using storage-common and messed confluent-log4j.

## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
