### PR TITLE
CC-19464 | Add logs to track the count for each of the rotation criteria. This helps debug at runtime the number of rotations that occurred for each criteria.

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -232,6 +232,11 @@ public class S3SinkTask extends SinkTask {
       TopicPartitionWriter writer = topicPartitionWriters.get(tp);
       try {
         writer.write();
+        if (log.isDebugEnabled()) {
+          log.debug("TopicPartition: {}, SchemaCompatibility:{}, FileRotations: {}",
+              tp.toString(), writer.getSchemaCompatibility(),
+              writer.getFileRotationTracker().toString());
+        }
       } catch (RetriableException e) {
         log.error("Exception on topic partition {}: ", tp, e);
         Long currentStartOffset = writer.currentStartOffset();

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/FileRotationTracker.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/FileRotationTracker.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2022 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.util;
+
+import io.confluent.connect.storage.schema.SchemaIncompatibilityType;
+import java.util.HashMap;
+import java.util.Map;
+
+public final class FileRotationTracker {
+
+  private final Map<String, RotationMetrics> metrics = new HashMap<>();
+
+  private static final class RotationMetrics {
+
+    int rotationByFlushSize = 0;
+
+    int rotationByRotationInterval = 0;
+
+    int rotationByScheduledRotationInterval = 0;
+
+    int rotationByDiffSchema = 0;
+
+    int rotationByDiffName = 0;
+
+    int rotationByDiffParams = 0;
+
+    int rotationByDiffType = 0;
+
+    int rotationByDiffVersion = 0;
+
+    public void incrementRotationBySchemaChangeCount(
+        SchemaIncompatibilityType schemaIncompatibilityType) {
+      switch (schemaIncompatibilityType) {
+        case DIFFERENT_NAME:
+          rotationByDiffName++;
+          break;
+        case DIFFERENT_SCHEMA:
+          rotationByDiffSchema++;
+          break;
+        case DIFFERENT_PARAMS:
+          rotationByDiffParams++;
+          break;
+        case DIFFERENT_TYPE:
+          rotationByDiffType++;
+          break;
+        case DIFFERENT_VERSION:
+          rotationByDiffVersion++;
+          break;
+        default:
+      }
+    }
+
+    public void incrementRotationByFlushSizeCount() {
+      rotationByFlushSize++;
+    }
+
+    public void incrementRotationByRotationIntervalCount() {
+      rotationByRotationInterval++;
+    }
+
+    public void incrementRotationByScheduledRotationIntervalCount() {
+      rotationByScheduledRotationInterval++;
+    }
+  }
+
+  public void incrementRotationBySchemaChangeCount(String outputPartition,
+      SchemaIncompatibilityType schemaIncompatibilityType) {
+    if (!metrics.containsKey(outputPartition)) {
+      metrics.put(outputPartition, new RotationMetrics());
+    }
+    metrics.get(outputPartition).incrementRotationBySchemaChangeCount(schemaIncompatibilityType);
+  }
+
+  public void incrementRotationByFlushSizeCount(String outputPartition) {
+    if (!metrics.containsKey(outputPartition)) {
+      metrics.put(outputPartition, new RotationMetrics());
+    }
+    metrics.get(outputPartition).incrementRotationByFlushSizeCount();
+  }
+
+  public void incrementRotationByRotationIntervalCount(String outputPartition) {
+    if (!metrics.containsKey(outputPartition)) {
+      metrics.put(outputPartition, new RotationMetrics());
+    }
+    metrics.get(outputPartition).incrementRotationByRotationIntervalCount();
+  }
+
+  public void incrementRotationByScheduledRotationIntervalCount(String outputPartition) {
+    if (!metrics.containsKey(outputPartition)) {
+      metrics.put(outputPartition, new RotationMetrics());
+    }
+    metrics.get(outputPartition).incrementRotationByScheduledRotationIntervalCount();
+  }
+
+  public void clear() {
+    metrics.clear();
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    for (Map.Entry<String, RotationMetrics> metrics : metrics.entrySet()) {
+      RotationMetrics rotationMetrics = metrics.getValue();
+      sb.append("OutputPartition: ");
+      sb.append(metrics.getKey());
+      sb.append(", RotationByInterval: ");
+      sb.append(rotationMetrics.rotationByRotationInterval);
+      sb.append(", RotationByScheduledInterval: ");
+      sb.append(rotationMetrics.rotationByScheduledRotationInterval);
+      sb.append(", RotationByFlushSize: ");
+      sb.append(rotationMetrics.rotationByFlushSize);
+      sb.append(", RotationByDiffName: ");
+      sb.append(rotationMetrics.rotationByDiffName);
+      sb.append(", RotationByDiffSchema: ");
+      sb.append(rotationMetrics.rotationByDiffSchema);
+      sb.append(", RotationByDiffType: ");
+      sb.append(rotationMetrics.rotationByDiffType);
+      sb.append(", RotationByDiffVersion: ");
+      sb.append(rotationMetrics.rotationByDiffVersion);
+      sb.append(", RotationByDiffParams: ");
+      sb.append(rotationMetrics.rotationByDiffParams);
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+}
+
+

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/SchemaCompatibilityTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/SchemaCompatibilityTest.java
@@ -94,7 +94,7 @@ public class SchemaCompatibilityTest extends S3SinkConnectorTestBase {
       SinkRecord sinkRecordNoSchema = new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, null, record, 16);
 
       // Test when both schemas are null
-      assertFalse(mode.shouldChangeSchema(sinkRecordNoSchema, null, null));
+      assertFalse(mode.shouldChangeSchema(sinkRecordNoSchema, null, null).isInCompatible());
 
       try {
         mode.shouldChangeSchema(sinkRecord, null, null);
@@ -120,8 +120,8 @@ public class SchemaCompatibilityTest extends S3SinkConnectorTestBase {
           }
           break;
         case NONE:
-          assertTrue(mode.shouldChangeSchema(sinkRecordNoVersion, null, sinkRecord.valueSchema()));
-          assertFalse(mode.shouldChangeSchema(sinkRecordNoVersion, null, sinkRecordNoVersion.valueSchema()));
+          assertTrue(mode.shouldChangeSchema(sinkRecordNoVersion, null, sinkRecord.valueSchema()).isInCompatible());
+          assertFalse(mode.shouldChangeSchema(sinkRecordNoVersion, null, sinkRecordNoVersion.valueSchema()).isInCompatible());
       }
     }
   }
@@ -142,28 +142,28 @@ public class SchemaCompatibilityTest extends S3SinkConnectorTestBase {
         case BACKWARD:
         case FULL:
           // new record has higher version
-          assertTrue(mode.shouldChangeSchema(newSinkRecord, null, sinkRecord.valueSchema()));
+          assertTrue(mode.shouldChangeSchema(newSinkRecord, null, sinkRecord.valueSchema()).isInCompatible());
           // new record has lower version
-          assertFalse(mode.shouldChangeSchema(sinkRecord, null, newSinkRecord.valueSchema()));
+          assertFalse(mode.shouldChangeSchema(sinkRecord, null, newSinkRecord.valueSchema()).isInCompatible());
           // Same
-          assertFalse(mode.shouldChangeSchema(sinkRecord, null, sinkRecord.valueSchema()));
+          assertFalse(mode.shouldChangeSchema(sinkRecord, null, sinkRecord.valueSchema()).isInCompatible());
           break;
         case FORWARD:
           // new record has higher version
-          assertFalse(mode.shouldChangeSchema(newSinkRecord, null, sinkRecord.valueSchema()));
+          assertFalse(mode.shouldChangeSchema(newSinkRecord, null, sinkRecord.valueSchema()).isInCompatible());
           // new record has lower version
-          assertTrue(mode.shouldChangeSchema(sinkRecord, null, newSinkRecord.valueSchema()));
+          assertTrue(mode.shouldChangeSchema(sinkRecord, null, newSinkRecord.valueSchema()).isInCompatible());
           // Same
-          assertFalse(mode.shouldChangeSchema(sinkRecord, null, sinkRecord.valueSchema()));
+          assertFalse(mode.shouldChangeSchema(sinkRecord, null, sinkRecord.valueSchema()).isInCompatible());
           break;
         case NONE:
         default:
           // new record has higher version
-          assertTrue(mode.shouldChangeSchema(newSinkRecord, null, sinkRecord.valueSchema()));
+          assertTrue(mode.shouldChangeSchema(newSinkRecord, null, sinkRecord.valueSchema()).isInCompatible());
           // new record has lower version
-          assertTrue(mode.shouldChangeSchema(sinkRecord, null, newSinkRecord.valueSchema()));
+          assertTrue(mode.shouldChangeSchema(sinkRecord, null, newSinkRecord.valueSchema()).isInCompatible());
           // Same
-          assertFalse(mode.shouldChangeSchema(sinkRecord, null, sinkRecord.valueSchema()));
+          assertFalse(mode.shouldChangeSchema(sinkRecord, null, sinkRecord.valueSchema()).isInCompatible());
       }
     }
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileRotationTrackerTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileRotationTrackerTest.java
@@ -1,0 +1,47 @@
+package io.confluent.connect.s3.util;
+
+import io.confluent.connect.storage.schema.SchemaIncompatibilityType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileRotationTrackerTest {
+
+  private static final String FILE_1 = "file1";
+
+  private static final String FILE_2 = "file2";
+
+  private static final String FILE_3 = "file3";
+
+  @Test
+  public void testRotationIncrements() {
+    FileRotationTracker fileRotationTracker = new FileRotationTracker();
+    fileRotationTracker.incrementRotationByRotationIntervalCount(FILE_1);
+    fileRotationTracker.incrementRotationByFlushSizeCount(FILE_2);
+    fileRotationTracker
+        .incrementRotationBySchemaChangeCount(FILE_3, SchemaIncompatibilityType.DIFFERENT_VERSION);
+    fileRotationTracker.incrementRotationByFlushSizeCount(FILE_1);
+    String actual = fileRotationTracker.toString();
+    String expected = "OutputPartition: file2, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0\n"
+        + "OutputPartition: file3, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 0, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 1, RotationByDiffParams: 0\n"
+        + "OutputPartition: file1, RotationByInterval: 1, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0\n";
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testRotationCountClearance() {
+    FileRotationTracker fileRotationTracker = new FileRotationTracker();
+    fileRotationTracker.incrementRotationByRotationIntervalCount(FILE_1);
+    fileRotationTracker.incrementRotationByFlushSizeCount(FILE_2);
+    fileRotationTracker
+        .incrementRotationBySchemaChangeCount(FILE_3, SchemaIncompatibilityType.DIFFERENT_VERSION);
+    fileRotationTracker.incrementRotationByFlushSizeCount(FILE_1);
+    String actual = fileRotationTracker.toString();
+    String expected = "OutputPartition: file2, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0\n"
+        + "OutputPartition: file3, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 0, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 1, RotationByDiffParams: 0\n"
+        + "OutputPartition: file1, RotationByInterval: 1, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0\n";
+    Assert.assertEquals(expected, actual);
+    fileRotationTracker.clear();
+    actual = fileRotationTracker.toString();
+    Assert.assertEquals("", actual);
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.0.20</version>
+        <version>11.2.0</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem
Currently when file rotations happen, we do not know the reason behind them. In this PR we print the rotation counts for each output file so that we know th e

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
