### PR TITLE
CCMSG-2014: Upgrade storage-common-parent version to remove parquet vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.11</version>
+        <version>11.0.12</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem
[CCMSG-2014](https://confluentinc.atlassian.net/browse/CCMSG-2014): Vulnerable dependency "parquet:parquet-format-structures" for kafka-connect-storage-cloud:master-latest

## Solution
- Updated parquet version in kafka-connect-storage-common
- Use latest kafka-connect-storage-common with updated parquet version as parent

```
➜  kafka-connect-storage-cloud git:(10.0.x) ✗ mvn dependency:tree | grep parquet
[INFO] |  +- org.apache.parquet:parquet-column:jar:1.12.3:compile
[INFO] |  |  +- org.apache.parquet:parquet-common:jar:1.12.3:compile
[INFO] |  |  |  \- org.apache.parquet:parquet-format-structures:jar:1.12.3:compile
[INFO] |  |  +- org.apache.parquet:parquet-encoding:jar:1.12.3:compile
[INFO] |  \- org.apache.parquet:parquet-avro:jar:1.12.3:compile
[INFO] |     \- org.apache.parquet:parquet-hadoop:jar:1.12.3:compile
[INFO] +- org.apache.parquet:parquet-tools:jar:1.11.1:test
[INFO] |  +- org.apache.parquet:parquet-column:jar:1.12.3:compile
[INFO] |  |  +- org.apache.parquet:parquet-common:jar:1.12.3:compile
[INFO] |  |  |  \- org.apache.parquet:parquet-format-structures:jar:1.12.3:compile
[INFO] |  |  \- org.apache.parquet:parquet-encoding:jar:1.12.3:compile
[INFO] |  \- org.apache.parquet:parquet-avro:jar:1.12.3:compile
[INFO] |     \- org.apache.parquet:parquet-hadoop:jar:1.12.3:compile
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [X] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
Release as minor versions