### PR TITLE
CCMSG-2232: Add support for topic record name strategy

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -189,6 +189,15 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String ELASTIC_BUFFER_INIT_CAPACITY = "s3.elastic.buffer.init.capacity";
   public static final int ELASTIC_BUFFER_INIT_CAPACITY_DEFAULT = 128 * 1024;  // 128KB
+  public static final String SCHEMA_PARTITION_AFFIX_TYPE_CONFIG =
+      "s3.schema.partition.affix.type";
+  public static final String SCHEMA_PARTITION_AFFIX_TYPE_DEFAULT = AffixType.NONE.name();
+  public static final String SCHEMA_PARTITION_AFFIX_TYPE_DOC = "Append the record schema name "
+      + "to prefix or suffix in the s3 path after the topic name."
+      + " None will not append the schema name in the s3 path.";
+
+  private static final GenericRecommender SCHEMA_PARTITION_AFFIX_TYPE_RECOMMENDER =
+      new GenericRecommender();
 
   private final String name;
 
@@ -241,6 +250,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
             FieldPartitioner.class
         )
     );
+
+    SCHEMA_PARTITION_AFFIX_TYPE_RECOMMENDER.addValidValues(Arrays.asList(AffixType.names()));
   }
 
   public static ConfigDef newConfigDef() {
@@ -621,6 +632,20 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Width.SHORT,
           "Behavior for null-valued records"
       );
+
+      configDef.define(
+          SCHEMA_PARTITION_AFFIX_TYPE_CONFIG,
+          Type.STRING,
+          SCHEMA_PARTITION_AFFIX_TYPE_DEFAULT,
+          ConfigDef.ValidString.in(AffixType.names()),
+          Importance.LOW,
+          SCHEMA_PARTITION_AFFIX_TYPE_DOC,
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "Schema Partition Affix Type",
+          SCHEMA_PARTITION_AFFIX_TYPE_RECOMMENDER
+      );
     }
 
     {
@@ -921,6 +946,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     return map;
   }
 
+  public AffixType getSchemaPartitionAffixType() {
+    return AffixType.valueOf(getString(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG));
+  }
+
   private static class PartRange implements ConfigDef.Validator {
     // S3 specific limit
     final int min = 5 * 1024 * 1024;
@@ -1217,6 +1246,16 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     @Override
     public String toString() {
       return name().toLowerCase(Locale.ROOT);
+    }
+  }
+
+  public enum AffixType {
+    SUFFIX,
+    PREFIX,
+    NONE;
+
+    public static String[] names() {
+      return Arrays.stream(values()).map(AffixType::name).toArray(String[]::new);
     }
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -189,6 +189,11 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String ELASTIC_BUFFER_INIT_CAPACITY = "s3.elastic.buffer.init.capacity";
   public static final int ELASTIC_BUFFER_INIT_CAPACITY_DEFAULT = 128 * 1024;  // 128KB
+
+  /**
+   * Append schema name in s3-path
+   */
+
   public static final String SCHEMA_PARTITION_AFFIX_TYPE_CONFIG =
       "s3.schema.partition.affix.type";
   public static final String SCHEMA_PARTITION_AFFIX_TYPE_DEFAULT = AffixType.NONE.name();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -251,7 +251,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
         )
     );
 
-    SCHEMA_PARTITION_AFFIX_TYPE_RECOMMENDER.addValidValues(Arrays.asList(AffixType.names()));
+    SCHEMA_PARTITION_AFFIX_TYPE_RECOMMENDER.addValidValues(
+        Arrays.stream(AffixType.names()).collect(Collectors.toList()));
   }
 
   public static ConfigDef newConfigDef() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -17,6 +17,7 @@ package io.confluent.connect.s3;
 
 import com.amazonaws.AmazonClientException;
 import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreOrFailBehavior;
+import io.confluent.connect.s3.util.SchemaPartitioner;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.errors.ConnectException;
@@ -205,7 +206,10 @@ public class S3SinkTask extends SinkTask {
       }
     }
     partitioner.configure(plainValues);
-
+    if (config.getSchemaPartitionAffixType() != S3SinkConnectorConfig.AffixType.NONE) {
+      partitioner = new SchemaPartitioner<>(
+          plainValues, config.getSchemaPartitionAffixType(), partitioner);
+    }
     return partitioner;
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -205,11 +205,10 @@ public class S3SinkTask extends SinkTask {
         plainValues.put(originalKey, originals.get(originalKey));
       }
     }
-    partitioner.configure(plainValues);
     if (config.getSchemaPartitionAffixType() != S3SinkConnectorConfig.AffixType.NONE) {
-      partitioner = new SchemaPartitioner<>(
-          plainValues, config.getSchemaPartitionAffixType(), partitioner);
+      partitioner = new SchemaPartitioner<>(partitioner);
     }
+    partitioner.configure(plainValues);
     return partitioner;
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/SchemaPartitioner.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/SchemaPartitioner.java
@@ -48,27 +48,23 @@ public class SchemaPartitioner<T> implements Partitioner<T> {
   public String encodePartition(SinkRecord sinkRecord) {
     String encodePartition = this.delegatePartitioner.encodePartition(sinkRecord);
     Schema valueSchema = sinkRecord.valueSchema();
-    if (valueSchema != null) {
-      encodePartition = generateSchemaBasedPath(encodePartition, valueSchema);
-    }
-    return encodePartition;
+    String valueSchemaName = valueSchema != null ? valueSchema.name() : null;
+    return generateSchemaBasedPath(encodePartition, valueSchemaName);
   }
 
   @Override
   public String encodePartition(SinkRecord sinkRecord, long nowInMillis) {
     String encodePartition = this.delegatePartitioner.encodePartition(sinkRecord, nowInMillis);
     Schema valueSchema = sinkRecord.valueSchema();
-    if (valueSchema != null) {
-      encodePartition = generateSchemaBasedPath(encodePartition, valueSchema);
-    }
-    return encodePartition;
+    String valueSchemaName = valueSchema != null ? valueSchema.name() : null;
+    return generateSchemaBasedPath(encodePartition, valueSchemaName);
   }
 
-  private String generateSchemaBasedPath(String encodedPartition, Schema valueSchema) {
+  private String generateSchemaBasedPath(String encodedPartition, String schemaName) {
     if (schemaAffixType == S3SinkConnectorConfig.AffixType.PREFIX) {
-      return "schema_name=" + valueSchema.name() + this.delim + encodedPartition;
+      return "schema_name=" + schemaName + this.delim + encodedPartition;
     } else {
-      return encodedPartition + this.delim + "schema_name=" + valueSchema.name();
+      return encodedPartition + this.delim + "schema_name=" + schemaName;
     }
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/SchemaPartitioner.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/SchemaPartitioner.java
@@ -38,7 +38,7 @@ public class SchemaPartitioner<T> implements Partitioner<T> {
 
   @Override
   public void configure(Map<String, Object> config) {
-    this.delim = (String)config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    this.delim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
     this.schemaAffixType = S3SinkConnectorConfig.AffixType.valueOf(
         (String) config.get(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG));
     delegatePartitioner.configure(config);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/SchemaPartitioner.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/SchemaPartitioner.java
@@ -1,0 +1,82 @@
+/*
+* Copyright 2018 Confluent Inc.
+*
+* Licensed under the Confluent Community License (the "License"); you may not use
+* this file except in compliance with the License.  You may obtain a copy of the
+* License at
+*
+* http://www.confluent.io/confluent-community-license
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+* WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations under the License.
+*/
+
+package io.confluent.connect.s3.util;
+
+import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.storage.common.StorageCommonConfig;
+import io.confluent.connect.storage.partitioner.Partitioner;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public class SchemaPartitioner<T> implements Partitioner<T> {
+
+  private final Partitioner<T> delegatePartitioner;
+  private final S3SinkConnectorConfig.AffixType schemaAffixType;
+  protected String delim;
+
+  public SchemaPartitioner(Map<String, Object> config,
+      S3SinkConnectorConfig.AffixType schemaAffixType, Partitioner<T> delegatePartitioner) {
+    this.delim = (String)config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    this.delegatePartitioner = delegatePartitioner;
+    this.schemaAffixType = schemaAffixType;
+  }
+
+  @Override
+  public void configure(Map<String, Object> map) {
+    delegatePartitioner.configure(map);
+  }
+
+  @Override
+  public String encodePartition(SinkRecord sinkRecord) {
+    String encodePartition = this.delegatePartitioner.encodePartition(sinkRecord);
+    Schema valueSchema = sinkRecord.valueSchema();
+    if (valueSchema != null) {
+      encodePartition = generateSchemaBasedPath(encodePartition, valueSchema);
+    }
+    return encodePartition;
+  }
+
+  @Override
+  public String encodePartition(SinkRecord sinkRecord, long nowInMillis) {
+    String encodePartition = this.delegatePartitioner.encodePartition(sinkRecord, nowInMillis);
+    Schema valueSchema = sinkRecord.valueSchema();
+    if (valueSchema != null) {
+      encodePartition = generateSchemaBasedPath(encodePartition, valueSchema);
+    }
+    return encodePartition;
+  }
+
+  private String generateSchemaBasedPath(String encodedPartition, Schema valueSchema) {
+    if (schemaAffixType == S3SinkConnectorConfig.AffixType.PREFIX) {
+      return "schema_name=" + valueSchema.name() + this.delim + encodedPartition;
+    } else {
+      return encodedPartition + this.delim + "schema_name=" + valueSchema.name();
+    }
+  }
+
+  @Override
+  public String generatePartitionedPath(String topic, String encodedPartition) {
+    return delegatePartitioner.generatePartitionedPath(topic, encodedPartition);
+  }
+
+  @Override
+  public List<T> partitionFields() {
+    return delegatePartitioner.partitionFields();
+  }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/SchemaPartitioner.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/SchemaPartitioner.java
@@ -24,22 +24,24 @@ import java.util.Map;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.sink.SinkRecord;
 
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
+
 public class SchemaPartitioner<T> implements Partitioner<T> {
 
   private final Partitioner<T> delegatePartitioner;
-  private final S3SinkConnectorConfig.AffixType schemaAffixType;
-  protected String delim;
+  private S3SinkConnectorConfig.AffixType schemaAffixType;
+  private String delim;
 
-  public SchemaPartitioner(Map<String, Object> config,
-      S3SinkConnectorConfig.AffixType schemaAffixType, Partitioner<T> delegatePartitioner) {
-    this.delim = (String)config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+  public SchemaPartitioner(Partitioner<T> delegatePartitioner) {
     this.delegatePartitioner = delegatePartitioner;
-    this.schemaAffixType = schemaAffixType;
   }
 
   @Override
-  public void configure(Map<String, Object> map) {
-    delegatePartitioner.configure(map);
+  public void configure(Map<String, Object> config) {
+    this.delim = (String)config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    this.schemaAffixType = S3SinkConnectorConfig.AffixType.valueOf(
+        (String) config.get(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG));
+    delegatePartitioner.configure(config);
   }
 
   @Override

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -220,7 +220,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     );
     properties.put(
         configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME),
-        "3"
+        "5"
     );
     connectorConfig = new S3SinkConnectorConfig(properties);
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider;
@@ -47,8 +48,10 @@ import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
 import io.confluent.connect.avro.AvroDataConfig;
 
+import static io.confluent.connect.s3.S3SinkConnectorConfig.AffixType;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -112,21 +115,24 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
         TimeBasedPartitioner.class,
         FieldPartitioner.class
     );
+    List<Object> expectedSchemaPartitionerAffixTypes = Arrays.stream(
+        S3SinkConnectorConfig.AffixType.names()).collect(Collectors.toList());
 
     List<ConfigValue> values = S3SinkConnectorConfig.getConfig().validate(properties);
     for (ConfigValue val : values) {
-      if (val.value() instanceof Class) {
-        switch (val.name()) {
-          case StorageCommonConfig.STORAGE_CLASS_CONFIG:
-            assertEquals(expectedStorageClasses, val.recommendedValues());
-            break;
-          case S3SinkConnectorConfig.FORMAT_CLASS_CONFIG:
-            assertEquals(expectedFormatClasses, val.recommendedValues());
-            break;
-          case PartitionerConfig.PARTITIONER_CLASS_CONFIG:
-            assertEquals(expectedPartitionerClasses, val.recommendedValues());
-            break;
-        }
+      switch (val.name()) {
+        case StorageCommonConfig.STORAGE_CLASS_CONFIG:
+          assertEquals(expectedStorageClasses, val.recommendedValues());
+          break;
+        case S3SinkConnectorConfig.FORMAT_CLASS_CONFIG:
+          assertEquals(expectedFormatClasses, val.recommendedValues());
+          break;
+        case PartitionerConfig.PARTITIONER_CLASS_CONFIG:
+          assertEquals(expectedPartitionerClasses, val.recommendedValues());
+          break;
+        case SCHEMA_PARTITION_AFFIX_TYPE_CONFIG:
+          assertEquals(expectedSchemaPartitionerAffixTypes, val.recommendedValues());
+          break;
       }
     }
   }
@@ -570,6 +576,34 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     properties.put(HEADERS_FORMAT_CLASS_CONFIG, ParquetFormat.class.getCanonicalName());
     connectorConfig = new S3SinkConnectorConfig(properties);
     assertEquals(ParquetFormat.class, connectorConfig.getClass(HEADERS_FORMAT_CLASS_CONFIG));
+  }
+
+  @Test
+  public void testSchemaPartitionerAffixTypDefault() {
+    properties.remove(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG);
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(AffixType.NONE, connectorConfig.getSchemaPartitionAffixType());
+  }
+
+  @Test
+  public void testSchemaPartitionerAffixType() {
+    properties.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, AffixType.NONE.name());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(AffixType.NONE, connectorConfig.getSchemaPartitionAffixType());
+
+    properties.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, AffixType.PREFIX.name());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(AffixType.PREFIX, connectorConfig.getSchemaPartitionAffixType());
+
+    properties.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, AffixType.SUFFIX.name());
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertEquals(S3SinkConnectorConfig.AffixType.SUFFIX, connectorConfig.getSchemaPartitionAffixType());
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testSchemaPartitionerAffixTypeExceptionOnWrongValue() {
+    properties.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, "Random");
+    new S3SinkConnectorConfig(properties);
   }
 }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -637,18 +637,23 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   @DataPoints("affixType")
   public static S3SinkConnectorConfig.AffixType[] affixTypeValues(){
     return new S3SinkConnectorConfig.AffixType[]{
-        S3SinkConnectorConfig.AffixType.PREFIX, S3SinkConnectorConfig.AffixType.SUFFIX};
+        S3SinkConnectorConfig.AffixType.PREFIX, S3SinkConnectorConfig.AffixType.SUFFIX
+    };
   }
+
   @DataPoints("testWithSchemaData")
   public static boolean[] testWithSchemaDataValues(){
     return new boolean[]{true, false};
   }
+
   @Theory
   public void testWriteSchemaPartitionerWithAffix(
       @FromDataPoints("affixType")S3SinkConnectorConfig.AffixType affixType,
-      @FromDataPoints("testWithSchemaData") boolean testWithSchemaData) throws Exception {
+      @FromDataPoints("testWithSchemaData") boolean testWithSchemaData
+  ) throws Exception {
     testWriteSchemaPartitionerWithAffix(testWithSchemaData, affixType);
   }
+
 
   @Test
   public void testWriteRecordsAfterScheduleRotationExpiryButNoResetShouldGoToSameFile()

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -1849,7 +1849,6 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
       );
       assertEquals(expectedSize, actualRecords.size());
       for (Object currentRecord : actualRecords) {
-        System.out.println(currentRecord);
         SinkRecord expectedRecord = expectedRecords.get(index++);
         Object expectedValue = expectedRecord.value();
         JsonConverter converter = new JsonConverter();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -87,6 +87,7 @@ import io.confluent.connect.storage.partitioner.TimestampExtractor;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
 import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
 import static io.confluent.connect.storage.partitioner.PartitionerConfig.PARTITION_FIELD_NAME_CONFIG;
@@ -632,9 +633,9 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
     // Define the partitioner
     Partitioner<?> basePartitioner = new DefaultPartitioner<>();
-    Partitioner<?> partitioner = new SchemaPartitioner<>(
-            parsedConfig, S3SinkConnectorConfig.AffixType.PREFIX, basePartitioner);
-    basePartitioner.configure(parsedConfig);
+    parsedConfig.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, S3SinkConnectorConfig.AffixType.PREFIX.name());
+    Partitioner<?> partitioner = new SchemaPartitioner<>(basePartitioner);
+    partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
             TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
@@ -735,11 +736,11 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     localProps.put(FLUSH_SIZE_CONFIG, "9");
     setUp();
 
+    parsedConfig.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, S3SinkConnectorConfig.AffixType.SUFFIX.name());
     // Define the partitioner
     Partitioner<?> basePartitioner = new DefaultPartitioner<>();
-    Partitioner<?> partitioner = new SchemaPartitioner<>(
-            parsedConfig, S3SinkConnectorConfig.AffixType.SUFFIX, basePartitioner);
-    basePartitioner.configure(parsedConfig);
+    Partitioner<?> partitioner = new SchemaPartitioner<>(basePartitioner);
+    partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
             TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -1828,8 +1828,8 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
   private void verifyWithJsonOutput(
       List<String> expectedFileKeys, int expectedSize,
-      List<SinkRecord> expectedRecords, CompressionType compressionType)
-          throws IOException {
+      List<SinkRecord> expectedRecords, CompressionType compressionType
+  ) throws IOException {
     List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
     List<String> actualFiles = new ArrayList<>();
     for (S3ObjectSummary summary : summaries) {
@@ -1845,7 +1845,8 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     for (String fileKey : actualFiles) {
       Collection<Object> actualRecords = readRecordsJson(
           S3_TEST_BUCKET_NAME, fileKey,
-          s3, compressionType);
+          s3, compressionType
+      );
       assertEquals(expectedSize, actualRecords.size());
       for (Object currentRecord : actualRecords) {
         System.out.println(currentRecord);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -31,8 +31,7 @@ import io.confluent.connect.s3.storage.CompressionType;
 import io.confluent.connect.s3.util.SchemaPartitioner;
 import io.confluent.connect.storage.errors.PartitionException;
 import io.confluent.kafka.serializers.NonRecordContainer;
-import java.util.HashSet;
-import java.util.Set;
+
 import org.apache.avro.util.Utf8;
 import org.apache.kafka.common.record.TimestampType;
 import org.apache.kafka.connect.connector.ConnectRecord;
@@ -56,13 +55,15 @@ import org.junit.After;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -84,12 +85,19 @@ import io.confluent.connect.storage.partitioner.Partitioner;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
 import io.confluent.connect.storage.partitioner.TimestampExtractor;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.FromDataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
 import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
+import static io.confluent.connect.storage.StorageSinkConnectorConfig.FORMAT_CLASS_CONFIG;
+import static io.confluent.connect.storage.common.StorageCommonConfig.DIRECTORY_DELIM_CONFIG;
 import static io.confluent.connect.storage.partitioner.PartitionerConfig.PARTITION_FIELD_NAME_CONFIG;
 import static org.apache.kafka.common.utils.Time.SYSTEM;
 import static org.hamcrest.CoreMatchers.is;
@@ -99,6 +107,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 
+@RunWith(Theories.class)
 public class TopicPartitionWriterTest extends TestWithMockedS3 {
   // The default
   private static final String ZERO_PAD_FMT = "%010d";
@@ -625,215 +634,20 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
         topicsDir, dirPrefix, TOPIC_PARTITION, 0, extension, ZERO_PAD_FMT));
     verify(expectedFiles, 6, schema, records);
   }
-
-  @Test
-  public void testWriteSchemaPartitionerWithPrefix() throws Exception {
-    localProps.put(FLUSH_SIZE_CONFIG, "9");
-    setUp();
-
-    // Define the partitioner
-    Partitioner<?> basePartitioner = new DefaultPartitioner<>();
-    parsedConfig.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, S3SinkConnectorConfig.AffixType.PREFIX.name());
-    Partitioner<?> partitioner = new SchemaPartitioner<>(basePartitioner);
-    partitioner.configure(parsedConfig);
-
-    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
-
-    String key = "key";
-    Schema schema1 = SchemaBuilder.struct()
-            .name(null)
-            .version(null)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
-    List<Struct> records1 = createRecordBatches(schema1, 3, 6);
-
-    Schema schema2 = SchemaBuilder.struct()
-            .name("record1")
-            .version(1)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
-
-
-    List<Struct> records2 = createRecordBatches(schema2, 3, 6);
-
-    Schema schema3 = SchemaBuilder.struct()
-            .name("record2")
-            .version(1)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
-
-
-    List<Struct> records3 = createRecordBatches(schema3, 3, 6);
-
-    int offset = 0;
-    for (int i=0; i<records1.size(); i++) {
-      topicPartitionWriter.buffer(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema1, records1.get(i),
-                      offset++));
-      topicPartitionWriter.buffer(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema2, records2.get(i),
-                      offset++));
-      topicPartitionWriter.buffer(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema3, records3.get(i),
-                      offset++));
-    }
-    // Test actual write
-    topicPartitionWriter.write();
-    topicPartitionWriter.close();
-
-    String dirPrefix1 = partitioner.generatePartitionedPath(TOPIC,
-            "schema_name" + "=" + "null" + "_partition=" + PARTITION);
-    String dirPrefix2 = partitioner.generatePartitionedPath(TOPIC,
-            "schema_name" + "=" + "record1" + "_partition=" + PARTITION);
-    String dirPrefix3 = partitioner.generatePartitionedPath(TOPIC,
-            "schema_name" + "=" + "record2" + "_partition=" + PARTITION);
-
-    List<Struct> expectedRecords = new ArrayList<>();
-    int ibase = 16;
-    float fbase = 12.2f;
-    // The expected sequence of records is constructed taking into account that sorting of files occurs in verify
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        expectedRecords.add(createRecord(schema1, ibase + j, fbase + j));
-      }
-    }
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        expectedRecords.add(createRecord(schema2, ibase + j, fbase + j));
-      }
-    }
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        expectedRecords.add(createRecord(schema3, ibase + j, fbase + j));
-      }
-    }
-
-    List<String> expectedFiles = new ArrayList<>();
-    for(int i = 0; i < 54; i += 9) {
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix1, TOPIC_PARTITION, i, extension, ZERO_PAD_FMT));
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix2, TOPIC_PARTITION, i+1, extension, ZERO_PAD_FMT));
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix3, TOPIC_PARTITION, i+2, extension, ZERO_PAD_FMT));
-    }
-
-    verify(expectedFiles, 3, schema1, expectedRecords);
+  @DataPoints("affixType")
+  public static S3SinkConnectorConfig.AffixType[] affixTypeValues(){
+    return new S3SinkConnectorConfig.AffixType[]{
+        S3SinkConnectorConfig.AffixType.PREFIX, S3SinkConnectorConfig.AffixType.SUFFIX};
   }
-
-  @Test
-  public void testWriteSchemaPartitionerWithSuffix() throws Exception {
-    localProps.put(FLUSH_SIZE_CONFIG, "9");
-    setUp();
-
-    parsedConfig.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, S3SinkConnectorConfig.AffixType.SUFFIX.name());
-    // Define the partitioner
-    Partitioner<?> basePartitioner = new DefaultPartitioner<>();
-    Partitioner<?> partitioner = new SchemaPartitioner<>(basePartitioner);
-    partitioner.configure(parsedConfig);
-
-    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
-
-    String key = "key";
-    Schema schema1 = SchemaBuilder.struct()
-            .name(null)
-            .version(null)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
-    List<Struct> records1 = createRecordBatches(schema1, 3, 6);
-
-    Schema schema2 = SchemaBuilder.struct()
-            .name("record1")
-            .version(1)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
-
-
-    List<Struct> records2 = createRecordBatches(schema2, 3, 6);
-
-    Schema schema3 = SchemaBuilder.struct()
-            .name("record2")
-            .version(1)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
-
-
-    List<Struct> records3 = createRecordBatches(schema3, 3, 6);
-
-    int offset = 0;
-    for (int i=0; i<records1.size(); i++) {
-      topicPartitionWriter.buffer(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema1, records1.get(i),
-                      offset++));
-      topicPartitionWriter.buffer(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema2, records2.get(i),
-                      offset++));
-      topicPartitionWriter.buffer(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema3, records3.get(i),
-                      offset++));
-    }
-    // Test actual write
-    topicPartitionWriter.write();
-    topicPartitionWriter.close();
-
-    String dirPrefix1 = partitioner.generatePartitionedPath(TOPIC,
-            "partition=" + PARTITION + "_schema_name" + "=" + "null" );
-    String dirPrefix2 = partitioner.generatePartitionedPath(TOPIC,
-            "partition=" + PARTITION + "_schema_name" + "=" + "record1" );
-    String dirPrefix3 = partitioner.generatePartitionedPath(TOPIC,
-            "partition=" + PARTITION + "_schema_name" + "=" + "record2" );
-
-    List<Struct> expectedRecords = new ArrayList<>();
-    int ibase = 16;
-    float fbase = 12.2f;
-    // The expected sequence of records is constructed taking into account that sorting of files occurs in verify
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        expectedRecords.add(createRecord(schema1, ibase + j, fbase + j));
-      }
-    }
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        expectedRecords.add(createRecord(schema2, ibase + j, fbase + j));
-      }
-    }
-    for (int i = 0; i < 6; ++i) {
-      for (int j = 0; j < 3; ++j) {
-        expectedRecords.add(createRecord(schema3, ibase + j, fbase + j));
-      }
-    }
-
-    List<String> expectedFiles = new ArrayList<>();
-    for(int i = 0; i < 54; i += 9) {
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix1, TOPIC_PARTITION, i, extension, ZERO_PAD_FMT));
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix2, TOPIC_PARTITION, i+1, extension, ZERO_PAD_FMT));
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix3, TOPIC_PARTITION, i+2, extension, ZERO_PAD_FMT));
-    }
-
-    verify(expectedFiles, 3, schema1, expectedRecords);
+  @DataPoints("testWithSchemaData")
+  public static boolean[] testWithSchemaDataValues(){
+    return new boolean[]{true, false};
+  }
+  @Theory
+  public void testWriteSchemaPartitionerWithAffix(
+      @FromDataPoints("affixType")S3SinkConnectorConfig.AffixType affixType,
+      @FromDataPoints("testWithSchemaData") boolean testWithSchemaData) throws Exception {
+    testWriteSchemaPartitionerWithAffix(testWithSchemaData, affixType);
   }
 
   @Test
@@ -1665,6 +1479,211 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     );
   }
 
+  public void testWriteSchemaPartitionerWithAffix(boolean testWithSchemaData, S3SinkConnectorConfig.AffixType affixType) throws Exception {
+    localProps.put(FLUSH_SIZE_CONFIG, "9");
+    localProps.put(FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
+    setUp();
+
+    Format<S3SinkConnectorConfig, String> myFormat = new JsonFormat(storage);
+    writerProvider = myFormat.getRecordWriterProvider();
+    extension = writerProvider.getExtension();
+
+    parsedConfig.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, affixType.name());
+    // Define the partitioner
+    Partitioner<?> basePartitioner = new DefaultPartitioner<>();
+    Partitioner<?> partitioner =  new SchemaPartitioner<>(basePartitioner);;
+    partitioner.configure(parsedConfig);
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+            TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+
+    List<Object> testData;
+    if (testWithSchemaData) {
+      testData = generateTestDataWithSchema(partitioner, affixType);
+    } else {
+      testData = generateTestDataWithoutSchema(partitioner, affixType);
+    }
+
+    String key = (String) testData.get(0);
+    List<SinkRecord> actualRecords = (List<SinkRecord>) testData.get(1);
+    List<SinkRecord> expectedRecords = (List<SinkRecord>) testData.get(2);
+    List<String> expectedFiles = (List<String>) testData.get(3);
+
+
+    for (int i=0; i<actualRecords.size(); i++) {
+      topicPartitionWriter.buffer(actualRecords.get(i));
+    }
+    // Test actual write
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    verifyWithJsonOutput(
+        expectedFiles, expectedRecords.size()/expectedFiles.size(), expectedRecords, CompressionType.NONE);
+  }
+
+  private List<Object> generateTestDataWithSchema(Partitioner<?> partitioner, S3SinkConnectorConfig.AffixType affixType) {
+    String key = "key";
+
+    Schema schema1 = SchemaBuilder.struct()
+            .name(null)
+            .version(null)
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("int", Schema.INT32_SCHEMA)
+            .field("long", Schema.INT64_SCHEMA)
+            .field("float", Schema.FLOAT32_SCHEMA)
+            .field("double", Schema.FLOAT64_SCHEMA)
+            .build();
+    List<Struct> records1 = createRecordBatches(schema1, 3, 6);
+
+    Schema schema2 = SchemaBuilder.struct()
+            .name("record1")
+            .version(1)
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("int", Schema.INT32_SCHEMA)
+            .field("long", Schema.INT64_SCHEMA)
+            .field("float", Schema.FLOAT32_SCHEMA)
+            .field("double", Schema.FLOAT64_SCHEMA)
+            .build();
+
+    List<Struct> records2 = createRecordBatches(schema2, 3, 6);
+
+    Schema schema3 = SchemaBuilder.struct()
+            .name("record2")
+            .version(1)
+            .field("boolean", Schema.BOOLEAN_SCHEMA)
+            .field("int", Schema.INT32_SCHEMA)
+            .field("long", Schema.INT64_SCHEMA)
+            .field("float", Schema.FLOAT32_SCHEMA)
+            .field("double", Schema.FLOAT64_SCHEMA)
+            .build();
+
+
+    List<Struct> records3 = createRecordBatches(schema3, 3, 6);
+
+    ArrayList<SinkRecord> actualData = new ArrayList<>();
+    int offset = 0;
+    for (int i=0; i<records1.size(); i++) {
+      actualData.add(
+              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema1, records1.get(i),
+                      offset++));
+      actualData.add(
+              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema2, records2.get(i),
+                      offset++));
+      actualData.add(
+              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema3, records3.get(i),
+                      offset++));
+    }
+    List<SinkRecord> expectedRecords = new ArrayList<>();
+    int ibase = 16;
+    float fbase = 12.2f;
+    offset = 0;
+    // The expected sequence of records is constructed taking into account that sorting of files occurs in verify
+
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        expectedRecords.add(
+                new SinkRecord(
+                        TOPIC, PARTITION, Schema.STRING_SCHEMA,
+                        key, schema1, createRecord(schema1, ibase + j, fbase + j),
+                        offset++));
+      }
+    }
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        expectedRecords.add(
+                new SinkRecord(
+                        TOPIC, PARTITION, Schema.STRING_SCHEMA,
+                        key, schema2, createRecord(schema2, ibase + j, fbase + j),
+                        offset++));
+      }
+    }
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        expectedRecords.add(
+                new SinkRecord(
+                        TOPIC, PARTITION, Schema.STRING_SCHEMA,
+                        key, schema3, createRecord(schema3, ibase + j, fbase + j),
+                        offset++));
+      }
+    }
+
+    String dirPrefix1 = generateS3DirectoryPathWithDefaultPartitioner(
+            partitioner, affixType, PARTITION, TOPIC, "null");
+    String dirPrefix2 = generateS3DirectoryPathWithDefaultPartitioner(
+            partitioner, affixType, PARTITION, TOPIC, "record1");
+    String dirPrefix3 = generateS3DirectoryPathWithDefaultPartitioner(
+            partitioner, affixType, PARTITION, TOPIC, "record2");
+    List<String> expectedFiles = new ArrayList<>();
+    for(int i = 0; i < 54; i += 9) {
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix1, TOPIC_PARTITION, i, extension, ZERO_PAD_FMT));
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix2, TOPIC_PARTITION, i+1, extension, ZERO_PAD_FMT));
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix3, TOPIC_PARTITION, i+2, extension, ZERO_PAD_FMT));
+    }
+    return Arrays.asList(key, actualData, expectedRecords, expectedFiles);
+  }
+  private List<Object> generateTestDataWithoutSchema(Partitioner<?> partitioner, S3SinkConnectorConfig.AffixType affixType) {
+    String key = "key";
+    List<String> records = createJsonRecordsWithoutSchema(18);
+
+    ArrayList<SinkRecord> actualData = new ArrayList<>();
+    int offset = 0;
+    for (String record : records) {
+      actualData.add(
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, null, record,
+              offset++));
+    }
+    List<SinkRecord> expectedRecords = new ArrayList<>(actualData);
+
+    String dirPrefix = generateS3DirectoryPathWithDefaultPartitioner(
+            partitioner, affixType, PARTITION, TOPIC, "null");
+    List<String> expectedFiles = new ArrayList<>();
+    for(int i = 0; i < 18; i += 9) {
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, i, extension, ZERO_PAD_FMT));
+    }
+    return Arrays.asList(key, actualData, expectedRecords, expectedFiles);
+  }
+
+  private String generateS3DirectoryPathWithDefaultPartitioner(
+      Partitioner<?> basePartitioner,
+      S3SinkConnectorConfig.AffixType affixType, int partition,
+      String topic, String schema_name) {
+    if (affixType == S3SinkConnectorConfig.AffixType.SUFFIX) {
+      return basePartitioner.generatePartitionedPath(topic,
+          "partition=" + partition + parsedConfig.get(DIRECTORY_DELIM_CONFIG)
+          + "schema_name" + "=" + schema_name);
+    } else if(affixType == S3SinkConnectorConfig.AffixType.PREFIX) {
+      return basePartitioner.generatePartitionedPath(topic,
+          "schema_name" + "=" + schema_name
+          + parsedConfig.get(DIRECTORY_DELIM_CONFIG) + "partition=" + partition);
+    } else {
+      return basePartitioner.generatePartitionedPath(topic,
+          "partition=" + partition);
+    }
+  }
+
+  protected List<String> createJsonRecordsWithoutSchema(int size) {
+    ArrayList<String> records = new ArrayList<>();
+    int ibase = 16;
+    float fbase = 12.2f;
+    for (int i = 0; i < size; ++i) {
+      String record = "{\"schema\":{\"type\":\"struct\",\"fields\":[ " +
+          "{\"type\":\"boolean\",\"optional\":true,\"field\":\"booleanField\"}," +
+          "{\"type\":\"int\",\"optional\":true,\"field\":\"intField\"}," +
+          "{\"type\":\"long\",\"optional\":true,\"field\":\"longField\"}," +
+          "{\"type\":\"float\",\"optional\":true,\"field\":\"floatField\"}," +
+          "{\"type\":\"double\",\"optional\":true,\"field\":\"doubleField\"}]," +
+          "\"payload\":" +
+          "{\"booleanField\":\"true\"," +
+          "\"intField\":" + String.valueOf(ibase + i) + "," +
+          "\"longField\":" + String.valueOf((long) ibase + i) + "," +
+          "\"floatField\":" + String.valueOf(fbase + i) + "," +
+          "\"doubleField\":" + String.valueOf((double) (fbase + i)) +
+          "}}";
+        records.add(record);
+    }
+    return records;
+  }
+
   private Struct createRecord(Schema schema, int ibase, float fbase) {
     return new Struct(schema)
                .put("boolean", true)
@@ -1763,6 +1782,43 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
       for (Object avroRecord : actualRecords) {
         Object expectedRecord = format.getAvroData().fromConnectData(records.get(index).schema(), records.get(index++));
         assertEquals(expectedRecord, avroRecord);
+      }
+    }
+  }
+
+  private void verifyWithJsonOutput(
+      List<String> expectedFileKeys, int expectedSize,
+      List<SinkRecord> expectedRecords, CompressionType compressionType)
+          throws IOException {
+    List<S3ObjectSummary> summaries = listObjects(S3_TEST_BUCKET_NAME, null, s3);
+    List<String> actualFiles = new ArrayList<>();
+    for (S3ObjectSummary summary : summaries) {
+      String fileKey = summary.getKey();
+      actualFiles.add(fileKey);
+    }
+
+    Collections.sort(actualFiles);
+    Collections.sort(expectedFileKeys);
+    assertThat(actualFiles, is(expectedFileKeys));
+
+    int index = 0;
+    for (String fileKey : actualFiles) {
+      Collection<Object> actualRecords = readRecordsJson(
+          S3_TEST_BUCKET_NAME, fileKey,
+          s3, compressionType);
+      assertEquals(expectedSize, actualRecords.size());
+      for (Object currentRecord : actualRecords) {
+        System.out.println(currentRecord);
+        SinkRecord expectedRecord = expectedRecords.get(index++);
+        Object expectedValue = expectedRecord.value();
+        JsonConverter converter = new JsonConverter();
+        converter.configure(Collections.singletonMap("schemas.enable", "false"), false);
+        ObjectMapper mapper = new ObjectMapper();
+        if (expectedValue instanceof Struct) {
+          byte[] expectedBytes = converter.fromConnectData(TOPIC, expectedRecord.valueSchema(), expectedRecord.value());
+          expectedValue = mapper.readValue(expectedBytes, Object.class);
+        }
+        assertEquals(expectedValue, currentRecord);
       }
     }
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -1479,7 +1479,9 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     );
   }
 
-  public void testWriteSchemaPartitionerWithAffix(boolean testWithSchemaData, S3SinkConnectorConfig.AffixType affixType) throws Exception {
+  public void testWriteSchemaPartitionerWithAffix(
+      boolean testWithSchemaData, S3SinkConnectorConfig.AffixType affixType
+  ) throws Exception {
     localProps.put(FLUSH_SIZE_CONFIG, "9");
     localProps.put(FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
     setUp();
@@ -1491,11 +1493,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     parsedConfig.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, affixType.name());
     // Define the partitioner
     Partitioner<?> basePartitioner = new DefaultPartitioner<>();
-    Partitioner<?> partitioner =  new SchemaPartitioner<>(basePartitioner);;
+    Partitioner<?> partitioner = new SchemaPartitioner<>(basePartitioner);
     partitioner.configure(parsedConfig);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null
+    );
 
     List<Object> testData;
     if (testWithSchemaData) {
@@ -1510,68 +1513,76 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     List<String> expectedFiles = (List<String>) testData.get(3);
 
 
-    for (int i=0; i<actualRecords.size(); i++) {
-      topicPartitionWriter.buffer(actualRecords.get(i));
+    for (SinkRecord actualRecord : actualRecords) {
+      topicPartitionWriter.buffer(actualRecord);
     }
     // Test actual write
     topicPartitionWriter.write();
     topicPartitionWriter.close();
 
     verifyWithJsonOutput(
-        expectedFiles, expectedRecords.size()/expectedFiles.size(), expectedRecords, CompressionType.NONE);
+        expectedFiles, expectedRecords.size() / expectedFiles.size(), expectedRecords, CompressionType.NONE
+    );
   }
 
-  private List<Object> generateTestDataWithSchema(Partitioner<?> partitioner, S3SinkConnectorConfig.AffixType affixType) {
+  private List<Object> generateTestDataWithSchema(
+      Partitioner<?> partitioner, S3SinkConnectorConfig.AffixType affixType
+  ) {
     String key = "key";
 
     Schema schema1 = SchemaBuilder.struct()
-            .name(null)
-            .version(null)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
+        .name(null)
+        .version(null)
+        .field("boolean", Schema.BOOLEAN_SCHEMA)
+        .field("int", Schema.INT32_SCHEMA)
+        .field("long", Schema.INT64_SCHEMA)
+        .field("float", Schema.FLOAT32_SCHEMA)
+        .field("double", Schema.FLOAT64_SCHEMA)
+        .build();
     List<Struct> records1 = createRecordBatches(schema1, 3, 6);
 
     Schema schema2 = SchemaBuilder.struct()
-            .name("record1")
-            .version(1)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
+        .name("record1")
+        .version(1)
+        .field("boolean", Schema.BOOLEAN_SCHEMA)
+        .field("int", Schema.INT32_SCHEMA)
+        .field("long", Schema.INT64_SCHEMA)
+        .field("float", Schema.FLOAT32_SCHEMA)
+        .field("double", Schema.FLOAT64_SCHEMA)
+        .build();
 
     List<Struct> records2 = createRecordBatches(schema2, 3, 6);
 
     Schema schema3 = SchemaBuilder.struct()
-            .name("record2")
-            .version(1)
-            .field("boolean", Schema.BOOLEAN_SCHEMA)
-            .field("int", Schema.INT32_SCHEMA)
-            .field("long", Schema.INT64_SCHEMA)
-            .field("float", Schema.FLOAT32_SCHEMA)
-            .field("double", Schema.FLOAT64_SCHEMA)
-            .build();
-
+        .name("record2")
+        .version(1)
+        .field("boolean", Schema.BOOLEAN_SCHEMA)
+        .field("int", Schema.INT32_SCHEMA)
+        .field("long", Schema.INT64_SCHEMA)
+        .field("float", Schema.FLOAT32_SCHEMA)
+        .field("double", Schema.FLOAT64_SCHEMA)
+        .build();
 
     List<Struct> records3 = createRecordBatches(schema3, 3, 6);
 
     ArrayList<SinkRecord> actualData = new ArrayList<>();
     int offset = 0;
-    for (int i=0; i<records1.size(); i++) {
+    for (int i = 0; i < records1.size(); i++) {
       actualData.add(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema1, records1.get(i),
-                      offset++));
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema1, records1.get(i),
+              offset++
+          )
+      );
       actualData.add(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema2, records2.get(i),
-                      offset++));
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema2, records2.get(i),
+              offset++
+          )
+      );
       actualData.add(
-              new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema3, records3.get(i),
-                      offset++));
+          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema3, records3.get(i),
+              offset++
+          )
+      );
     }
     List<SinkRecord> expectedRecords = new ArrayList<>();
     int ibase = 16;
@@ -1582,46 +1593,64 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     for (int i = 0; i < 6; ++i) {
       for (int j = 0; j < 3; ++j) {
         expectedRecords.add(
-                new SinkRecord(
-                        TOPIC, PARTITION, Schema.STRING_SCHEMA,
-                        key, schema1, createRecord(schema1, ibase + j, fbase + j),
-                        offset++));
+            new SinkRecord(
+                TOPIC, PARTITION, Schema.STRING_SCHEMA,
+                key, schema1, createRecord(schema1, ibase + j, fbase + j),
+                offset++
+            )
+        );
       }
     }
     for (int i = 0; i < 6; ++i) {
       for (int j = 0; j < 3; ++j) {
         expectedRecords.add(
-                new SinkRecord(
-                        TOPIC, PARTITION, Schema.STRING_SCHEMA,
-                        key, schema2, createRecord(schema2, ibase + j, fbase + j),
-                        offset++));
+            new SinkRecord(
+                TOPIC, PARTITION, Schema.STRING_SCHEMA,
+                key, schema2, createRecord(schema2, ibase + j, fbase + j),
+                offset++
+            )
+        );
       }
     }
     for (int i = 0; i < 6; ++i) {
       for (int j = 0; j < 3; ++j) {
         expectedRecords.add(
-                new SinkRecord(
-                        TOPIC, PARTITION, Schema.STRING_SCHEMA,
-                        key, schema3, createRecord(schema3, ibase + j, fbase + j),
-                        offset++));
+            new SinkRecord(
+                TOPIC, PARTITION, Schema.STRING_SCHEMA,
+                key, schema3, createRecord(schema3, ibase + j, fbase + j),
+                offset++
+            )
+        );
       }
     }
 
     String dirPrefix1 = generateS3DirectoryPathWithDefaultPartitioner(
-            partitioner, affixType, PARTITION, TOPIC, "null");
+        partitioner, affixType, PARTITION, TOPIC, "null"
+    );
     String dirPrefix2 = generateS3DirectoryPathWithDefaultPartitioner(
-            partitioner, affixType, PARTITION, TOPIC, "record1");
+        partitioner, affixType, PARTITION, TOPIC, "record1"
+    );
     String dirPrefix3 = generateS3DirectoryPathWithDefaultPartitioner(
-            partitioner, affixType, PARTITION, TOPIC, "record2");
+        partitioner, affixType, PARTITION, TOPIC, "record2"
+    );
     List<String> expectedFiles = new ArrayList<>();
-    for(int i = 0; i < 54; i += 9) {
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix1, TOPIC_PARTITION, i, extension, ZERO_PAD_FMT));
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix2, TOPIC_PARTITION, i+1, extension, ZERO_PAD_FMT));
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix3, TOPIC_PARTITION, i+2, extension, ZERO_PAD_FMT));
+    for (int i = 0; i < 54; i += 9) {
+      expectedFiles.add(FileUtils.fileKeyToCommit(
+          topicsDir, dirPrefix1, TOPIC_PARTITION, i, extension, ZERO_PAD_FMT
+      ));
+      expectedFiles.add(FileUtils.fileKeyToCommit(
+          topicsDir, dirPrefix2, TOPIC_PARTITION, i + 1, extension, ZERO_PAD_FMT
+      ));
+      expectedFiles.add(FileUtils.fileKeyToCommit(
+          topicsDir, dirPrefix3, TOPIC_PARTITION, i + 2, extension, ZERO_PAD_FMT
+      ));
     }
     return Arrays.asList(key, actualData, expectedRecords, expectedFiles);
   }
-  private List<Object> generateTestDataWithoutSchema(Partitioner<?> partitioner, S3SinkConnectorConfig.AffixType affixType) {
+
+  private List<Object> generateTestDataWithoutSchema(
+      Partitioner<?> partitioner, S3SinkConnectorConfig.AffixType affixType
+  ) {
     String key = "key";
     List<String> records = createJsonRecordsWithoutSchema(18);
 
@@ -1629,16 +1658,21 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     int offset = 0;
     for (String record : records) {
       actualData.add(
-          new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, null, record,
-              offset++));
+          new SinkRecord(
+              TOPIC, PARTITION, Schema.STRING_SCHEMA, key, null, record, offset++
+          )
+      );
     }
     List<SinkRecord> expectedRecords = new ArrayList<>(actualData);
 
     String dirPrefix = generateS3DirectoryPathWithDefaultPartitioner(
-            partitioner, affixType, PARTITION, TOPIC, "null");
+        partitioner, affixType, PARTITION, TOPIC, "null"
+    );
     List<String> expectedFiles = new ArrayList<>();
-    for(int i = 0; i < 18; i += 9) {
-      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, i, extension, ZERO_PAD_FMT));
+    for (int i = 0; i < 18; i += 9) {
+      expectedFiles.add(FileUtils.fileKeyToCommit(
+          topicsDir, dirPrefix, TOPIC_PARTITION, i, extension, ZERO_PAD_FMT
+      ));
     }
     return Arrays.asList(key, actualData, expectedRecords, expectedFiles);
   }
@@ -1646,15 +1680,16 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   private String generateS3DirectoryPathWithDefaultPartitioner(
       Partitioner<?> basePartitioner,
       S3SinkConnectorConfig.AffixType affixType, int partition,
-      String topic, String schema_name) {
+      String topic, String schema_name
+  ) {
     if (affixType == S3SinkConnectorConfig.AffixType.SUFFIX) {
       return basePartitioner.generatePartitionedPath(topic,
           "partition=" + partition + parsedConfig.get(DIRECTORY_DELIM_CONFIG)
-          + "schema_name" + "=" + schema_name);
-    } else if(affixType == S3SinkConnectorConfig.AffixType.PREFIX) {
+              + "schema_name" + "=" + schema_name);
+    } else if (affixType == S3SinkConnectorConfig.AffixType.PREFIX) {
       return basePartitioner.generatePartitionedPath(topic,
           "schema_name" + "=" + schema_name
-          + parsedConfig.get(DIRECTORY_DELIM_CONFIG) + "partition=" + partition);
+              + parsedConfig.get(DIRECTORY_DELIM_CONFIG) + "partition=" + partition);
     } else {
       return basePartitioner.generatePartitionedPath(topic,
           "partition=" + partition);
@@ -1679,7 +1714,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
           "\"floatField\":" + String.valueOf(fbase + i) + "," +
           "\"doubleField\":" + String.valueOf((double) (fbase + i)) +
           "}}";
-        records.add(record);
+      records.add(record);
     }
     return records;
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3StorageTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3StorageTest.java
@@ -142,7 +142,7 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
     String configPrefix = S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CONFIG_PREFIX;
     localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.ACCESS_KEY_NAME), "foo_key");
     localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.SECRET_KEY_NAME), "bar_secret");
-    localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME), "3");
+    localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME), "5");
     localProps.put(
         S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
         DummyAssertiveCredentialsProvider.class.getName()

--- a/pom.xml
+++ b/pom.xml
@@ -252,8 +252,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CCMSG-2232

## Solution
Will expose subject name strategy in cloud template; for an on-prem customer can easily override the value converter config.
Added Schema based partitioner for supporting multiple writers for different schemas

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

Manually tested in CP:
Attached screenshots with json data, json data with schema in payload (schema2), schema in sr:
<img width="1602" alt="Screenshot 2022-12-01 at 4 48 41 PM" src="https://user-images.githubusercontent.com/105902781/205040450-6ac21e8a-4bdf-424e-8384-c672e9c897cb.png">

Screenshot with prefix:
<img width="1602" alt="Screenshot 2022-12-01 at 4 48 27 PM" src="https://user-images.githubusercontent.com/105902781/205040690-a9c2bde7-e31f-4403-8295-6bc516683702.png">
<img width="1595" alt="Screenshot 2022-12-01 at 4 48 11 PM" src="https://user-images.githubusercontent.com/105902781/205040708-3679f1c0-6071-41da-9caa-1a3c2944b13b.png">

Suffix Screenshot:
<img width="1602" alt="Screenshot 2022-12-01 at 4 51 26 PM" src="https://user-images.githubusercontent.com/105902781/205040751-ab90a6c8-c056-4b9f-b85c-f44f289e92d7.png">


## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
