### PR TITLE
[Draft solution] Add S3 Sink Connector V2

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorV2.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorV2.java
@@ -1,0 +1,30 @@
+package io.confluent.connect.s3;
+
+import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.connect.connector.Task;
+
+public class S3SinkConnectorV2 extends S3SinkConnector {
+    @Override
+    public Class<? extends Task> taskClass() {
+        return S3SinkTaskV2.class;
+    }
+    public S3SinkConnectorV2() {
+        // no-arg constructor required by Connect framework.
+    }
+
+    @Override
+    public ConfigDef config() {
+        ConfigDef configDef = S3SinkConnectorConfig.getConfig();
+        configDef.define("transform.threads.max",
+                ConfigDef.Type.INT,
+                1,
+                ConfigDef.Importance.HIGH,
+                "Max number of threads to use for converting batch of records in parallel.",
+                "parallel_processing",
+                1,
+                ConfigDef.Width.LONG,
+                "Max number of threads to use for converting batch of records in parallel."
+        );
+        return configDef;
+    }
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTaskV2.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTaskV2.java
@@ -1,0 +1,86 @@
+package io.confluent.connect.s3;
+
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.apache.kafka.connect.transforms.CoerceToSegmentPayload;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import com.hotstar.kafka.connect.transforms.ProtoToPayloadTransform;
+
+public class S3SinkTaskV2 extends S3SinkTask {
+    private ExecutorService executorService;
+    public static final long THREAD_KEEP_ALIVE_TIME_SECONDS = 60L;
+    private static final Logger LOGGER = LoggerFactory.getLogger(S3SinkTaskV2.class);
+
+    private static final ProtoToPayloadTransform.Value<SinkRecord> protoToPayloadTransform = new ProtoToPayloadTransform.Value<>();
+    private static final CoerceToSegmentPayload<SinkRecord> coerceToSegmentPayloadTransform = new CoerceToSegmentPayload.Value<>();
+
+    static {
+        // This is needed to initialise the statsD client with default values.
+        protoToPayloadTransform.configure(new HashMap<>());
+
+    }
+
+
+    @Override
+    public void start(Map<String, String> props) {
+        super.start(props);
+        int transformThreadPoolMaxSize = Integer.parseInt(props.get("transform.threads.max"));
+        this.executorService = new ThreadPoolExecutor(1, transformThreadPoolMaxSize,
+                THREAD_KEEP_ALIVE_TIME_SECONDS,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<>(),
+                new ThreadPoolExecutor.CallerRunsPolicy()
+        );
+    }
+
+    @Override
+    public void put(Collection<SinkRecord> records) throws ConnectException {
+        transformInParallel(records);
+        super.put(records);
+    }
+
+    private Collection<SinkRecord> transformInParallel(Collection<SinkRecord> sinkRecords) {
+        int batchSize = sinkRecords.size();
+        SinkRecord[] kafkaRecordArray = sinkRecords.toArray(new SinkRecord[0]);
+        List<Future<SinkRecord>> futureList = new ArrayList<>(batchSize);
+//        LOGGER.debug("In transformInParallel Method.");
+        for (int i = 0; i < batchSize; i++) {
+            int recordNumber = i;
+            futureList.add(executorService.submit((Callable) () -> transformProtoToEventPayload(kafkaRecordArray[recordNumber])));
+        }
+        List<SinkRecord> transformedRecords = new ArrayList<>(batchSize);
+        futureList.stream().forEach(future -> {
+            try {
+                SinkRecord transformedRecord = future.get();
+                transformedRecords.add(transformedRecord);
+            } catch (InterruptedException e) {
+                throw new RuntimeException(e);
+            } catch (ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return transformedRecords;
+    }
+
+    private SinkRecord transformProtoToEventPayload(SinkRecord sinkRecord){
+//        LOGGER.warn("Staring protoToPayloadTransform  on {}",sinkRecord);
+        SinkRecord intermediateRecord = protoToPayloadTransform.apply(sinkRecord);
+//        LOGGER.warn("Staring coerceToSegmentPayload  on {}",intermediateRecord);
+        return coerceToSegmentPayloadTransform.apply(intermediateRecord);
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     </modules>
 
     <properties>
-        <confluent.maven.repo>http://packages.confluent.io/maven/</confluent.maven.repo>
+        <confluent.maven.repo>https://packages.confluent.io/maven/</confluent.maven.repo>
         <licenses.version>5.5.3</licenses.version>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <hadoop.version>2.7.7</hadoop.version>
@@ -67,9 +67,25 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>confluent</id>
-            <name>Confluent</name>
-            <url>${confluent.maven.repo}</url>
+            <url>https://packages.confluent.io/maven/</url>
+        </repository>
+        <repository>
+            <id>data-platform</id>
+            <name>Data Platform</name>
+            <url>https://nexus.hotstar.com/repository/data-platform/</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
         </repository>
     </repositories>
 
@@ -105,6 +121,12 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-partitioner</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.hotstar</groupId>
+            <artifactId>kafka-connect-plugins_2.11</artifactId>
+            <version>0.1.0-SNAPSHOT</version>
+<!--            <scope>provided</scope>-->
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
S3SinkConnectorV2 extends the original class S3SinkConnector.
Similarly S3SinkTaskV2 extends the original class S3SinkTask.

New connector was created so that we can still use the plain S3SinkConnector.
New SinkClass transforms the records in parallel. 

The Connectors needs the kafka-connect-plugins and the minerva jar in the directory.(This was added manually for now)

Confluent repo's url was changed and I am using https url instead of http one since I was getting dependency resolution errors in that case.

To build this package command used was : 
` mvn clean install -Dcheckstyle.skip`

