### PR TITLE
Minor: Remove property confluent.maven.repo and use url directly

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,6 @@
     </modules>
 
     <properties>
-        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <licenses.version>5.5.14-SNAPSHOT</licenses.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
@@ -71,7 +70,7 @@
         <repository>
             <id>confluent</id>
             <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
## Problem
Build is failing with following error - 
```
The project io.confluent:kafka-connect-storage-cloud:10.0.17-SNAPSHOT (/home/jenkins/workspace/fka-connect-storage-cloud_PR-611/pom.xml) has 1 error
10:38:32  [ERROR]     Non-resolvable parent POM for io.confluent:kafka-connect-storage-cloud:10.0.17-SNAPSHOT: Could not transfer artifact io.confluent:kafka-connect-storage-common-parent:pom:11.0.18 from/to confluent (${confluent.maven.repo}): Cannot access ${confluent.maven.repo} with type default using the available connector factories: BasicRepositoryConnectorFactory and 'parent.relativePath' points at wrong local POM @ line 21, column 13: Cannot access ${confluent.maven.repo} using the registered transporter factories: WagonTransporterFactory: Unsupported transport protocol -> [Help 2]
```

## Solution
- To fix this, we need to use url directly as suggested in this PR - https://github.com/confluentinc/kafka-connect-elasticsearch/pull/419

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
