### PR TITLE
CCMSG-1974: CVE - remove dependency on slf4j-log4j and add dependency on sl4j-reload4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,12 @@
             <artifactId>connect-runtime</artifactId>
             <version>${kafka.version}</version>
             <scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.kafka</groupId>
@@ -170,7 +176,15 @@
                     <groupId>io.netty</groupId>
                     <artifactId>netty-codec</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-reload4j</artifactId>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
@@ -188,6 +202,10 @@
             <artifactId>hadoop-mapreduce-client-core</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-log4j12</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>


### PR DESCRIPTION
## Problem
CCMSG-1974: Vulnerable dependency "org.slf4j_slf4j-log4j12:1.7.25" for kafka-connect-storage-cloud:master-latest
CCMSG-1970: Vulnerable dependency "org.slf4j_slf4j-log4j12:1.7.26" for kafka-connect-storage-cloud:5.5.x-latest
CCMSG-1972: Vulnerable dependency "org.slf4j_slf4j-log4j12:1.7.26" for kafka-connect-storage-cloud:5.4.x-latest


## Solution
- Remove indirect dependency on slf4j-log4j12
- Add an explicit dependency on slf4j-reload4j
- Note: slf4j-reload4j version has been added to kafka-connect-storage-common


Removed all dependency on `slf4j-log4j12` for this repo:
```
➜  kafka-connect-storage-cloud git:(CCMSG-1972) mvn dependency:tree -Dincludes=org.slf4j:slf4j-log4j12
[INFO] --------------< io.confluent:kafka-connect-storage-cloud >--------------
[INFO] Building kafka-connect-storage-cloud 5.4.9-SNAPSHOT                [1/2]
[INFO] --------------------------------[ pom ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ kafka-connect-storage-cloud ---
[INFO]
[INFO] -------------------< io.confluent:kafka-connect-s3 >--------------------
[INFO] Building kafka-connect-s3 5.4.9-SNAPSHOT                           [2/2]
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:3.0.2:tree (default-cli) @ kafka-connect-s3 ---
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-storage-cloud 5.4.9-SNAPSHOT:
[INFO]
[INFO] kafka-connect-storage-cloud ........................ SUCCESS [  4.640 s]
[INFO] kafka-connect-s3 ................................... SUCCESS [  0.613 s]
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
Release as patch version for all versions 5.4.x and above