### PR TITLE
CCMSG-1577 label change to compression level for s3 sink connector

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -445,7 +445,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           group,
           ++orderInGroup,
           Width.LONG,
-          "Compression type",
+          "Compression Level",
           COMPRESSION_LEVEL_VALIDATOR
       );
 


### PR DESCRIPTION
## Problem
Jira ticket : https://confluentinc.atlassian.net/browse/CCMSG-1577
The label for Compression Level config is incorrect in the S3 Sink connector for Confluent Platform


## Solution

In the S3 sink connector Confluent Platform the label for the config 's3.compression.level' is incorrectly set as 'Compression Type' . Look at the screen shot attached which shows how the config label looks in Confluent Platform.

We must rename that label to 'Compression Level'

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
