### PR TITLE
Update storage common version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.12</version>
+        <version>11.0.15</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem
Bumping up the version of parent kafka-connect-storage-common to address:

* Version updates coming for other CVE fixes
   * log4j(https://github.com/confluentinc/kafka-connect-storage-common/pull/268)
   * derby (https://github.com/confluentinc/kafka-connect-storage-common/pull/266)
   * hadoop (https://github.com/confluentinc/kafka-connect-storage-common/pull/269)
* Bug Fix for https://github.com/confluentinc/kafka-connect-storage-cloud/issues/553

## Solution

For https://github.com/confluentinc/kafka-connect-storage-cloud/issues/553, check PR description in https://github.com/confluentinc/kafka-connect-storage-common/pull/273

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
Release as new patch version