### PR TITLE
bumping hadoop and jettison version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,11 +131,16 @@
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>${hadoop.version}</version>
+            <version>3.2.3</version>
             <exclusions>
+                <exclusion>
+                    <groupId>com.sun.jersey</groupId>
+                    <artifactId>jersey-json</artifactId>
+                </exclusion>
                 <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>
@@ -196,6 +201,22 @@
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
             <version>1.9.4</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.jersey</groupId>
+            <artifactId>jersey-json</artifactId>
+            <version>1.19</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.jettison</groupId>
+                    <artifactId>jettison</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jettison</groupId>
+            <artifactId>jettison</artifactId>
+            <version>1.5.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,8 @@
     <properties>
         <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
         <licenses.version>5.4.11-SNAPSHOT</licenses.version>
+        <hadoop.version>3.2.3</hadoop.version>
+        <jettison.version>1.5.1</jettison.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>
 
@@ -135,12 +137,8 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.2.3</version>
+            <version>${hadoop.version}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>com.sun.jersey</groupId>
-                    <artifactId>jersey-json</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>
@@ -203,20 +201,9 @@
             <version>1.9.4</version>
         </dependency>
         <dependency>
-            <groupId>com.sun.jersey</groupId>
-            <artifactId>jersey-json</artifactId>
-            <version>1.19</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.codehaus.jettison</groupId>
-                    <artifactId>jettison</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
-            <version>1.5.1</version>
+            <version>${jettison.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
## Problem
[CCMSG-2287](https://confluentinc.atlassian.net/browse/CCMSG-2287) - Upgrade jettison at kafka-connect-storage-cloud
[CCMSG-2293](https://confluentinc.atlassian.net/browse/CCMSG-2293) - Upgrade org.apache.hadoop:hadoop-common at kafka-connect-storage-cloud

## Solution
1- modifying hadoop-common version to  3.2.3.
2- And adding jettison dependency with version 1.5.1 explicitly.



<--- Snippet from dependency listing--->

[INFO] +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] +- org.codehaus.jettison:jettison:jar:1.5.1:compile
[INFO] +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:3.2.3:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-client:jar:3.2.3:test
[INFO] |  |  \- org.apache.hadoop:hadoop-yarn-api:jar:3.2.3:test

+- org.apache.hadoop:hadoop-common:jar:3.2.3:compile
[INFO] |  +- org.apache.hadoop:hadoop-annotations:jar:3.2.3:compile


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
