### PR TITLE
CC-18575: Exclude commons-net from hadoop-common dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,6 +209,10 @@
                     <groupId>org.eclipse.jetty</groupId>
                     <artifactId>jetty-util</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>commons-net</groupId>
+                    <artifactId>commons-net</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Problem
- https://confluentinc.atlassian.net/browse/CC-18575
- commons-net dependency has a CVE which is coming from hadoop-common parent dep. 

## Solution
- Exclude this CVE dependency from parent dependency. 
 
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
- Manual testing on kafka-docker-playground. 

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
