### PR TITLE
Support custom keystore

### DIFF
--- a/kafka-connect-s3/config/quickstart-s3.properties
+++ b/kafka-connect-s3/config/quickstart-s3.properties
@@ -34,3 +34,6 @@ schema.compatibility=NONE
 #path.format=
 #locale=
 #timezone=
+#ssl.truststore.location=
+#ssl.truststore.password=
+#ssl.truststore.type=

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -43,6 +43,7 @@ import java.util.stream.Collectors;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.format.parquet.ParquetFormat;
 import io.confluent.connect.s3.util.S3ProxyConfig;
+import io.confluent.connect.s3.util.TrustStoreConfig;
 import io.confluent.connect.s3.util.Version;
 import io.confluent.connect.storage.Storage;
 import io.confluent.connect.storage.common.util.StringUtils;
@@ -54,6 +55,7 @@ import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PROXY_URL_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_RETRY_BACKOFF_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_RETRY_MAX_BACKOFF_TIME_MS;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SSL_TRUSTSTORE_LOCATION_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.WAN_MODE_CONFIG;
 
 /**
@@ -142,10 +144,13 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
           .withProxyPassword(proxyConfig.pass());
     }
     clientConfiguration.withUseExpectContinue(config.useExpectContinue());
-
+    if (StringUtils.isNotBlank(config.getString(SSL_TRUSTSTORE_LOCATION_CONFIG))) {
+      TrustStoreConfig trustStoreConfig = new TrustStoreConfig(config);
+      clientConfiguration.getApacheHttpClientConfig()
+          .setSslSocketFactory(trustStoreConfig.getSslSocketFactory());
+    }
     return clientConfiguration;
   }
-
 
   /**
    * Creates a retry policy, based on full jitter backoff strategy

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/TrustStoreConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/TrustStoreConfig.java
@@ -53,11 +53,11 @@ public class TrustStoreConfig {
       String typeValue = config.getString(SSL_TRUSTSTORE_TYPE_CONFIG);
       type = StringUtils.isNotBlank(typeValue)
           ? typeValue.toLowerCase().trim()
-          : KeyStore.getDefaultType().toString();
+          : KeyStore.getDefaultType();
       Password passwordValue = config.getPassword(SSL_TRUSTSTORE_PASSWORD_CONFIG);
       password = StringUtils.isNotBlank(passwordValue.value())
           ? passwordValue.value()
-          : new Password(null).toString();
+          : null;
       log.debug("Using Custom trust store {}", this);
     } catch (Exception e) {
       throw new ConfigException(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/TrustStoreConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/TrustStoreConfig.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.util;
+
+import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.types.Password;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.http.conn.ssl.SdkTLSSocketFactory;
+
+import java.io.FileInputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.KeyStore;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+
+import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.storage.common.util.StringUtils;
+
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SSL_TRUSTSTORE_LOCATION_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SSL_TRUSTSTORE_PASSWORD_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SSL_TRUSTSTORE_TYPE_CONFIG;
+
+public class TrustStoreConfig {
+  private static final Logger log = LoggerFactory.getLogger(TrustStoreConfig.class);
+
+  private final Path trustStoreLocation;
+  private final String password;
+  private final String type;
+
+  public TrustStoreConfig(S3SinkConnectorConfig config) {
+    try {
+      trustStoreLocation = Paths.get(
+          config.getString(SSL_TRUSTSTORE_LOCATION_CONFIG).trim());
+      String typeValue = config.getString(SSL_TRUSTSTORE_TYPE_CONFIG);
+      type = StringUtils.isNotBlank(typeValue)
+          ? typeValue.toLowerCase().trim()
+          : KeyStore.getDefaultType().toString();
+      Password passwordValue = config.getPassword(SSL_TRUSTSTORE_PASSWORD_CONFIG);
+      password = StringUtils.isNotBlank(passwordValue.value())
+          ? passwordValue.value()
+          : new Password(null).toString();
+      log.debug("Using Custom trust store {}", this);
+    } catch (Exception e) {
+      throw new ConfigException(
+          SSL_TRUSTSTORE_LOCATION_CONFIG,
+          config.getString(SSL_TRUSTSTORE_LOCATION_CONFIG),
+          e.toString());
+    }
+  }
+
+  public ConnectionSocketFactory getSslSocketFactory() {
+    try {
+      char[] password = this.password.toCharArray();
+      String keyStoreFile = this.trustStoreLocation.toAbsolutePath().toString();
+      KeyStore keyStore = KeyStore.getInstance(this.type);
+
+      try (FileInputStream fis = new FileInputStream(keyStoreFile)) {
+        keyStore.load(fis, password);
+      }
+      TrustManagerFactory tmf;
+      tmf = TrustManagerFactory.getInstance(TrustManagerFactory.getDefaultAlgorithm());
+      tmf.init(keyStore);
+      TrustManager[] tms = tmf.getTrustManagers();
+      SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, tms, null);
+      SdkTLSSocketFactory sslSocketFactory = new SdkTLSSocketFactory(sslContext, null);
+      return sslSocketFactory;
+    } catch (Exception e) {
+      throw new ConfigException(
+          SSL_TRUSTSTORE_LOCATION_CONFIG,
+          this.trustStoreLocation,
+          e.toString());
+    }
+  }
+
+  public Path trustStoreLocation() {
+    return trustStoreLocation;
+  }
+
+  public String type() {
+    return type;
+  }
+
+  public String password() {
+    return password;
+  }
+
+  @Override
+  public String toString() {
+    return "TrustStoreConfig{"
+        + "trustStoreLocation=" + trustStoreLocation.toAbsolutePath().toString()
+        + ", type='" + type + '\''
+        + ", password='*****************'"
+        + '}';
+  }
+}


### PR DESCRIPTION
## Problem
Complementary PR for the Issue [Support for custom truststore at Connector level #546](https://github.com/confluentinc/kafka-connect-storage-cloud/issues/546)

## Solution
Add the following connector settings:
```
ssl.truststore.location
ssl.truststore.password
ssl.truststore.type
```
Via this settings will be possible include additional certificates to the trustchain by storing them in a keystore file, so that private CA root certificates and Self-signed certificates are supported.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ x] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
Merge into master
<!-- If you are reverting or rolling back, is it safe? --> 
