### PR TITLE
CC-18749 CVE fix : Pins nimbus-jose-jwt version in pom.xml 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <jettison.version>1.5.1</jettison.version>
         <woodstox.version>5.4.0</woodstox.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
+        <com.nimbusds.nimbus-jose-jwt.version>9.29</com.nimbusds.nimbus-jose-jwt.version>
     </properties>
 
     <repositories>
@@ -187,6 +188,11 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>${com.nimbusds.nimbus-jose-jwt.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,6 @@
         <jettison.version>1.5.1</jettison.version>
         <woodstox.version>5.4.0</woodstox.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
-        <com.nimbusds.nimbus-jose-jwt.version>9.29</com.nimbusds.nimbus-jose-jwt.version>
     </properties>
 
     <repositories>
@@ -148,6 +147,10 @@
                     <artifactId>avro</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>com.nimbusds</groupId>
+                    <artifactId>nimbus-jose-jwt</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
@@ -188,11 +191,6 @@
                     <artifactId>slf4j-log4j12</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>com.nimbusds</groupId>
-            <artifactId>nimbus-jose-jwt</artifactId>
-            <version>${com.nimbusds.nimbus-jose-jwt.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Problem
An update to hadoop in kafka-connect-storage-cloud reintroduced this vulnerability due to a shaded jar: nimbus-jose-jwt-9.8.1.jar
The dependency com.nimbusds:nimbus-jose-jwt:jar:9.8.1  comes as follows -
```
io.confluent:kafka-connect-s3:jar:*-SNAPSHOT
 org.apache.hadoop:hadoop-common:jar:3.2.4:compile
     org.apache.hadoop:hadoop-auth:jar:3.2.4:compile
         com.nimbusds:nimbus-jose-jwt:jar:9.8.1:compile
```

All below tickets have reported the same jar issue in different branches. 
[CCMSG-2359](https://confluentinc.atlassian.net/browse/CCMSG-2359): Vulnerable dependency "net.minidev_json-smart:1.3.2" for kafka-connect-storage-cloud:5.5.x-latest
[CC-18749](https://confluentinc.atlassian.net/browse/CC-18749): Request to fix CVE-2021-31684: net.minidev_json-smart in kafka-connect-storage-cloud
[CC-18767](https://confluentinc.atlassian.net/browse/CC-18767): Request to fix CVE-2021-31684: net.minidev:json-smart in kafka-connect-storage-cloud
https://confluentinc.atlassian.net/browse/CCMSG-2337 
https://confluentinc.atlassian.net/browse/CCMSG-2345

## Solution
Checked that hadoop-common latest non-vulnerable version uses 9.8.1 of com.nimbusds:nimbus-jose-jwt:jar
so adding the dependency directly into parent pom.
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CCMSG-2359]: https://confluentinc.atlassian.net/browse/CCMSG-2359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-18749]: https://confluentinc.atlassian.net/browse/CC-18749?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-18767]: https://confluentinc.atlassian.net/browse/CC-18767?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ