### PR TITLE
To fix the CVE CCDB-4985 in kafka-connect-databricks-delta-lake

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -36,7 +36,7 @@
     </description>
 
     <properties>
-        <aws.version>1.11.725</aws.version>
+        <aws.version>1.12.270</aws.version>
         <s3mock.version>0.1.5</s3mock.version>
         <apache.httpclient.version>4.5.9</apache.httpclient.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>

--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -65,6 +65,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk-s3</artifactId>
+            <version>${aws.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
-                      <argLine>@{argLine} -Djava.awt.headless=true -Xmx1024m -XX:MaxPermSize=512m</argLine>
+                      <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
                       <reuseForks>false</reuseForks>
                       <forkCount>1</forkCount>
                   </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -175,11 +175,10 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
-                      <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
-                      <reuseForks>true</reuseForks>
-                      <forkCount>0</forkCount>
+                      <argLine>@{argLine} -Djava.awt.headless=true -Xmx1024m -XX:MaxPermSize=512m</argLine>
+                      <reuseForks>false</reuseForks>
+                      <forkCount>1</forkCount>
                   </configuration>
-                  <!--This commit has been causing surefire to fail. https://github.com/confluentinc/kafka-connect-storage-cloud/pull/460-->
               </plugin>
               <plugin>
                   <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
                   <configuration>
                       <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
                       <reuseForks>false</reuseForks>
-                      <forkCount>1</forkCount>
+                      <forkCount>2</forkCount>
                   </configuration>
               </plugin>
               <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,7 @@
               <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
+                  <version>2.22.2</version>
                   <configuration>
                       <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
                       <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
-                      <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
+                      <argLine>@{argLine} -Djava.awt.headless=true -Xmx1024m -XX:MaxPermSize=512m</argLine>
                       <reuseForks>false</reuseForks>
                       <forkCount>1</forkCount>
                   </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -178,7 +178,7 @@
                   <configuration>
                       <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
                       <reuseForks>false</reuseForks>
-                      <forkCount>2</forkCount>
+                      <forkCount>1</forkCount>
                   </configuration>
               </plugin>
               <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -174,7 +174,6 @@
               <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
-                  <version>2.22.2</version>
                   <configuration>
                       <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
                       <reuseForks>false</reuseForks>

--- a/pom.xml
+++ b/pom.xml
@@ -175,10 +175,11 @@
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-surefire-plugin</artifactId>
                   <configuration>
-                      <argLine>@{argLine} -Djava.awt.headless=true -Xmx1024m -XX:MaxPermSize=512m</argLine>
-                      <reuseForks>false</reuseForks>
-                      <forkCount>1</forkCount>
+                      <argLine>@{argLine} -Djava.awt.headless=true -XX:MaxPermSize=512m</argLine>
+                      <reuseForks>true</reuseForks>
+                      <forkCount>0</forkCount>
                   </configuration>
+                  <!--This commit has been causing surefire to fail. https://github.com/confluentinc/kafka-connect-storage-cloud/pull/460-->
               </plugin>
               <plugin>
                   <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Problem
The CVE in kafka-connect-databricks-delta-lake  : https://confluentinc.atlassian.net/browse/CCDB-4985
Needs the version of aws-java-sdk bumped up.
This library derives from kafka-connect-s3, which comes from this repository.
The problem is this `pom.xml` file does not contain a version entry for aws-java-sdk and therefore cannot be pinned in the dependent pom in kafka-connect-databricks-delta-lake.



## Solution
Add the version entry so that it can be overridden and pint merge to the latest.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
