### PR TITLE
CCMSG-2432 Update SnakeYaml to address CVE-2022-1471

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <hadoop.version>3.2.4</hadoop.version>
         <jettison.version>1.5.2</jettison.version>
         <jetty.version>9.4.48.v20220622</jetty.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox.version>5.4.0</woodstox.version>
     </properties>
 
@@ -73,6 +74,17 @@
             <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- band aid until connector catches up with the updated schema registry -->
+            <dependency>
+                <groupId>org.yaml</groupId>
+                <artifactId>snakeyaml</artifactId>
+                <version>${snakeyaml.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>


### PR DESCRIPTION
## Problem
SnakeYaml brought in as transitive dependency of Schema Registry is affected by CVE-2022-1471

## Solution
Pin the SnakeYaml dependency version until non vulnerable version will be brought in from an updated Schema Registry

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
