### PR TITLE
CCMSG-2267 - Vulnerable dependency "com.fasterxml.woodstox_woodstox-core:5.3.0" for kafka-connect-storage-cloud:master-latest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
         <dependency.check.version>6.1.6</dependency.check.version>
         <hadoop.version>3.2.3</hadoop.version>
         <jettison.version>1.5.1</jettison.version>
+        <woodstox.version><5.4.0></woodstox.version>
     </properties>
 
     <repositories>
@@ -139,6 +140,11 @@
             <groupId>org.codehaus.jettison</groupId>
             <artifactId>jettison</artifactId>
             <version>${jettison.version}</version>
+        </dependency>
+        <dependency>
+    	    <groupId>com.fasterxml.woodstox</groupId>
+            <artifactId>woodstox-core</artifactId>
+            <version>${woodstox.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <dependency.check.version>6.1.6</dependency.check.version>
         <hadoop.version>3.2.3</hadoop.version>
         <jettison.version>1.5.1</jettison.version>
-        <woodstox.version><5.4.0></woodstox.version>
+        <woodstox.version>5.4.0</woodstox.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Problem
Vulnerable dependency "com.fasterxml.woodstox_woodstox-core:5.3.0" for kafka-connect-storage-cloud:master-latest


## Solution
Explicitly add woodstox with 5.4.0 as hadoop-common extracts 5.3.0 version

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy

Docker-PlayGround Test Results :



<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
