### PR TITLE
Fixing release issues for 5.4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
         <licenses.version>5.4.11-SNAPSHOT</licenses.version>
         <hadoop.version>3.2.4</hadoop.version>
         <jettison.version>1.5.1</jettison.version>
+        <kafka.connect.storage.common.version>5.4.10</kafka.connect.storage.common.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
     </properties>
 
@@ -110,19 +111,22 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-core</artifactId>
+            <version>${kafka.connect.storage.common.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-format</artifactId>
+            <version>${kafka.connect.storage.common.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-partitioner</artifactId>
+            <version>${kafka.connect.storage.common.version}</version>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-common-htrace-core4-shaded</artifactId>
-            <version>${project.parent.version}</version>
+            <version>${kafka.connect.storage.common.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
@@ -285,3 +289,4 @@
         </pluginManagement>
     </build>
 </project>
+


### PR DESCRIPTION
## Problem
Currently, Unable to release 5.4.x and 5.5.x because SNAPSHOT versions are getting imported   

] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project kafka-connect-storage-cloud: Can't release project due to non released dependencies :
17:47:21  [ERROR]     io.confluent:kafka-connect-storage-common:jar:5.4.11-SNAPSHOT:compile
17:47:21  [ERROR]     io.confluent:kafka-connect-storage-core:jar:5.4.11-SNAPSHOT:compile
17:47:21  [ERROR]     io.confluent:kafka-connect-storage-format:jar:5.4.11-SNAPSHOT:compile
17:47:21  [ERROR]     io.confluent:kafka-connect-storage-partitioner:jar:5.4.11-SNAPSHOT:compile
17:47:21  [ERROR] in project 'kafka-connect-storage-cloud' (io.confluent:kafka-connect-storage-cloud:pom:5.4.11-SNAPSHOT)
17:47:21  [ERROR] -> [Help 1]

## Solution
Pinned version to 5.4.10


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
