### PR TITLE
CCDB-4880: Adding a S3 Sink Connector config to modify behavior w.r.t tagging errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ for guidance on this process.
 
 You can build *kafka-connect-storage-cloud* with Maven using the standard lifecycle phases.
 
+# Running Integration Tests
+Integration tests are run as part of `mvn install`; however one needs to first configure the environment variable`AWS_CREDENTIALS_PATH` to point to a json file path with following structure:
+```
+{
+    "aws_access_key_id": "<key>",
+    "aws_secret_access_key": "<secret>"
+}
+```
 
 # Contribute
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -80,6 +80,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String S3_OBJECT_TAGGING_CONFIG = "s3.object.tagging";
   public static final boolean S3_OBJECT_TAGGING_DEFAULT = false;
 
+  public static final String S3_OBJECT_IGNORE_TAGGING_ERROR_CONFIG = "ignore.tagging.errors";
+  public static final boolean S3_OBJECT_IGNORE_TAGGING_ERROR_DEFAULT = true;
+
   public static final String SSEA_CONFIG = "s3.ssea.name";
   public static final String SSEA_DEFAULT = "";
 
@@ -269,6 +272,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.LONG,
           "S3 Object Tagging"
+      );
+
+      configDef.define(
+              S3_OBJECT_IGNORE_TAGGING_ERROR_CONFIG,
+              Type.BOOLEAN,
+              S3_OBJECT_IGNORE_TAGGING_ERROR_DEFAULT,
+              Importance.LOW,
+              "Whether to ignore any S3 objects tagging error or not.",
+              group,
+              ++orderInGroup,
+              Width.LONG,
+              "Ignore S3 Object Tagging Error"
       );
 
       configDef.define(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -83,7 +83,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG =
           "s3.object.behavior.on.tagging.error";
   public static final String S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_DEFAULT =
-          IgnoreFailBehavior.IGNORE.toString();
+          IgnoreOrFailBehavior.IGNORE.toString();
 
   public static final String SSEA_CONFIG = "s3.ssea.name";
   public static final String SSEA_DEFAULT = "";
@@ -157,7 +157,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       ClientConfiguration.DEFAULT_USE_EXPECT_CONTINUE;
 
   public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
-  public static final String BEHAVIOR_ON_NULL_VALUES_DEFAULT = IgnoreFailBehavior.FAIL.toString();
+  public static final String BEHAVIOR_ON_NULL_VALUES_DEFAULT = IgnoreOrFailBehavior.FAIL.toString();
 
   /**
    * Maximum back-off time when retrying failed requests.
@@ -290,7 +290,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
               S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG,
               Type.STRING,
               S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_DEFAULT,
-              IgnoreFailBehavior.VALIDATOR,
+              IgnoreOrFailBehavior.VALIDATOR,
               Importance.LOW,
               "How to handle S3 object tagging error. Valid options are 'ignore' and 'fail'.",
               group,
@@ -609,7 +609,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           BEHAVIOR_ON_NULL_VALUES_CONFIG,
           Type.STRING,
           BEHAVIOR_ON_NULL_VALUES_DEFAULT,
-          IgnoreFailBehavior.VALIDATOR,
+          IgnoreOrFailBehavior.VALIDATOR,
           Importance.LOW,
           "How to handle records with a null value (i.e. Kafka tombstone records)."
               + " Valid options are 'ignore' and 'fail'.",
@@ -1158,7 +1158,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     return getString(BEHAVIOR_ON_NULL_VALUES_CONFIG);
   }
 
-  public enum IgnoreFailBehavior {
+  public enum IgnoreOrFailBehavior {
     IGNORE,
     FAIL;
 
@@ -1182,7 +1182,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     };
 
     public static String[] names() {
-      IgnoreFailBehavior[] behaviors = values();
+      IgnoreOrFailBehavior[] behaviors = values();
       String[] result = new String[behaviors.length];
 
       for (int i = 0; i < behaviors.length; i++) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -80,8 +80,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String S3_OBJECT_TAGGING_CONFIG = "s3.object.tagging";
   public static final boolean S3_OBJECT_TAGGING_DEFAULT = false;
 
-  public static final String S3_OBJECT_IGNORE_TAGGING_ERROR_CONFIG = "ignore.tagging.errors";
-  public static final boolean S3_OBJECT_IGNORE_TAGGING_ERROR_DEFAULT = true;
+  public static final String S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG =
+          "s3.object.behavior.on.tagging.error";
+  public static final String S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_DEFAULT =
+          IgnoreFailBehavior.IGNORE.toString();
 
   public static final String SSEA_CONFIG = "s3.ssea.name";
   public static final String SSEA_DEFAULT = "";
@@ -155,7 +157,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       ClientConfiguration.DEFAULT_USE_EXPECT_CONTINUE;
 
   public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
-  public static final String BEHAVIOR_ON_NULL_VALUES_DEFAULT = BehaviorOnNullValues.FAIL.toString();
+  public static final String BEHAVIOR_ON_NULL_VALUES_DEFAULT = IgnoreFailBehavior.FAIL.toString();
 
   /**
    * Maximum back-off time when retrying failed requests.
@@ -275,15 +277,16 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       );
 
       configDef.define(
-              S3_OBJECT_IGNORE_TAGGING_ERROR_CONFIG,
-              Type.BOOLEAN,
-              S3_OBJECT_IGNORE_TAGGING_ERROR_DEFAULT,
+              S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG,
+              Type.STRING,
+              S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_DEFAULT,
+              IgnoreFailBehavior.VALIDATOR,
               Importance.LOW,
-              "Whether to ignore any S3 objects tagging error or not.",
+              "How to handle S3 object tagging error. Valid options are 'ignore' and 'fail'.",
               group,
               ++orderInGroup,
-              Width.LONG,
-              "Ignore S3 Object Tagging Error"
+              Width.SHORT,
+              "Behavior for S3 object tagging error"
       );
 
       configDef.define(
@@ -596,7 +599,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           BEHAVIOR_ON_NULL_VALUES_CONFIG,
           Type.STRING,
           BEHAVIOR_ON_NULL_VALUES_DEFAULT,
-          BehaviorOnNullValues.VALIDATOR,
+          IgnoreFailBehavior.VALIDATOR,
           Importance.LOW,
           "How to handle records with a null value (i.e. Kafka tombstone records)."
               + " Valid options are 'ignore' and 'fail'.",
@@ -1111,7 +1114,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     return getString(BEHAVIOR_ON_NULL_VALUES_CONFIG);
   }
 
-  public enum BehaviorOnNullValues {
+  public enum IgnoreFailBehavior {
     IGNORE,
     FAIL;
 
@@ -1135,7 +1138,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     };
 
     public static String[] names() {
-      BehaviorOnNullValues[] behaviors = values();
+      IgnoreFailBehavior[] behaviors = values();
       String[] result = new String[behaviors.length];
 
       for (int i = 0; i < behaviors.length; i++) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -16,7 +16,7 @@
 package io.confluent.connect.s3;
 
 import com.amazonaws.AmazonClientException;
-import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
+import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreFailBehavior;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -249,7 +249,7 @@ public class S3SinkTask extends SinkTask {
   private boolean maybeSkipOnNullValue(SinkRecord record) {
     if (record.value() == null) {
       if (connectorConfig.nullValueBehavior()
-          .equalsIgnoreCase(BehaviorOnNullValues.IGNORE.toString())) {
+          .equalsIgnoreCase(IgnoreFailBehavior.IGNORE.toString())) {
         log.debug(
             "Null valued record from topic '{}', partition {} and offset {} was skipped.",
             record.topic(),

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -16,7 +16,7 @@
 package io.confluent.connect.s3;
 
 import com.amazonaws.AmazonClientException;
-import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreFailBehavior;
+import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreOrFailBehavior;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -249,7 +249,7 @@ public class S3SinkTask extends SinkTask {
   private boolean maybeSkipOnNullValue(SinkRecord record) {
     if (record.value() == null) {
       if (connectorConfig.nullValueBehavior()
-          .equalsIgnoreCase(IgnoreFailBehavior.IGNORE.toString())) {
+          .equalsIgnoreCase(IgnoreOrFailBehavior.IGNORE.toString())) {
         log.debug(
             "Null valued record from topic '{}', partition {} and offset {} was skipped.",
             record.topic(),

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -128,8 +128,9 @@ public class TopicPartitionWriter {
                                   ? ((TimeBasedPartitioner) partitioner).getTimestampExtractor()
                                   : null;
     isTaggingEnabled = connectorConfig.getBoolean(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG);
-    ignoreTaggingErrors = connectorConfig.getBoolean(
-            S3SinkConnectorConfig.S3_OBJECT_IGNORE_TAGGING_ERROR_CONFIG);
+    ignoreTaggingErrors = connectorConfig.getString(
+            S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG)
+            .equalsIgnoreCase(S3SinkConnectorConfig.IgnoreFailBehavior.IGNORE.toString());
     flushSize = connectorConfig.getInt(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG);
     topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
     rotateIntervalMs = connectorConfig.getLong(S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG);
@@ -665,14 +666,14 @@ public class TopicPartitionWriter {
       if (ignoreTaggingErrors) {
         log.warn("Unable to tag S3 object {}. Ignoring.", s3ObjectPath, e);
       } else {
-        throw new ConnectException(String.format("Unable to tag S3 object %s.", s3ObjectPath), e);
+        throw new ConnectException(String.format("Unable to tag S3 object %s", s3ObjectPath), e);
       }
     } catch (Exception e) {
       if (ignoreTaggingErrors) {
         log.warn("Unrecoverable exception while attempting to tag S3 object {}. Ignoring.",
                 s3ObjectPath, e);
       } else {
-        throw new ConnectException(String.format("Unable to tag S3 object %s.", s3ObjectPath), e);
+        throw new ConnectException(String.format("Unable to tag S3 object %s", s3ObjectPath), e);
       }
     }
   }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -134,7 +134,7 @@ public class TopicPartitionWriter {
     isTaggingEnabled = connectorConfig.getBoolean(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG);
     ignoreTaggingErrors = connectorConfig.getString(
             S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG)
-            .equalsIgnoreCase(S3SinkConnectorConfig.IgnoreFailBehavior.IGNORE.toString());
+            .equalsIgnoreCase(S3SinkConnectorConfig.IgnoreOrFailBehavior.IGNORE.toString());
     flushSize = connectorConfig.getInt(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG);
     topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
     rotateIntervalMs = connectorConfig.getLong(S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/RetryUtil.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/RetryUtil.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.util;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.TimeUnit;
+
+public class RetryUtil {
+  private static final Logger log = LoggerFactory.getLogger(RetryUtil.class);
+
+  /**
+   * @param runnable
+   *     An executable piece of code which will be retried in case an expected exception occurred.
+   * @param exceptionClass
+   *     The function will be retried only if it throws an instance of exceptionClass.
+   * @param totalNumIterations
+   *     This is the overall execution count e.g. if 3 then it'd be retried a max of twice.
+   * @param delayInMillis
+   *     Delay between 2 retries, each time it'd be doubled.
+   */
+  public static void exponentialBackoffRetry(final Runnable runnable,
+                         final Class<? extends Exception> exceptionClass,
+                         final int totalNumIterations,
+                         final long delayInMillis) throws ConnectException {
+    long expDelayInMillis = delayInMillis;
+    for (int i = 1; i <= totalNumIterations; i++) {
+      try {
+        runnable.run();
+        break;
+      } catch (Exception e) {
+        if (e.getClass().equals(exceptionClass)) {
+          log.warn("Attempt {} of {} failed.", i, totalNumIterations, e);
+          if (i == totalNumIterations) {
+            wrapAndThrowAsConnectException(e);
+          } else {
+            log.warn("Awaiting {} milliseconds before retrying.", expDelayInMillis);
+            await(expDelayInMillis);
+            expDelayInMillis <<= 1;
+          }
+        } else {
+          wrapAndThrowAsConnectException(e);
+        }
+      }
+    }
+  }
+
+  private static void wrapAndThrowAsConnectException(Exception e) throws ConnectException {
+    if (e instanceof ConnectException) {
+      throw (ConnectException) e;
+    }
+    throw new ConnectException(e);
+  }
+
+  private static void await(long millis) {
+    try {
+      TimeUnit.MILLISECONDS.sleep(millis);
+    } catch (InterruptedException e) {
+      // Restore the interrupted status
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -321,6 +321,16 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     properties.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "false");
     connectorConfig = new S3SinkConnectorConfig(properties);
     assertEquals(false, connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG));
+
+    properties.put(S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG, "ignore");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals("ignore",
+            connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG));
+
+    properties.put(S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG, "fail");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals("fail",
+            connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG));
   }
 
   private void assertDefaultPartitionerVisibility(List<ConfigValue> values) {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -118,7 +118,7 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
     task.initialize(mockContext);
 
     properties.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
-        S3SinkConnectorConfig.IgnoreFailBehavior.IGNORE.toString());
+        S3SinkConnectorConfig.IgnoreOrFailBehavior.IGNORE.toString());
     task.start(properties);
     verifyAll();
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -118,7 +118,7 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
     task.initialize(mockContext);
 
     properties.put(S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG,
-        S3SinkConnectorConfig.BehaviorOnNullValues.IGNORE.toString());
+        S3SinkConnectorConfig.IgnoreFailBehavior.IGNORE.toString());
     task.start(properties);
     verifyAll();
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -15,6 +15,7 @@
 
 package io.confluent.connect.s3;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.Tag;
@@ -91,8 +92,7 @@ import static io.confluent.connect.storage.partitioner.PartitionerConfig.PARTITI
 import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -154,6 +154,30 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     };
 
     format = new AvroFormat(storage);
+
+    Format<S3SinkConnectorConfig, String> format = new AvroFormat(storage);
+    writerProvider = format.getRecordWriterProvider();
+    extension = writerProvider.getExtension();
+  }
+
+  public void setUpWithTaggingException(boolean mockSdkClientException) throws Exception {
+    super.setUp();
+
+    s3 = newS3Client(connectorConfig);
+    storage = new S3Storage(connectorConfig, url, S3_TEST_BUCKET_NAME, s3) {
+      @Override
+      public void addTags(String fileName, Map<String, String> tags) throws SdkClientException {
+        if (mockSdkClientException) {
+          throw new SdkClientException("Mock SdkClientException while tagging");
+        }
+        throw new RuntimeException("Mock RuntimeException while tagging");
+      }
+    };
+
+    format = new AvroFormat(storage);
+
+    s3.createBucket(S3_TEST_BUCKET_NAME);
+    assertTrue(s3.doesBucketExistV2(S3_TEST_BUCKET_NAME));
 
     Format<S3SinkConnectorConfig, String> format = new AvroFormat(storage);
     writerProvider = format.getRecordWriterProvider();
@@ -1096,6 +1120,65 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     expectedTaggedFiles.put(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 6, extension, ZERO_PAD_FMT),
             Arrays.asList(new Tag("startOffset", "6"), new Tag("endOffset", "8"), new Tag("recordCount", "3")));
     verifyTags(expectedTaggedFiles);
+  }
+
+  @Test
+  public void testIgnoreS3ObjectTaggingSdkClientException() throws Exception {
+    // Tagging error occurred (SdkClientException) but getting ignored.
+    testS3ObjectTaggingErrorHelper(true, true);
+  }
+
+  @Test
+  public void testIgnoreS3ObjectTaggingRuntimeException() throws Exception {
+    // Tagging error occurred (RuntimeException) but getting ignored.
+    testS3ObjectTaggingErrorHelper(false, true);
+  }
+
+  @Test
+  public void testFailS3ObjectTaggingSdkClientException() throws Exception {
+    ConnectException exception = assertThrows(ConnectException.class, () -> {
+      testS3ObjectTaggingErrorHelper(true, false);
+    });
+    assertEquals("Unable to tag S3 object topics_test-topic_partition=12_test-topic#12#0000000000.avro", exception.getMessage());
+    assertEquals("Mock SdkClientException while tagging", exception.getCause().getMessage());
+  }
+
+  @Test
+  public void testFailS3ObjectTaggingRuntimeException() throws Exception {
+    ConnectException exception = assertThrows(ConnectException.class, () -> {
+      testS3ObjectTaggingErrorHelper(false, false);
+    });
+    assertEquals("Unable to tag S3 object topics_test-topic_partition=12_test-topic#12#0000000000.avro", exception.getMessage());
+    assertEquals("Mock RuntimeException while tagging", exception.getCause().getMessage());
+  }
+
+  public void testS3ObjectTaggingErrorHelper(boolean mockSdkClientException, boolean ignoreTaggingError) throws Exception {
+    // Enabling tagging and setting behavior for tagging error.
+    localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "true");
+    localProps.put(S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG, ignoreTaggingError ? "ignore" : "fail");
+
+    // Setup mock exception while tagging
+    setUpWithTaggingException(mockSdkClientException);
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new DefaultPartitioner<>();
+    partitioner.configure(parsedConfig);
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 3, 3);
+
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // Invoke write so as to simulate tagging error.
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
   }
 
   @Test

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -42,7 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
 import io.confluent.connect.s3.S3SinkConnector;
-import io.confluent.connect.s3.S3SinkConnectorConfig.BehaviorOnNullValues;
+import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreFailBehavior;
 import io.confluent.connect.s3.format.avro.AvroFormat;
 import io.confluent.connect.s3.format.json.JsonFormat;
 import io.confluent.connect.s3.format.parquet.ParquetFormat;
@@ -302,7 +302,7 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
   @Test
   public void testFaultyRecordsReportedToDLQ() throws Throwable {
     props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
-    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, BehaviorOnNullValues.IGNORE.toString());
+    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, IgnoreFailBehavior.IGNORE.toString());
     props.put(STORE_KAFKA_KEYS_CONFIG, "true");
     props.put(STORE_KAFKA_HEADERS_CONFIG, "true");
     props.put(DLQ_TOPIC_CONFIG, DLQ_TOPIC_NAME);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -42,7 +42,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableMap;
 
 import io.confluent.connect.s3.S3SinkConnector;
-import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreFailBehavior;
+import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreOrFailBehavior;
 import io.confluent.connect.s3.format.avro.AvroFormat;
 import io.confluent.connect.s3.format.json.JsonFormat;
 import io.confluent.connect.s3.format.parquet.ParquetFormat;
@@ -302,7 +302,7 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
   @Test
   public void testFaultyRecordsReportedToDLQ() throws Throwable {
     props.put(KEY_CONVERTER_CLASS_CONFIG, StringConverter.class.getName());
-    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, IgnoreFailBehavior.IGNORE.toString());
+    props.put(BEHAVIOR_ON_NULL_VALUES_CONFIG, IgnoreOrFailBehavior.IGNORE.toString());
     props.put(STORE_KAFKA_KEYS_CONFIG, "true");
     props.put(STORE_KAFKA_HEADERS_CONFIG, "true");
     props.put(DLQ_TOPIC_CONFIG, DLQ_TOPIC_NAME);


### PR DESCRIPTION
## Problem
[CCDB-4880](https://confluentinc.atlassian.net/browse/CCDB-4880): Databricks Delta Lake Sink Connector sporadically fails with a NPE when trying to read "endOffset" tag from S3 objects. The root cause is that the Delta Lake Sink Connector under the hood leverages S3 Sink Connector code to write/create S3 objects and the S3 Sink Connector code in case of any tagging errors simply ignores them. However from Databricks Sink Connector POV ignoring such tagging errors means the S3 object is left in an inconsistent state because it expects that if object is there in S3 then tag must also be there for that S3 object. See discussions in this [slack thread](https://confluent.slack.com/archives/C011CCECDB7/p1660623278820309).

## Solution
Adding a S3 Sink Connector low level configuartion so that the client/caller can decide whether it is okay for it to ignore tagging errors or not. This PR is part-1 of a 2 parts PR. The part-2 PR will have the Databricks connector side of changes leveraging the newly added S3 Sink config & handle any tagging errors gracefully at Databricks Sink connector end. However until this current S3 Sink PR is merged and a new version is created, I cannot raise part-2 PR as in Databricks Sink Connector pom I'd have to use the new version number of S3 Sink Connector.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [] no

##### If yes, where?
Databricks Delta Lake Sink Connector

## Test Strategy
Manually tested via docker playground the overall tagging failure scenario from Databricks connector end by hardcoding a throw clause in the S3 Sink Connector's TopicPartitionWriter#tagFile method.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
