### PR TITLE
Write a lot of small files in s3 when there are two versions schema data in topic

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -72,6 +72,7 @@ public class TopicPartitionWriter {
   private final int flushSize;
   private final long rotateIntervalMs;
   private final long rotateScheduleIntervalMs;
+  private final boolean rotateMultipleSchema;
   private long nextScheduledRotation;
   private long currentOffset;
   private Long currentTimestamp;
@@ -144,6 +145,7 @@ public class TopicPartitionWriter {
     if (rotateScheduleIntervalMs > 0) {
       timeZone = DateTimeZone.forID(connectorConfig.getString(PartitionerConfig.TIMEZONE_CONFIG));
     }
+    rotateMultipleSchema = connectorConfig.getBoolean(S3SinkConnectorConfig.ROTATE_MULTIPLE_SCHEMA_CONFIG);
     timeoutMs = connectorConfig.getLong(S3SinkConnectorConfig.RETRY_BACKOFF_CONFIG);
     compatibility = StorageSchemaCompatibility.getCompatibility(
         connectorConfig.getString(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG));
@@ -228,6 +230,9 @@ public class TopicPartitionWriter {
         String encodedPartition;
         try {
           encodedPartition = partitioner.encodePartition(record, now);
+          if (!rotateMultipleSchema) {
+            encodedPartition = encodedPartition + fileDelim + valueSchema.version();
+          }
         } catch (PartitionException e) {
           if (reporter != null) {
             reporter.report(record, e);
@@ -379,7 +384,12 @@ public class TopicPartitionWriter {
   }
 
   private String getDirectoryPrefix(String encodedPartition) {
-    return partitioner.generatePartitionedPath(tp.topic(), encodedPartition);
+    String adjustedEncodedPartition = encodedPartition;
+    if (!rotateMultipleSchema) {
+      adjustedEncodedPartition =
+          adjustedEncodedPartition.substring(0, adjustedEncodedPartition.lastIndexOf(fileDelim));
+    }
+    return partitioner.generatePartitionedPath(tp.topic(), adjustedEncodedPartition);
   }
 
   private void nextState() {
@@ -505,7 +515,7 @@ public class TopicPartitionWriter {
     } else {
       long startOffset = startOffsets.get(encodedPartition);
       String prefix = getDirectoryPrefix(encodedPartition);
-      commitFile = fileKeyToCommit(prefix, startOffset);
+      commitFile = fileKeyToCommit(prefix, startOffset, encodedPartition);
       commitFiles.put(encodedPartition, commitFile);
     }
     return commitFile;
@@ -518,12 +528,14 @@ public class TopicPartitionWriter {
            : suffix;
   }
 
-  private String fileKeyToCommit(String dirPrefix, long startOffset) {
+  private String fileKeyToCommit(String dirPrefix, long startOffset, String encodedPartition) {
     String name = tp.topic()
                       + fileDelim
                       + tp.partition()
                       + fileDelim
                       + String.format(zeroPadOffsetFormat, startOffset)
+                      + (rotateMultipleSchema ? "" : fileDelim
+                      + encodedPartition.substring(encodedPartition.lastIndexOf(fileDelim) + 1))
                       + extension;
     return fileKey(topicsDir, dirPrefix, name);
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -26,6 +26,7 @@ import io.confluent.connect.s3.format.RecordViewSetter;
 import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
 import io.confluent.connect.s3.format.RecordViews.KeyRecordView;
 import io.confluent.connect.s3.format.json.JsonFormat;
+import io.confluent.connect.s3.format.parquet.ParquetFormat;
 import io.confluent.connect.s3.storage.CompressionType;
 import io.confluent.connect.storage.errors.PartitionException;
 import io.confluent.kafka.serializers.NonRecordContainer;
@@ -63,6 +64,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import io.confluent.common.utils.MockTime;
 import io.confluent.common.utils.Time;
@@ -165,6 +167,44 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   public void tearDown() throws Exception {
     super.tearDown();
     localProps.clear();
+  }
+
+  @Test
+  public void testWriteRecordRotateFileMultipleSchema() throws Exception {
+    localProps.put(S3SinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG, "2");
+    localProps.put(S3SinkConnectorConfig.ROTATE_MULTIPLE_SCHEMA_CONFIG, "false");
+    localProps.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, TimeBasedPartitioner.class.getName());
+    localProps.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'dt'=YYYY-MM-dd/'hh'=HH/'minute'=mm");
+    localProps.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, "900000");
+    localProps.put(PartitionerConfig.TIMEZONE_CONFIG, "UTC");
+    localProps.put(S3SinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "60000");
+    localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "10");
+    localProps.put(StorageCommonConfig.DIRECTORY_DELIM_CONFIG, "/");
+    localProps.put(StorageCommonConfig.FILE_DELIM_CONFIG, "+");
+    setUp();
+
+    // Define parquet format
+    Format<S3SinkConnectorConfig, String> format = new ParquetFormat(storage);
+    writerProvider = format.getRecordWriterProvider();
+    extension = writerProvider.getExtension();
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new TimeBasedPartitioner<>();
+    partitioner.configure(parsedConfig);
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+
+    // Mock sink records
+    List<SinkRecord> sinkRecords = createSinkRecordsWithTwoSchemas(10);
+    sinkRecords.stream().forEach(record -> topicPartitionWriter.buffer(record));
+
+    // Test actual write
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
+    List<String> actualFiles = summaries.stream().map(m -> m.getKey()).collect(Collectors.toList());
+    assertEquals(4, actualFiles.size());
   }
 
   @Test
@@ -1399,6 +1439,28 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
         null,
         headerWriterProvider
     );
+  }
+
+  private List<SinkRecord> createSinkRecordsWithTwoSchemas(int size) {
+    String key = "key";
+    List<Struct> records = createRecordBatch(createSchema(), size);
+    Schema newSchema = createNewSchema();
+    for (int i = 0; i < size; i ++) {
+      records.add(new Struct(newSchema)
+          .put("boolean", true)
+          .put("int", 12)
+          .put("long", 12L)
+          .put("float", 12.2f)
+          .put("double", 12.2)
+          .put("string", "def" + i));
+    }
+    Collections.shuffle(records);
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    for (int i = 0; i < records.size(); i++) {
+      sinkRecords.add(new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, records.get(i).schema(), records.get(i), i));
+    }
+    return sinkRecords;
   }
 
   private Struct createRecord(Schema schema, int ibase, float fbase) {


### PR DESCRIPTION

## Problem
https://github.com/confluentinc/kafka-connect-storage-cloud/issues/520
## Solution
Modify the encoded partition with schema version to support the different schema.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
