### PR TITLE
FEDRAMP-4815: update jetty and hodoop

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,10 +63,10 @@
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>
-        <hadoop.version>3.2.4</hadoop.version>
+        <hadoop.version>3.3.5</hadoop.version>
         <jettison.version>1.5.4</jettison.version>
         <json-smart.version>2.4.10</json-smart.version>
-        <jetty.version>9.4.48.v20220622</jetty.version>
+        <jetty.version>9.4.51.v20230217</jetty.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox.version>5.4.0</woodstox.version>
     </properties>


### PR DESCRIPTION
## Problem
Security hygiene cleanup of Jetty. 
Update of hadoop-common to avoid customers' confusion about issues in hadoop 3.2.4

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
