### PR TITLE
[CC-20979] [CC-20329] Updated CVEs (jackson and snappy package)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         <maven-assembly.version>2.6</maven-assembly.version>
         <maven-site-plugin.version>3.7.1</maven-site-plugin.version>
         <maven-project-info-reports-plugin.version>2.9</maven-project-info-reports-plugin.version>
+        <jackson.core.version>2.15.0</jackson.core.version>
+        <snappy.java>1.1.10.1</snappy.java>
     </properties>
 
     <repositories>
@@ -142,6 +144,16 @@
             <artifactId>powermock-api-easymock</artifactId>
             <version>${powermock.version}</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy.java}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>${jackson.core.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-20979
https://confluentinc.atlassian.net/browse/CC-20978
https://confluentinc.atlassian.net/browse/CC-20329
https://confluentinc.atlassian.net/browse/CC-20736

## Solution
Pinning snappy version since it is originating from kafka-clients package which is set in common module.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests
```
[INFO]
[INFO] --- dependency:2.8:tree (default-cli) @ kafka-connect-s3 ---
[INFO] io.confluent:kafka-connect-s3:jar:3.2.5-SNAPSHOT
[INFO] +- com.amazonaws:aws-java-sdk-s3:jar:1.11.725:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-kms:jar:1.11.725:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-core:jar:1.11.725:compile
[INFO] |  |  +- commons-logging:commons-logging:jar:1.1.3:compile
[INFO] |  |  +- org.apache.httpcomponents:httpclient:jar:4.5.9:compile
[INFO] |  |  |  \- org.apache.httpcomponents:httpcore:jar:4.4.11:compile
[INFO] |  |  +- software.amazon.ion:ion-java:jar:1.0.2:compile
[INFO] |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.6.7:compile
[INFO] |  \- com.amazonaws:jmespath-java:jar:1.11.725:compile
[INFO] +- io.findify:s3mock_2.11:jar:0.1.5:test
[INFO] |  +- org.scala-lang:scala-library:jar:2.11.8:test
[INFO] |  +- com.typesafe.akka:akka-stream_2.11:jar:2.4.14:test
[INFO] |  |  +- com.typesafe.akka:akka-actor_2.11:jar:2.4.14:test
[INFO] |  |  |  +- com.typesafe:config:jar:1.3.0:test
[INFO] |  |  |  \- org.scala-lang.modules:scala-java8-compat_2.11:jar:0.7.0:test
[INFO] |  |  +- org.reactivestreams:reactive-streams:jar:1.0.0:test
[INFO] |  |  \- com.typesafe:ssl-config-core_2.11:jar:0.2.1:test
[INFO] |  |     \- org.scala-lang.modules:scala-parser-combinators_2.11:jar:1.0.4:test
[INFO] |  +- com.typesafe.akka:akka-http_2.11:jar:10.0.0:test
[INFO] |  |  \- com.typesafe.akka:akka-http-core_2.11:jar:10.0.0:test
[INFO] |  |     \- com.typesafe.akka:akka-parsing_2.11:jar:10.0.0:test
[INFO] |  +- org.scala-lang.modules:scala-xml_2.11:jar:1.0.6:test
[INFO] |  +- com.github.pathikrit:better-files_2.11:jar:2.16.0:test
[INFO] |  \- com.typesafe.scala-logging:scala-logging_2.11:jar:3.5.0:test
[INFO] |     \- org.scala-lang:scala-reflect:jar:2.11.8:test
[INFO] +- org.apache.kafka:connect-api:jar:0.10.2.3-SNAPSHOT:provided
[INFO] |  +- org.apache.kafka:kafka-clients:jar:0.10.2.3-SNAPSHOT:provided
[INFO] |  |  \- net.jpountz.lz4:lz4:jar:1.3.0:provided
[INFO] |  \- org.slf4j:slf4j-api:jar:1.7.21:compile
[INFO] +- org.apache.kafka:connect-json:jar:0.10.2.3-SNAPSHOT:provided
[INFO] +- io.confluent:kafka-connect-storage-common:jar:3.2.5-SNAPSHOT:compile
[INFO] +- io.confluent:kafka-connect-storage-core:jar:3.2.5-SNAPSHOT:compile
[INFO] |  +- io.confluent:kafka-connect-avro-converter:jar:3.2.5-SNAPSHOT:compile
[INFO] |  |  +- io.confluent:kafka-avro-serializer:jar:3.2.5-SNAPSHOT:compile
[INFO] |  |  +- org.apache.avro:avro:jar:1.7.7:compile
[INFO] |  |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.13:compile
[INFO] |  |  |  +- com.thoughtworks.paranamer:paranamer:jar:2.3:compile
[INFO] |  |  |  \- org.apache.commons:commons-compress:jar:1.4.1:compile
[INFO] |  |  |     \- org.tukaani:xz:jar:1.0:compile
[INFO] |  |  +- io.confluent:kafka-schema-registry-client:jar:3.2.5-SNAPSHOT:compile
[INFO] |  |  \- io.confluent:common-config:jar:3.2.5-SNAPSHOT:compile
[INFO] |  |     \- io.confluent:common-utils:jar:3.2.5-SNAPSHOT:compile
[INFO] |  |        \- com.101tec:zkclient:jar:0.10:compile
[INFO] |  \- joda-time:joda-time:jar:2.9.6:compile
[INFO] +- io.confluent:kafka-connect-storage-format:jar:3.2.5-SNAPSHOT:compile
[INFO] |  +- org.apache.parquet:parquet-column:jar:1.7.0:compile
[INFO] |  |  +- org.apache.parquet:parquet-common:jar:1.7.0:compile
[INFO] |  |  +- org.apache.parquet:parquet-encoding:jar:1.7.0:compile
[INFO] |  |  |  \- org.apache.parquet:parquet-generator:jar:1.7.0:compile
[INFO] |  |  \- commons-codec:commons-codec:jar:1.5:compile
[INFO] |  \- org.apache.parquet:parquet-avro:jar:1.7.0:compile
[INFO] |     +- org.apache.parquet:parquet-hadoop:jar:1.7.0:compile
[INFO] |     |  \- org.apache.parquet:parquet-jackson:jar:1.7.0:compile
[INFO] |     \- org.apache.parquet:parquet-format:jar:2.3.0-incubating:compile
[INFO] +- io.confluent:kafka-connect-storage-hive:jar:3.2.5-SNAPSHOT:compile
[INFO] |  +- org.apache.hadoop:hadoop-client:jar:2.7.3:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-common:jar:2.7.3:compile
[INFO] |  |  |  +- commons-cli:commons-cli:jar:1.2:compile
[INFO] |  |  |  +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] |  |  |  +- xmlenc:xmlenc:jar:0.52:compile
[INFO] |  |  |  +- commons-httpclient:commons-httpclient:jar:3.1:compile
[INFO] |  |  |  +- commons-io:commons-io:jar:2.4:compile
[INFO] |  |  |  +- commons-net:commons-net:jar:3.1:compile
[INFO] |  |  |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] |  |  |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  |  |  +- log4j:log4j:jar:1.2.17:compile
[INFO] |  |  |  +- commons-lang:commons-lang:jar:2.6:compile
[INFO] |  |  |  +- commons-configuration:commons-configuration:jar:1.6:compile
[INFO] |  |  |  |  +- commons-digester:commons-digester:jar:1.8:compile
[INFO] |  |  |  |  |  \- commons-beanutils:commons-beanutils:jar:1.7.0:compile
[INFO] |  |  |  |  \- commons-beanutils:commons-beanutils-core:jar:1.8.0:compile
[INFO] |  |  |  +- com.google.protobuf:protobuf-java:jar:2.5.0:compile
[INFO] |  |  |  +- com.google.code.gson:gson:jar:2.2.4:compile
[INFO] |  |  |  +- org.apache.hadoop:hadoop-auth:jar:2.7.3:compile
[INFO] |  |  |  |  \- org.apache.directory.server:apacheds-kerberos-codec:jar:2.0.0-M15:compile
[INFO] |  |  |  |     +- org.apache.directory.server:apacheds-i18n:jar:2.0.0-M15:compile
[INFO] |  |  |  |     +- org.apache.directory.api:api-asn1-api:jar:1.0.0-M20:compile
[INFO] |  |  |  |     \- org.apache.directory.api:api-util:jar:1.0.0-M20:compile
[INFO] |  |  |  +- org.apache.curator:curator-client:jar:2.7.1:compile
[INFO] |  |  |  +- org.apache.curator:curator-recipes:jar:2.7.1:compile
[INFO] |  |  |  +- com.google.code.findbugs:jsr305:jar:3.0.0:compile
[INFO] |  |  |  +- org.apache.htrace:htrace-core:jar:3.1.0-incubating:compile
[INFO] |  |  |  \- org.apache.zookeeper:zookeeper:jar:3.4.6:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-hdfs:jar:2.7.3:compile
[INFO] |  |  |  +- org.mortbay.jetty:jetty-util:jar:6.1.26:compile
[INFO] |  |  |  +- io.netty:netty:jar:3.6.2.Final:compile
[INFO] |  |  |  +- io.netty:netty-all:jar:4.0.23.Final:compile
[INFO] |  |  |  +- xerces:xercesImpl:jar:2.9.1:compile
[INFO] |  |  |  |  \- xml-apis:xml-apis:jar:1.3.04:compile
[INFO] |  |  |  \- org.fusesource.leveldbjni:leveldbjni-all:jar:1.8:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-mapreduce-client-app:jar:2.7.3:compile
[INFO] |  |  |  +- org.apache.hadoop:hadoop-mapreduce-client-common:jar:2.7.3:compile
[INFO] |  |  |  |  +- org.apache.hadoop:hadoop-yarn-client:jar:2.7.3:compile
[INFO] |  |  |  |  \- org.apache.hadoop:hadoop-yarn-server-common:jar:2.7.3:compile
[INFO] |  |  |  \- org.apache.hadoop:hadoop-mapreduce-client-shuffle:jar:2.7.3:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-yarn-api:jar:2.7.3:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:2.7.3:compile
[INFO] |  |  |  \- org.apache.hadoop:hadoop-yarn-common:jar:2.7.3:compile
[INFO] |  |  |     +- javax.xml.bind:jaxb-api:jar:2.2.2:compile
[INFO] |  |  |     |  +- javax.xml.stream:stax-api:jar:1.0-2:compile
[INFO] |  |  |     |  \- javax.activation:activation:jar:1.1:compile
[INFO] |  |  |     +- javax.servlet:servlet-api:jar:2.5:compile
[INFO] |  |  |     +- com.sun.jersey:jersey-core:jar:1.9:compile
[INFO] |  |  |     +- com.sun.jersey:jersey-client:jar:1.9:compile
[INFO] |  |  |     +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.13:compile
[INFO] |  |  |     \- org.codehaus.jackson:jackson-xc:jar:1.9.13:compile
[INFO] |  |  +- org.apache.hadoop:hadoop-mapreduce-client-jobclient:jar:2.7.3:compile
[INFO] |  |  \- org.apache.hadoop:hadoop-annotations:jar:2.7.3:compile
[INFO] |  \- org.apache.hive.hcatalog:hive-hcatalog-core:jar:1.2.1:compile
[INFO] |     +- org.apache.hive:hive-cli:jar:1.2.1:compile
[INFO] |     |  +- org.apache.hive:hive-serde:jar:1.2.1:compile
[INFO] |     |  |  +- net.sf.opencsv:opencsv:jar:2.3:compile
[INFO] |     |  |  \- com.twitter:parquet-hadoop-bundle:jar:1.6.0:compile
[INFO] |     |  +- org.apache.hive:hive-service:jar:1.2.1:compile
[INFO] |     |  |  +- net.sf.jpam:jpam:jar:1.1:compile
[INFO] |     |  |  \- org.eclipse.jetty.aggregate:jetty-all:jar:7.6.0.v20120127:compile
[INFO] |     |  |     +- org.apache.geronimo.specs:geronimo-jta_1.1_spec:jar:1.1.1:compile
[INFO] |     |  |     +- javax.mail:mail:jar:1.4.1:compile
[INFO] |     |  |     +- org.apache.geronimo.specs:geronimo-jaspic_1.0_spec:jar:1.0:compile
[INFO] |     |  |     +- org.apache.geronimo.specs:geronimo-annotation_1.0_spec:jar:1.1.1:compile
[INFO] |     |  |     \- asm:asm-commons:jar:3.1:compile
[INFO] |     |  |        \- asm:asm-tree:jar:3.1:compile
[INFO] |     |  |           \- asm:asm:jar:3.1:compile
[INFO] |     |  +- org.apache.hive:hive-shims:jar:1.2.1:compile
[INFO] |     |  |  +- org.apache.hive.shims:hive-shims-common:jar:1.2.1:compile
[INFO] |     |  |  +- org.apache.hive.shims:hive-shims-0.20S:jar:1.2.1:runtime
[INFO] |     |  |  +- org.apache.hive.shims:hive-shims-0.23:jar:1.2.1:runtime
[INFO] |     |  |  |  \- org.apache.hadoop:hadoop-yarn-server-resourcemanager:jar:2.6.0:runtime
[INFO] |     |  |  |     +- com.google.inject.extensions:guice-servlet:jar:3.0:runtime
[INFO] |     |  |  |     +- com.google.inject:guice:jar:3.0:runtime
[INFO] |     |  |  |     |  +- javax.inject:javax.inject:jar:1:runtime
[INFO] |     |  |  |     |  \- aopalliance:aopalliance:jar:1.0:runtime
[INFO] |     |  |  |     +- com.sun.jersey:jersey-json:jar:1.9:runtime
[INFO] |     |  |  |     |  \- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:runtime
[INFO] |     |  |  |     +- com.sun.jersey.contribs:jersey-guice:jar:1.9:runtime
[INFO] |     |  |  |     |  \- com.sun.jersey:jersey-server:jar:1.9:runtime
[INFO] |     |  |  |     +- org.codehaus.jettison:jettison:jar:1.1:runtime
[INFO] |     |  |  |     +- org.apache.hadoop:hadoop-yarn-server-applicationhistoryservice:jar:2.6.0:runtime
[INFO] |     |  |  |     \- org.apache.hadoop:hadoop-yarn-server-web-proxy:jar:2.6.0:runtime
[INFO] |     |  |  |        \- org.mortbay.jetty:jetty:jar:6.1.26:runtime
[INFO] |     |  |  \- org.apache.hive.shims:hive-shims-scheduler:jar:1.2.1:runtime
[INFO] |     |  +- jline:jline:jar:2.12:compile
[INFO] |     |  \- org.apache.thrift:libthrift:jar:0.9.2:compile
[INFO] |     +- org.apache.hive:hive-common:jar:1.2.1:compile
[INFO] |     |  +- log4j:apache-log4j-extras:jar:1.2.17:compile
[INFO] |     |  +- org.apache.ant:ant:jar:1.9.1:compile
[INFO] |     |  |  \- org.apache.ant:ant-launcher:jar:1.9.1:compile
[INFO] |     |  \- org.json:json:jar:20090211:compile
[INFO] |     +- org.apache.hive:hive-metastore:jar:1.2.1:compile
[INFO] |     |  +- com.jolbox:bonecp:jar:0.8.0.RELEASE:compile
[INFO] |     |  +- org.apache.derby:derby:jar:10.10.2.0:compile
[INFO] |     |  +- org.datanucleus:datanucleus-api-jdo:jar:3.2.6:compile
[INFO] |     |  +- org.datanucleus:datanucleus-core:jar:3.2.10:compile
[INFO] |     |  +- org.datanucleus:datanucleus-rdbms:jar:3.2.9:compile
[INFO] |     |  +- commons-pool:commons-pool:jar:1.5.4:compile
[INFO] |     |  +- commons-dbcp:commons-dbcp:jar:1.4:compile
[INFO] |     |  +- javax.jdo:jdo-api:jar:3.0.1:compile
[INFO] |     |  |  \- javax.transaction:jta:jar:1.1:compile
[INFO] |     |  +- org.antlr:antlr-runtime:jar:3.4:compile
[INFO] |     |  |  +- org.antlr:stringtemplate:jar:3.2.1:compile
[INFO] |     |  |  \- antlr:antlr:jar:2.7.7:compile
[INFO] |     |  \- org.apache.thrift:libfb303:jar:0.9.2:compile
[INFO] |     +- org.apache.hive:hive-exec:jar:1.2.1:compile
[INFO] |     |  +- org.apache.hive:hive-ant:jar:1.2.1:compile
[INFO] |     |  |  \- org.apache.velocity:velocity:jar:1.5:compile
[INFO] |     |  |     \- oro:oro:jar:2.0.8:compile
[INFO] |     |  +- org.antlr:ST4:jar:4.0.4:compile
[INFO] |     |  +- org.apache.ivy:ivy:jar:2.4.0:compile
[INFO] |     |  +- org.apache.curator:curator-framework:jar:2.6.0:compile
[INFO] |     |  +- org.apache.curator:apache-curator:pom:2.6.0:compile
[INFO] |     |  +- org.codehaus.groovy:groovy-all:jar:2.1.6:compile
[INFO] |     |  +- org.apache.calcite:calcite-core:jar:1.2.0-incubating:compile
[INFO] |     |  |  +- org.apache.calcite:calcite-linq4j:jar:1.2.0-incubating:compile
[INFO] |     |  |  +- net.hydromatic:eigenbase-properties:jar:1.1.5:compile
[INFO] |     |  |  +- org.codehaus.janino:janino:jar:2.7.6:compile
[INFO] |     |  |  +- org.codehaus.janino:commons-compiler:jar:2.7.6:compile
[INFO] |     |  |  \- org.pentaho:pentaho-aggdesigner-algorithm:jar:5.1.5-jhyde:compile
[INFO] |     |  +- org.apache.calcite:calcite-avatica:jar:1.2.0-incubating:compile
[INFO] |     |  \- stax:stax-api:jar:1.0.1:compile
[INFO] |     +- com.google.guava:guava:jar:14.0.1:compile
[INFO] |     +- org.codehaus.jackson:jackson-mapper-asl:jar:1.9.2:compile
[INFO] |     \- org.slf4j:slf4j-log4j12:jar:1.7.5:compile
[INFO] +- io.confluent:kafka-connect-storage-partitioner:jar:3.2.5-SNAPSHOT:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.9.4:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.9.0:compile
[INFO] +- junit:junit:jar:4.12:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.easymock:easymock:jar:3.4:test
[INFO] |  \- org.objenesis:objenesis:jar:2.2:test
[INFO] +- org.powermock:powermock-module-junit4:jar:1.6.6:test
[INFO] |  \- org.powermock:powermock-module-junit4-common:jar:1.6.6:test
[INFO] |     +- org.powermock:powermock-core:jar:1.6.6:test
[INFO] |     |  \- org.javassist:javassist:jar:3.21.0-GA:test
[INFO] |     \- org.powermock:powermock-reflect:jar:1.6.6:test
[INFO] +- org.powermock:powermock-api-easymock:jar:1.6.6:test
[INFO] |  +- cglib:cglib-nodep:jar:2.2.2:test
[INFO] |  \- org.powermock:powermock-api-support:jar:1.6.6:test
[INFO] +- org.xerial.snappy:snappy-java:jar:1.1.10.1:compile
[INFO] \- com.fasterxml.jackson.core:jackson-core:jar:2.15.0:compile
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-storage-cloud 3.2.5-SNAPSHOT:
[INFO]
[INFO] kafka-connect-storage-cloud ........................ SUCCESS [ 27.248 s]
[INFO] kafka-connect-s3 ................................... SUCCESS [  0.106 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  27.562 s
[INFO] Finished at: 2023-08-09T10:32:30+05:30
[INFO] ------------------------------------------------------------------------                 
```

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
