### PR TITLE
Minor: Bump kafka-connect-storage-common version to 11.0.19 to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.15</version>
+        <version>11.0.19</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,12 @@
             <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-http</artifactId>
+            <version>9.4.48.v20220622</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Problem
- https://confluentinc.atlassian.net/browse/CC-18978
- protobuf java vulnerable version

## Solution
- Bring in latest version of kafka-connect-storage-common which has fix - https://github.com/confluentinc/kafka-connect-storage-common/pull/300

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
