### PR TITLE
CCMSG-2361 | Support writing of tombstone records.

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -637,10 +637,12 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Importance.LOW,
           "How to handle records with a null value (i.e. Kafka tombstone records)."
               + " Valid options are 'ignore', 'fail' and 'write'."
+              + " Ignore would skip the tombstone record and fail would cause the connector task to"
+              + " throw an exception."
               + " In case of the write tombstone option, the connector redirects tombstone records"
               + " to a separate directory mentioned in the config tombstone.encoded.partition."
-              + " The storage of keys is mandatory when this option is selected and the file for"
-              + " values is not generated.",
+              + " The storage of Kafka record keys is mandatory when this option is selected and"
+              + " the file for values is not generated for tombstone records.",
           group,
           ++orderInGroup,
           Width.SHORT,
@@ -654,7 +656,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Type.STRING,
           TOMBSTONE_ENCODED_PARTITION_DEFAULT,
           Importance.LOW,
-          "Output partition to write the tombstone records to.",
+          "Output s3 folder to write the tombstone records to. The configured"
+              + " partitioner would map tombstone records to this output folder.",
           group,
           ++orderInGroup,
           Width.SHORT,

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorValidator.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorValidator.java
@@ -36,6 +36,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
+import static io.confluent.connect.s3.S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.COMPRESSION_TYPE_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
@@ -90,6 +91,8 @@ public class S3SinkConnectorValidator {
           s3SinkConnectorConfig.storeKafkaKeys(), s3SinkConnectorConfig.keysFormatClass(),
           s3SinkConnectorConfig.storeKafkaHeaders(), s3SinkConnectorConfig.headersFormatClass()
       );
+      validateTombstoneWriter(s3SinkConnectorConfig.isTombstoneWriteEnabled(),
+          s3SinkConnectorConfig.storeKafkaKeys());
     }
 
     return new Config(new ArrayList<>(this.valuesByKey.values()));
@@ -125,6 +128,14 @@ public class S3SinkConnectorValidator {
               STORE_KAFKA_HEADERS_CONFIG, HEADERS_FORMAT_CLASS_CONFIG, COMPRESSION_TYPE_CONFIG);
         }
       }
+    }
+  }
+
+  public void validateTombstoneWriter(boolean isTombstoneWriteEnabled, boolean isStoreKeysEnabled) {
+    if (isTombstoneWriteEnabled && !isStoreKeysEnabled) {
+      recordErrors(
+          "Writing keys to storage is mandatory when tombstone writing is enabled.",
+          STORE_KAFKA_KEYS_CONFIG, BEHAVIOR_ON_NULL_VALUES_CONFIG);
     }
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorValidator.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorValidator.java
@@ -134,7 +134,8 @@ public class S3SinkConnectorValidator {
   public void validateTombstoneWriter(boolean isTombstoneWriteEnabled, boolean isStoreKeysEnabled) {
     if (isTombstoneWriteEnabled && !isStoreKeysEnabled) {
       recordErrors(
-          "Writing keys to storage is mandatory when tombstone writing is enabled.",
+          "Writing Kafka record keys to storage is mandatory when tombstone writing is"
+              + " enabled.",
           STORE_KAFKA_KEYS_CONFIG, BEHAVIOR_ON_NULL_VALUES_CONFIG);
     }
   }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -18,7 +18,6 @@ package io.confluent.connect.s3;
 import com.amazonaws.AmazonClientException;
 import io.confluent.connect.s3.S3SinkConnectorConfig.OutputWriteBehavior;
 import io.confluent.connect.s3.util.TombstoneSupportedPartitioner;
-import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreOrFailBehavior;
 import io.confluent.connect.s3.util.SchemaPartitioner;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
@@ -269,10 +268,12 @@ public class S3SinkTask extends SinkTask {
       } else if (connectorConfig.nullValueBehavior()
           .equalsIgnoreCase(OutputWriteBehavior.WRITE.toString())) {
         log.debug(
-            "Null valued record from topic '{}', partition {} and offset {} was written.",
+            "Null valued record from topic '{}', partition {} and offset {} was written in the"
+                + "partition {}.",
             record.topic(),
             record.kafkaPartition(),
-            record.kafkaOffset()
+            record.kafkaOffset(),
+            connectorConfig.getTombstoneEncodedPartition()
         );
         return false;
       } else {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -17,19 +17,19 @@
 package io.confluent.connect.s3.format;
 
 
-import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
-import org.apache.kafka.connect.errors.DataException;
-import org.apache.kafka.connect.sink.SinkRecord;
+import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
+import static java.util.Objects.requireNonNull;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.errors.DataException;
+import org.apache.kafka.connect.sink.SinkRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
-import static java.util.Objects.requireNonNull;
 
 /**
  * A class that adds a record writer layer to manage writing values, keys and headers
@@ -42,7 +42,7 @@ public class KeyValueHeaderRecordWriterProvider
   private static final Logger log =
       LoggerFactory.getLogger(KeyValueHeaderRecordWriterProvider.class);
 
-  @NotNull
+  @Nullable
   private final RecordWriterProvider<S3SinkConnectorConfig> valueProvider;
 
   @Nullable
@@ -75,20 +75,26 @@ public class KeyValueHeaderRecordWriterProvider
         ? filename.substring(0, filename.length() - valueProvider.getExtension().length())
         : filename;
 
-    RecordWriter valueWriter = valueProvider.getRecordWriter(conf, strippedFilename);
-    RecordWriter keyWriter =
-        keyProvider == null ? null : keyProvider.getRecordWriter(conf, strippedFilename);
-    RecordWriter headerWriter =
-        headerProvider == null ? null : headerProvider.getRecordWriter(conf, strippedFilename);
+    Optional<RecordWriter> valueWriter = filename.contains(conf.getTombstoneEncodedPartition())
+        ? Optional.empty() : Optional.of(valueProvider.getRecordWriter(conf, strippedFilename));
+    Optional<RecordWriter> keyWriter = Optional.ofNullable(keyProvider)
+            .map(keyProvider -> keyProvider.getRecordWriter(conf, strippedFilename));
+    Optional<RecordWriter> headerWriter = Optional.ofNullable(headerProvider)
+            .map(headerProvider -> headerProvider.getRecordWriter(conf, strippedFilename));
 
     return new RecordWriter() {
       @Override
       public void write(SinkRecord sinkRecord) {
+        if (conf.isTombstoneWriteEnabled() && !keyWriter.isPresent()) {
+          throw new ConnectException(
+              "Key Writer must be configured when writing tombstone records is enabled.");
+        }
+
         // The two data exceptions below must be caught before writing the value
         // to avoid misaligned K/V/H files.
 
         // keyWriter != null means writing keys is turned on
-        if (keyWriter != null && sinkRecord.key() == null) {
+        if (keyWriter.isPresent() && sinkRecord.key() == null) {
           throw new DataException(
               String.format("Key cannot be null for SinkRecord: %s",
                   sinkRecordToLoggableString(sinkRecord))
@@ -96,7 +102,7 @@ public class KeyValueHeaderRecordWriterProvider
         }
 
         // headerWriter != null means writing headers is turned on
-        if (headerWriter != null
+        if (headerWriter.isPresent()
             && (sinkRecord.headers() == null || sinkRecord.headers().isEmpty())) {
           throw new DataException(
               String.format("Headers cannot be null for SinkRecord: %s",
@@ -104,35 +110,51 @@ public class KeyValueHeaderRecordWriterProvider
           );
         }
 
-        valueWriter.write(sinkRecord); // null check happens in sink task
-        if (keyWriter != null) {
-          keyWriter.write(sinkRecord);
+        if (sinkRecord.value() == null) {
+          validateTombstoneWriteEnabled(sinkRecord);
+        } else {
+          writeValue(sinkRecord);
         }
-        if (headerWriter != null) {
-          headerWriter.write(sinkRecord);
+        keyWriter.ifPresent(writer -> writer.write(sinkRecord));
+        headerWriter.ifPresent(writer -> writer.write(sinkRecord));
+      }
+
+      private void writeValue(SinkRecord sinkRecord) {
+        if (valueWriter.isPresent()) {
+          valueWriter.get().write(sinkRecord);
+        } else {
+          throw new ConnectException(
+              String.format("Value writer not configured for SinkRecord: %s."
+                      + " fileName: %s, tombstonePartition: %s",
+                  sinkRecordToLoggableString(sinkRecord), filename,
+                  conf.getTombstoneEncodedPartition())
+          );
+        }
+      }
+
+      private void validateTombstoneWriteEnabled(SinkRecord sinkRecord) {
+        if (conf.isTombstoneWriteEnabled()) {
+          // Skip the record value writing, the corresponding key should be written.
+        } else {
+          throw new ConnectException(
+              String.format("Tombstone write must be enabled to sink null valued SinkRecord: %s",
+                  sinkRecordToLoggableString(sinkRecord))
+          );
         }
       }
 
       @Override
       public void close() {
-        valueWriter.close();
-        if (keyWriter != null) {
-          keyWriter.close();
-        }
-        if (headerWriter != null) {
-          headerWriter.close();
-        }
+        valueWriter.ifPresent(RecordWriter::close);
+        keyWriter.ifPresent(RecordWriter::close);
+        headerWriter.ifPresent(RecordWriter::close);
       }
 
       @Override
       public void commit() {
-        valueWriter.commit();
-        if (keyWriter != null) {
-          keyWriter.commit();
-        }
-        if (headerWriter != null) {
-          headerWriter.commit();
-        }
+        valueWriter.ifPresent(RecordWriter::commit);
+        keyWriter.ifPresent(RecordWriter::commit);
+        headerWriter.ifPresent(RecordWriter::commit);
       }
     };
   }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/TombstoneSupportedPartitioner.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/TombstoneSupportedPartitioner.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.util;
+
+import io.confluent.connect.storage.partitioner.DefaultPartitioner;
+import io.confluent.connect.storage.partitioner.Partitioner;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+public class TombstoneSupportedPartitioner<T> extends DefaultPartitioner<T> {
+
+  private final Partitioner<T> delegatePartitioner;
+  private final String tombstonePartition;
+
+  public TombstoneSupportedPartitioner(Partitioner<T> delegatePartitioner,
+      String tombstonePartition) {
+    this.delegatePartitioner = delegatePartitioner;
+    this.tombstonePartition = tombstonePartition;
+  }
+
+  @Override
+  public void configure(Map<String, Object> map) {
+    delegatePartitioner.configure(map);
+  }
+
+  @Override
+  public String encodePartition(SinkRecord sinkRecord) {
+    return sinkRecord.value() == null ? this.tombstonePartition
+        : delegatePartitioner.encodePartition(sinkRecord);
+  }
+
+  @Override
+  public String generatePartitionedPath(String s, String s1) {
+    return delegatePartitioner.generatePartitionedPath(s, s1);
+  }
+
+  @Override
+  public List<T> partitionFields() {
+    return delegatePartitioner.partitionFields();
+  }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/TombstoneTimestampExtractor.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/TombstoneTimestampExtractor.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.util;
+
+import io.confluent.connect.storage.partitioner.TimeBasedPartitioner.RecordTimestampExtractor;
+import io.confluent.connect.storage.partitioner.TimestampExtractor;
+import java.util.Map;
+import org.apache.kafka.connect.connector.ConnectRecord;
+
+public class TombstoneTimestampExtractor implements TimestampExtractor {
+
+  private final TimestampExtractor delegateTimestampExtractor;
+  private static final TimestampExtractor recordTimestampExtractor
+      = new RecordTimestampExtractor();
+
+  public TombstoneTimestampExtractor(TimestampExtractor delegateTimestampExtractor) {
+    this.delegateTimestampExtractor = delegateTimestampExtractor;
+  }
+
+  @Override
+  public void configure(Map<String, Object> map) {
+    delegateTimestampExtractor.configure(map);
+    recordTimestampExtractor.configure(map);
+  }
+
+  @Override
+  public Long extract(ConnectRecord<?> connectRecord) {
+    if (connectRecord.value() == null) {
+      return recordTimestampExtractor.extract(connectRecord);
+    }
+    return delegateTimestampExtractor.extract(connectRecord);
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -115,6 +115,44 @@ public abstract class BaseConnectorIT {
   }
 
   /**
+   * Get a list of the expected filenames containing keys for the tombstone records for the bucket.
+   * <p>
+   * Format: topics/s3_topic/tombstone/s3_topic+97+0000000001.keys.avro
+   *
+   * @param topic      the test kafka topic
+   * @param partition  the expected partition for the tests
+   * @param flushSize  the flush size connector config
+   * @param numRecords the number of records produced in the test
+   * @param extension  the expected extensions of the files including compression (snappy.parquet)
+   * @param tombstonePartition  the expected directory for tombstone records
+   * @return the list of expected filenames
+   */
+  protected List<String> getExpectedTombstoneFilenames(
+      String topic,
+      int partition,
+      int flushSize,
+      long numRecords,
+      String extension,
+      String tombstonePartition
+  ) {
+    int expectedFileCount = (int) numRecords / flushSize;
+    List<String> expectedFiles = new ArrayList<>();
+    for (int offset = 0; offset < expectedFileCount * flushSize; offset += flushSize) {
+      String filepath = String.format(
+          "topics/%s/%s/%s+%d+%010d.keys.%s",
+          topic,
+          tombstonePartition,
+          topic,
+          partition,
+          offset,
+          extension
+      );
+      expectedFiles.add(filepath);
+    }
+    return expectedFiles;
+  }
+
+  /**
    * Check if the file names in the bucket have the expected namings.
    *
    * @param bucketName    the name of the bucket with the files


### PR DESCRIPTION
## Problem
This PR adds a third option to behavior.on.null.values to write the tombstone records. It also introduces a new config tombstone.encoded.partition.
It creates a new decorator to the existing partitioner to redirect all the tombstone records to tombstone.encoded.partition when the tombstone write option is enabled.
The key writer becomes mandatory while sinking tombstone records.

Sinking of tombstone records to a separate output directory is a design choice made so as to avoid interleaving regular records with tombstone records.  This would trigger aggressive schema based rotations everytime a tombstone is encountered (resulting into a lot of small files being generated). Once while transitioning from some schema -> null and then while transitioning from null -> some schema.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
