### PR TITLE
CCMSG 1074 - Allow S3 sink to use assume role with aws.access.key.id

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -772,12 +772,20 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     return CannedAclValidator.ACLS_BY_HEADER_VALUE.get(getString(ACL_CANNED_CONFIG));
   }
 
+  public String awsAccessKeyId() {
+    return getString(AWS_ACCESS_KEY_ID_CONFIG);
+  }
+
+  public Password awsSecretKeyId() {
+    return getPassword(AWS_SECRET_ACCESS_KEY_CONFIG);
+  }
+
   public int getPartSize() {
     return getInt(PART_SIZE_CONFIG);
   }
 
   @SuppressWarnings("unchecked")
-  public AWSCredentialsProvider getCredentialsProvider(S3SinkConnectorConfig config) {
+  public AWSCredentialsProvider getCredentialsProvider() {
     try {
       AWSCredentialsProvider provider = ((Class<? extends AWSCredentialsProvider>)
           getClass(S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG)).newInstance();
@@ -788,15 +796,13 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
             CREDENTIALS_PROVIDER_CONFIG_PREFIX.length()
         ));
 
-        configs.put(AWS_ACCESS_KEY_ID_CONFIG,
-                config.getString(AWS_ACCESS_KEY_ID_CONFIG));
-        configs.put(AWS_SECRET_ACCESS_KEY_CONFIG,
-                config.getPassword(AWS_SECRET_ACCESS_KEY_CONFIG).value()
-        );
+        configs.put(AWS_ACCESS_KEY_ID_CONFIG, awsAccessKeyId());
+        configs.put(AWS_SECRET_ACCESS_KEY_CONFIG, awsSecretKeyId().value());
+
         ((Configurable) provider).configure(configs);
       } else {
-        final String accessKeyId = config.getString(AWS_ACCESS_KEY_ID_CONFIG);
-        final String secretKey = config.getPassword(AWS_SECRET_ACCESS_KEY_CONFIG).value();
+        final String accessKeyId = awsAccessKeyId();
+        final String secretKey = awsSecretKeyId().value();
         if (StringUtils.isNotBlank(accessKeyId) && StringUtils.isNotBlank(secretKey)) {
           BasicAWSCredentials basicCredentials = new BasicAWSCredentials(accessKeyId, secretKey);
           provider = new AWSStaticCredentialsProvider(basicCredentials);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -787,14 +787,17 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
         configs.remove(CREDENTIALS_PROVIDER_CLASS_CONFIG.substring(
             CREDENTIALS_PROVIDER_CONFIG_PREFIX.length()
         ));
+
+        configs.put(AWS_ACCESS_KEY_ID_CONFIG,
+                config.getString(AWS_ACCESS_KEY_ID_CONFIG));
+        configs.put(AWS_SECRET_ACCESS_KEY_CONFIG,
+                config.getPassword(AWS_SECRET_ACCESS_KEY_CONFIG).value()
+        );
         ((Configurable) provider).configure(configs);
       } else {
         final String accessKeyId = config.getString(AWS_ACCESS_KEY_ID_CONFIG);
         final String secretKey = config.getPassword(AWS_SECRET_ACCESS_KEY_CONFIG).value();
         if (StringUtils.isNotBlank(accessKeyId) && StringUtils.isNotBlank(secretKey)) {
-          /*log.info("Returning new credentials provider using the access key id and "
-                  + "the secret access key that were directly supplied through the connector's "
-                  + "configuration"); */
           BasicAWSCredentials basicCredentials = new BasicAWSCredentials(accessKeyId, secretKey);
           provider = new AWSStaticCredentialsProvider(basicCredentials);
         }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -66,8 +66,6 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
   private String roleSessionName;
 
   private BasicAWSCredentials basicCredentials;
-  private String accessKeyId;
-  private String secretKey;
 
   @Override
   public void configure(Map<String, ?> configs) {
@@ -89,8 +87,7 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
     if (basicCredentials != null) {
       return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
               .withStsClient(AWSSecurityTokenServiceClientBuilder.standard()
-                 .withCredentials(new AWSStaticCredentialsProvider(
-                         new BasicAWSCredentials(accessKeyId, secretKey))).build())
+                 .withCredentials(new AWSStaticCredentialsProvider(basicCredentials)).build())
               .withExternalId(roleExternalId)
               .build()
               .getCredentials();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -73,8 +73,8 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
     roleArn = config.getString(ROLE_ARN_CONFIG);
     roleExternalId = config.getString(ROLE_EXTERNAL_ID_CONFIG);
     roleSessionName = config.getString(ROLE_SESSION_NAME_CONFIG);
-    final String accessKeyId = config.getString(AWS_ACCESS_KEY_ID_CONFIG);
-    final String secretKey = config.getPassword(AWS_SECRET_ACCESS_KEY_CONFIG).value();
+    final String accessKeyId = (String) configs.get(AWS_ACCESS_KEY_ID_CONFIG);
+    final String secretKey = (String) configs.get(AWS_SECRET_ACCESS_KEY_CONFIG);
     if (StringUtils.isNotBlank(accessKeyId) && StringUtils.isNotBlank(secretKey)) {
       basicCredentials = new BasicAWSCredentials(accessKeyId, secretKey);
     } else {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -17,14 +17,20 @@
 package io.confluent.connect.s3.auth;
 
 import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClientBuilder;
+import io.confluent.connect.storage.common.util.StringUtils;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
 
 import java.util.Map;
+
+import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_ACCESS_KEY_ID_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_SECRET_ACCESS_KEY_CONFIG;
 
 /**
  * AWS credentials provider that uses the AWS Security Token Service to assume a Role and create a
@@ -59,21 +65,42 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
   private String roleExternalId;
   private String roleSessionName;
 
+  private BasicAWSCredentials basicCredentials;
+  private String accessKeyId;
+  private String secretKey;
+
   @Override
   public void configure(Map<String, ?> configs) {
     AbstractConfig config = new AbstractConfig(STS_CONFIG_DEF, configs);
     roleArn = config.getString(ROLE_ARN_CONFIG);
     roleExternalId = config.getString(ROLE_EXTERNAL_ID_CONFIG);
     roleSessionName = config.getString(ROLE_SESSION_NAME_CONFIG);
+    final String accessKeyId = config.getString(AWS_ACCESS_KEY_ID_CONFIG);
+    final String secretKey = config.getPassword(AWS_SECRET_ACCESS_KEY_CONFIG).value();
+    if (StringUtils.isNotBlank(accessKeyId) && StringUtils.isNotBlank(secretKey)) {
+      basicCredentials = new BasicAWSCredentials(accessKeyId, secretKey);
+    } else {
+      basicCredentials = null;
+    }
   }
 
   @Override
   public AWSCredentials getCredentials() {
-    return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
-        .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
-        .withExternalId(roleExternalId)
-        .build()
-        .getCredentials();
+    if (basicCredentials != null) {
+      return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
+              .withStsClient(AWSSecurityTokenServiceClientBuilder.standard()
+                 .withCredentials(new AWSStaticCredentialsProvider(
+                         new BasicAWSCredentials(accessKeyId, secretKey))).build())
+              .withExternalId(roleExternalId)
+              .build()
+              .getCredentials();
+    } else {
+      return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
+            .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
+            .withExternalId(roleExternalId)
+            .build()
+            .getCredentials();
+    }
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -172,7 +172,7 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
   protected AWSCredentialsProvider newCredentialsProvider(S3SinkConnectorConfig config) {
     log.info("Returning new credentials provider based on the configured "
            + "credentials provider class");
-    return config.getCredentialsProvider(config);
+    return config.getCredentialsProvider();
   }
 
   @Override

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -19,8 +19,6 @@ import com.amazonaws.ClientConfiguration;
 import com.amazonaws.PredefinedClientConfigurations;
 import com.amazonaws.SdkClientException;
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.AWSStaticCredentialsProvider;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.client.builder.AwsClientBuilder;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.retry.PredefinedBackoffStrategies;
@@ -47,8 +45,6 @@ import io.confluent.connect.s3.util.Version;
 import io.confluent.connect.storage.Storage;
 import io.confluent.connect.storage.common.util.StringUtils;
 
-import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_ACCESS_KEY_ID_CONFIG;
-import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_SECRET_ACCESS_KEY_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.REGION_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PROXY_URL_CONFIG;
@@ -174,18 +170,9 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ObjectListing> 
   }
 
   protected AWSCredentialsProvider newCredentialsProvider(S3SinkConnectorConfig config) {
-    final String accessKeyId = config.getString(AWS_ACCESS_KEY_ID_CONFIG);
-    final String secretKey = config.getPassword(AWS_SECRET_ACCESS_KEY_CONFIG).value();
-    if (StringUtils.isNotBlank(accessKeyId) && StringUtils.isNotBlank(secretKey)) {
-      log.info("Returning new credentials provider using the access key id and "
-          + "the secret access key that were directly supplied through the connector's "
-          + "configuration");
-      BasicAWSCredentials basicCredentials = new BasicAWSCredentials(accessKeyId, secretKey);
-      return new AWSStaticCredentialsProvider(basicCredentials);
-    }
-    log.info(
-        "Returning new credentials provider based on the configured credentials provider class");
-    return config.getCredentialsProvider();
+    log.info("Returning new credentials provider based on the configured "
+           + "credentials provider class");
+    return config.getCredentialsProvider(config);
   }
 
   @Override

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -218,7 +218,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     );
     connectorConfig = new S3SinkConnectorConfig(properties);
 
-    AWSCredentialsProvider credentialsProvider = connectorConfig.getCredentialsProvider();
+    AWSCredentialsProvider credentialsProvider = connectorConfig.getCredentialsProvider(connectorConfig);
 
     assertEquals(ACCESS_KEY_VALUE, credentialsProvider.getCredentials().getAWSAccessKeyId());
     assertEquals(SECRET_KEY_VALUE, credentialsProvider.getCredentials().getAWSSecretKey());
@@ -246,7 +246,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     connectorConfig = new S3SinkConnectorConfig(properties);
 
     AwsAssumeRoleCredentialsProvider credentialsProvider =
-        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider();
+        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider(connectorConfig);
   }
 
   @Test
@@ -279,7 +279,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     );
 
     connectorConfig = new S3SinkConnectorConfig(properties);
-    assertThrows("are mandatory configuration properties", ConfigException.class, () -> connectorConfig.getCredentialsProvider());
+    assertThrows("are mandatory configuration properties", ConfigException.class, () -> connectorConfig.getCredentialsProvider(connectorConfig));
   }
 
   @Test
@@ -304,7 +304,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     connectorConfig = new S3SinkConnectorConfig(properties);
 
     AwsAssumeRoleCredentialsProvider credentialsProvider =
-        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider();
+        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider(connectorConfig);
 
     assertThrows("Missing required configuration", ConfigException.class, () -> credentialsProvider.configure(properties));
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -218,7 +218,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     );
     connectorConfig = new S3SinkConnectorConfig(properties);
 
-    AWSCredentialsProvider credentialsProvider = connectorConfig.getCredentialsProvider(connectorConfig);
+    AWSCredentialsProvider credentialsProvider = connectorConfig.getCredentialsProvider();
 
     assertEquals(ACCESS_KEY_VALUE, credentialsProvider.getCredentials().getAWSAccessKeyId());
     assertEquals(SECRET_KEY_VALUE, credentialsProvider.getCredentials().getAWSSecretKey());
@@ -246,7 +246,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     connectorConfig = new S3SinkConnectorConfig(properties);
 
     AwsAssumeRoleCredentialsProvider credentialsProvider =
-        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider(connectorConfig);
+        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider();
   }
 
   @Test
@@ -279,7 +279,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     );
 
     connectorConfig = new S3SinkConnectorConfig(properties);
-    assertThrows("are mandatory configuration properties", ConfigException.class, () -> connectorConfig.getCredentialsProvider(connectorConfig));
+    assertThrows("are mandatory configuration properties", ConfigException.class, () -> connectorConfig.getCredentialsProvider());
   }
 
   @Test
@@ -304,7 +304,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     connectorConfig = new S3SinkConnectorConfig(properties);
 
     AwsAssumeRoleCredentialsProvider credentialsProvider =
-        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider(connectorConfig);
+        (AwsAssumeRoleCredentialsProvider) connectorConfig.getCredentialsProvider();
 
     assertThrows("Missing required configuration", ConfigException.class, () -> credentialsProvider.configure(properties));
   }


### PR DESCRIPTION
## Problem
Allow S3 sink to use assume role with aws.access.key.id

## Solution
when the connector uses aws.access.key.id it defaults to the BasicAWSCredential ignoring the assume role configs.
As part of solution, I hve introduced a check to find out which Provider has been configured by customer and instantiate appropriate provider.

Also, customer doesn't have to keep creds and roles info in .aws/credentials file now for Assumed role because 
we are creating StsClient with configured aws.access.key.id and aws.secret.access.key. If aws.access.key.id and aws.secret.access.key are not configured in connector, default stsclient will look for creds in aws/credential file. 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

Steps to test Assume Role :

1-  AWS account-1 (pooja-aws-devel)
2- Log into to the AWS management web console for the DEVEL account.
3- Create a test bucket ex.confluent-test-2 
4- Create a policy for the bucket in Homepage -> IAM -> Policies and Save policy. Ex.  read-write-pooja-bucket
5-  Create a role for the bucket. Roles -> Another AWS account -> Enter the other AWS Account ID: 596201386539(pooja-aws) . Use the previously created policy, ex. read-write-pooja-bucket. Save the role. ex. UpdatePoojaBucket and a new role will get created with `arn:aws:iam::596404860876:role/UpdatePoojaBucket` 
6-Login to another account (pooja-aws) Accont Id : 596404860876
7- Create a resource group under staging [Pooja-CLFT]. Homepage -> IAM -> Groups.
8-After creating, specify a custom policy. Permissions tab -> Inline Policies -> Create Group Policy. Policy name, ex: allow-assume-S3-role-in-pooja-devel . Use the pooja-aws-devel account id.
Inline Policy : `{
  “Version”: “2012-10-17”,
  “Statement”: {
    “Effect”: “Allow”,
    "Action": "sts:AssumeRole",
    “Resource”: “arn:aws:iam:: 037803949979:role/UpdateDanielBucket”
  }
}`

9-Add a test user to the pooja-aws account and add the user to the Pooja-CLFT.
10- Use the generated access_key and secret_access in connector config

Create a S3sink connector using following configs, it will push the data from data_4 topic to confluent-test-2 bucket:

`{
  "name": "S3SinkConnectorConnector_0",
  "config": {
    "s3.credentials.provider.sts.role.arn": "arn:aws:iam::596404860876:role/UpdatePoojaBucket",
    "s3.credentials.provider.sts.role.session.name": "session",
    "key.converter.schemas.enable": "false",
    "s3.credentials.provider.sts.role.external.id": "5544",
    "value.converter.schemas.enable": "false",
    "schemas.enable": "false",
    "name": "S3SinkConnectorConnector_0",
    "connector.class": "io.confluent.connect.s3.S3SinkConnector",
    "tasks.max": "1",
    "key.converter": "org.apache.kafka.connect.converters.ByteArrayConverter",
    "value.converter": "org.apache.kafka.connect.json.JsonConverter",
    "topics": "data_4",
    "format.class": "io.confluent.connect.s3.format.json.JsonFormat",
    "flush.size": "1",
    "s3.bucket.name": "confluent-test-2",
    "s3.region": "us-east-2",
    "s3.credentials.provider.class": " io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider",
    "aws.access.key.id": "AKIAYVUC7GIV4OIWR564",
    "aws.secret.access.key": "****************************************",
    "storage.class": "io.confluent.connect.s3.storage.S3Storage"
  }
}`



## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
