### PR TITLE
CCMSG-2368: Cache short-lived credentials when using AWSAssumeRoleCredentialProvider

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -108,7 +108,6 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
 
   @Override
   public void refresh() {
-    // STSAssumeRoleSessionCredentialsProvider refreshes credentials every 900s, but refresh()
     // performs a force refresh of credentials
     if (stsCredentialProvider != null) {
       stsCredentialProvider.refresh();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java
@@ -67,6 +67,10 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
 
   private BasicAWSCredentials basicCredentials;
 
+  // STSAssumeRoleSessionCredentialsProvider takes care of refreshing short-lived
+  // credentials 60 seconds before it's expiry
+  private STSAssumeRoleSessionCredentialsProvider stsCredentialProvider;
+
   @Override
   public void configure(Map<String, ?> configs) {
     AbstractConfig config = new AbstractConfig(STS_CONFIG_DEF, configs);
@@ -77,32 +81,38 @@ public class AwsAssumeRoleCredentialsProvider implements AWSCredentialsProvider,
     final String secretKey = (String) configs.get(AWS_SECRET_ACCESS_KEY_CONFIG);
     if (StringUtils.isNotBlank(accessKeyId) && StringUtils.isNotBlank(secretKey)) {
       basicCredentials = new BasicAWSCredentials(accessKeyId, secretKey);
+      stsCredentialProvider = new STSAssumeRoleSessionCredentialsProvider
+          .Builder(roleArn, roleSessionName)
+          .withStsClient(AWSSecurityTokenServiceClientBuilder
+              .standard()
+              .withCredentials(new AWSStaticCredentialsProvider(basicCredentials)).build()
+          )
+          .withExternalId(roleExternalId)
+          .build();
     } else {
       basicCredentials = null;
+      stsCredentialProvider = new STSAssumeRoleSessionCredentialsProvider
+          .Builder(roleArn, roleSessionName)
+          // default sts client will internally use default credentials chain provider
+          // https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html#credentials-default
+          .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
+          .withExternalId(roleExternalId)
+          .build();
     }
   }
 
   @Override
   public AWSCredentials getCredentials() {
-    if (basicCredentials != null) {
-      return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
-              .withStsClient(AWSSecurityTokenServiceClientBuilder.standard()
-                 .withCredentials(new AWSStaticCredentialsProvider(basicCredentials)).build())
-              .withExternalId(roleExternalId)
-              .build()
-              .getCredentials();
-    } else {
-      return new STSAssumeRoleSessionCredentialsProvider.Builder(roleArn, roleSessionName)
-            .withStsClient(AWSSecurityTokenServiceClientBuilder.defaultClient())
-            .withExternalId(roleExternalId)
-            .build()
-            .getCredentials();
-    }
+    return stsCredentialProvider.getCredentials();
   }
 
   @Override
   public void refresh() {
-    // Nothing to do really, since we acquire a new session every getCredentials() call.
+    // STSAssumeRoleSessionCredentialsProvider refreshes credentials every 900s, but refresh()
+    // performs a force refresh of credentials
+    if (stsCredentialProvider != null) {
+      stsCredentialProvider.refresh();
+    }
   }
 
 }


### PR DESCRIPTION
## Problem
[CCMSG-2368](https://confluentinc.atlassian.net/browse/CCMSG-2368): Some customers reported seeing 427 (throttles) from AWS STS service because we are not caching STS assume role call's credentials. 

## Solution
- Start caching  credentials fetched vis STSAssumeRoleCredential provider
- AWS sdk's STSAssumeRoleCredentialProvider implementation already takes care of refreshing the fetched temp creds via a background [thread](https://github.com/aws/aws-sdk-java/blob/6059d1033b8be1de544f679732e18220d22a848a/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/STSAssumeRoleSessionCredentialsProvider.java#L34-L48) before expiry

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy
Tested manually for CP

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [X] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
Release a patch version