### PR TITLE
[CC-20979] [CC-20329] Updated CVEs (jackson and snappy package)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,8 @@
         <jetty.version>9.4.48.v20220622</jetty.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox.version>5.4.0</woodstox.version>
+        <jackson.core.version>2.15.0</jackson.core.version>
+        <snappy.java>1.1.10.1</snappy.java>
     </properties>
 
     <repositories>
@@ -144,7 +146,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
+            <version>${jackson.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.xerial.snappy</groupId>
+            <artifactId>snappy-java</artifactId>
+            <version>${snappy.java}</version>
         </dependency>
         <dependency>
             <groupId>org.codehaus.jettison</groupId>


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-21844

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [ ] Manual tests
```
[INFO] io.confluent:kafka-connect-storage-cloud:pom:5.5.16-SNAPSHOT
[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- commons-codec:commons-codec:jar:1.15:compile
[INFO] +- org.apache.kafka:connect-api:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  +- org.apache.kafka:kafka-clients:jar:5.5.16-ccs-SNAPSHOT:compile
[INFO] |  |  +- com.github.luben:zstd-jni:jar:1.4.4-7:compile
[INFO] |  |  \- org.lz4:lz4-java:jar:1.7.1:compile
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.36:compile
[INFO] |  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:provided
[INFO] +- org.apache.kafka:connect-runtime:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  +- org.apache.kafka:kafka-tools:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  |  +- org.apache.kafka:kafka-log4j-appender:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  |  \- net.sourceforge.argparse4j:argparse4j:jar:0.7.0:provided
[INFO] |  +- org.apache.kafka:connect-transforms:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.13.4:provided
[INFO] |  |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.13.4:provided
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.13.4:provided
[INFO] |  |     +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:provided
[INFO] |  |     \- jakarta.activation:jakarta.activation-api:jar:1.2.1:provided
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.34:provided
[INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.34:provided
[INFO] |  |  |  \- org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:provided
[INFO] |  |  +- org.glassfish.jersey.core:jersey-common:jar:2.34:provided
[INFO] |  |  |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:provided
[INFO] |  |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:provided
[INFO] |  |  +- org.glassfish.jersey.core:jersey-server:jar:2.34:provided
[INFO] |  |  |  +- org.glassfish.jersey.core:jersey-client:jar:2.34:provided
[INFO] |  |  |  \- jakarta.validation:jakarta.validation-api:jar:2.0.2:provided
[INFO] |  |  \- jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:provided
[INFO] |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.34:provided
[INFO] |  |  +- org.glassfish.hk2:hk2-locator:jar:2.6.1:provided
[INFO] |  |  |  +- org.glassfish.hk2.external:aopalliance-repackaged:jar:2.6.1:provided
[INFO] |  |  |  +- org.glassfish.hk2:hk2-api:jar:2.6.1:provided
[INFO] |  |  |  \- org.glassfish.hk2:hk2-utils:jar:2.6.1:provided
[INFO] |  |  \- org.javassist:javassist:jar:3.25.0-GA:provided
[INFO] |  +- javax.xml.bind:jaxb-api:jar:2.3.0:compile
[INFO] |  +- javax.activation:activation:jar:1.1.1:provided
[INFO] |  +- org.eclipse.jetty:jetty-servlets:jar:9.4.48.v20220622:provided
[INFO] |  |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.48.v20220622:provided
[INFO] |  +- org.reflections:reflections:jar:0.9.12:provided
[INFO] |  \- org.apache.maven:maven-artifact:jar:3.8.1:provided
[INFO] |     \- org.codehaus.plexus:plexus-utils:jar:3.2.1:provided
[INFO] +- org.apache.kafka:connect-json:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.13.4:provided
[INFO] +- io.confluent:kafka-connect-storage-common:jar:5.5.16-SNAPSHOT:compile
[INFO] +- io.confluent:kafka-connect-storage-core:jar:5.5.16-SNAPSHOT:compile
[INFO] |  +- io.confluent:kafka-connect-avro-data:jar:5.5.16-SNAPSHOT:compile
[INFO] |  |  +- org.apache.avro:avro:jar:1.9.2:compile
[INFO] |  |  \- io.confluent:kafka-avro-serializer:jar:5.5.16-SNAPSHOT:compile
[INFO] |  |     +- io.confluent:kafka-schema-serializer:jar:5.5.16-SNAPSHOT:compile
[INFO] |  |     +- io.confluent:kafka-schema-registry-client:jar:5.5.16-SNAPSHOT:compile
[INFO] |  |     |  +- org.yaml:snakeyaml:jar:2.0:compile
[INFO] |  |     |  +- io.swagger:swagger-annotations:jar:1.6.2:compile
[INFO] |  |     |  +- io.swagger:swagger-core:jar:1.6.2:compile
[INFO] |  |     |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.13.4:compile
[INFO] |  |     |  |  \- io.swagger:swagger-models:jar:1.6.2:compile
[INFO] |  |     |  \- com.google.guava:guava:jar:30.1.1-jre:compile
[INFO] |  |     |     +- com.google.guava:failureaccess:jar:1.0.1:compile
[INFO] |  |     |     +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:compile
[INFO] |  |     |     +- org.checkerframework:checker-qual:jar:3.8.0:compile
[INFO] |  |     |     +- com.google.errorprone:error_prone_annotations:jar:2.5.1:compile
[INFO] |  |     |     \- com.google.j2objc:j2objc-annotations:jar:1.3:compile
[INFO] |  |     \- io.confluent:common-config:jar:5.5.16-SNAPSHOT:compile
[INFO] |  \- joda-time:joda-time:jar:2.9.6:compile
[INFO] +- io.confluent:kafka-connect-storage-format:jar:5.5.16-SNAPSHOT:compile
[INFO] |  +- org.apache.parquet:parquet-column:jar:1.11.2:compile
[INFO] |  |  +- org.apache.parquet:parquet-common:jar:1.11.2:compile
[INFO] |  |  \- org.apache.parquet:parquet-encoding:jar:1.11.2:compile
[INFO] |  \- org.apache.parquet:parquet-avro:jar:1.11.2:compile
[INFO] |     +- org.apache.parquet:parquet-hadoop:jar:1.11.2:compile
[INFO] |     |  \- commons-pool:commons-pool:jar:1.6:compile
[INFO] |     \- org.apache.parquet:parquet-format-structures:jar:1.11.2:compile
[INFO] |        \- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- io.confluent:kafka-connect-storage-partitioner:jar:5.5.16-SNAPSHOT:compile
[INFO] +- io.confluent:kafka-connect-storage-common-htrace-core4-shaded:jar:5.5.16-SNAPSHOT:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.4.2:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.4:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.15.0:compile
[INFO] +- org.xerial.snappy:snappy-java:jar:1.1.10.1:compile
[INFO] +- org.codehaus.jettison:jettison:jar:1.5.4:compile
[INFO] +- com.fasterxml.woodstox:woodstox-core:jar:5.4.0:compile
[INFO] |  \- org.codehaus.woodstox:stax2-api:jar:4.2:compile
[INFO] +- org.apache.hadoop:hadoop-common:jar:3.2.4:compile
[INFO] |  +- org.apache.hadoop:hadoop-annotations:jar:3.2.4:compile
[INFO] |  +- commons-cli:commons-cli:jar:1.2:compile
[INFO] |  +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] |  +- commons-io:commons-io:jar:2.7:compile
[INFO] |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] |  +- javax.servlet:javax.servlet-api:jar:3.1.0:compile
[INFO] |  +- javax.activation:javax.activation-api:jar:1.2.0:runtime
[INFO] |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  +- com.sun.jersey:jersey-core:jar:1.19:compile
[INFO] |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
[INFO] |  +- com.sun.jersey:jersey-servlet:jar:1.19:compile
[INFO] |  +- com.sun.jersey:jersey-json:jar:1.19:compile
[INFO] |  |  +- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.2:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.2:compile
[INFO] |  |  \- org.codehaus.jackson:jackson-xc:jar:1.9.2:compile
[INFO] |  +- com.sun.jersey:jersey-server:jar:1.19:compile
[INFO] |  +- ch.qos.reload4j:reload4j:jar:1.2.19:compile
[INFO] |  +- org.apache.commons:commons-configuration2:jar:2.1.1:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.7:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.4:compile
[INFO] |  +- com.google.re2j:re2j:jar:1.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.19.6:compile
[INFO] |  +- com.google.code.gson:gson:jar:2.9.0:compile
[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.2.4:compile
[INFO] |  |  +- net.minidev:json-smart:jar:2.4.7:compile
[INFO] |  |  |  \- net.minidev:accessors-smart:jar:2.4.7:compile
[INFO] |  |  |     \- org.ow2.asm:asm:jar:9.1:compile
[INFO] |  |  \- org.apache.curator:curator-framework:jar:2.13.0:compile
[INFO] |  +- com.jcraft:jsch:jar:0.1.55:compile
[INFO] |  +- org.apache.curator:curator-client:jar:2.13.0:compile
[INFO] |  +- org.apache.curator:curator-recipes:jar:2.13.0:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.apache.zookeeper:zookeeper:jar:3.5.8:compile
[INFO] |  |  +- org.apache.zookeeper:zookeeper-jute:jar:3.5.8:compile
[INFO] |  |  \- org.apache.yetus:audience-annotations:jar:0.5.0:compile
[INFO] |  +- org.apache.commons:commons-compress:jar:1.21:compile
[INFO] |  +- org.apache.kerby:kerb-simplekdc:jar:1.0.1:compile
[INFO] |  |  +- org.apache.kerby:kerb-client:jar:1.0.1:compile
[INFO] |  |  |  +- org.apache.kerby:kerby-config:jar:1.0.1:compile
[INFO] |  |  |  +- org.apache.kerby:kerb-core:jar:1.0.1:compile
[INFO] |  |  |  |  \- org.apache.kerby:kerby-pkix:jar:1.0.1:compile
[INFO] |  |  |  |     +- org.apache.kerby:kerby-asn1:jar:1.0.1:compile
[INFO] |  |  |  |     \- org.apache.kerby:kerby-util:jar:1.0.1:compile
[INFO] |  |  |  +- org.apache.kerby:kerb-common:jar:1.0.1:compile
[INFO] |  |  |  |  \- org.apache.kerby:kerb-crypto:jar:1.0.1:compile
[INFO] |  |  |  +- org.apache.kerby:kerb-util:jar:1.0.1:compile
[INFO] |  |  |  \- org.apache.kerby:token-provider:jar:1.0.1:compile
[INFO] |  |  \- org.apache.kerby:kerb-admin:jar:1.0.1:compile
[INFO] |  |     +- org.apache.kerby:kerb-server:jar:1.0.1:compile
[INFO] |  |     |  \- org.apache.kerby:kerb-identity:jar:1.0.1:compile
[INFO] |  |     \- org.apache.kerby:kerby-xdr:jar:1.0.1:compile
[INFO] |  \- dnsjava:dnsjava:jar:2.1.7:compile
[INFO] +- org.slf4j:slf4j-reload4j:jar:1.7.36:compile
[INFO] +- io.confluent:confluent-log4j:jar:1.2.17-cp2:test
[INFO] +- org.eclipse.jetty:jetty-http:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-io:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-servlet:jar:9.4.48.v20220622:test
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:9.4.48.v20220622:test
[INFO] |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-server:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-client:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-util:jar:9.4.48.v20220622:test
[INFO] +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:3.2.4:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-client:jar:3.2.4:test
[INFO] |  |  \- org.apache.hadoop:hadoop-yarn-api:jar:3.2.4:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-common:jar:3.2.4:test
[INFO] |  |  +- com.sun.jersey:jersey-client:jar:1.19:test
[INFO] |  |  +- com.google.inject:guice:jar:4.0:test
[INFO] |  |  |  +- javax.inject:javax.inject:jar:1:test
[INFO] |  |  |  \- aopalliance:aopalliance:jar:1.0:test
[INFO] |  |  \- com.sun.jersey.contribs:jersey-guice:jar:1.19:test
[INFO] |  +- org.apache.hadoop:hadoop-hdfs-client:jar:3.2.4:test
[INFO] |  |  \- com.squareup.okhttp:okhttp:jar:2.7.5:test
[INFO] |  |     \- com.squareup.okio:okio:jar:1.6.0:test
[INFO] |  +- com.google.inject.extensions:guice-servlet:jar:4.0:test
[INFO] |  \- io.netty:netty:jar:3.10.6.Final:test
[INFO] +- junit:junit:jar:4.13.1:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.easymock:easymock:jar:4.0.1:test
[INFO] |  \- org.objenesis:objenesis:jar:3.0.1:test
[INFO] +- org.powermock:powermock-module-junit4:jar:2.0.0:test
[INFO] |  \- org.powermock:powermock-module-junit4-common:jar:2.0.0:test
[INFO] |     +- org.powermock:powermock-reflect:jar:2.0.0:test
[INFO] |     \- org.powermock:powermock-core:jar:2.0.0:test
[INFO] +- org.powermock:powermock-api-easymock:jar:2.0.0:test
[INFO] |  +- org.powermock:powermock-api-support:jar:2.0.0:test
[INFO] |  \- cglib:cglib-nodep:jar:3.2.9:test
[INFO] +- org.powermock:powermock-api-mockito2:jar:2.0.0:test
[INFO] +- org.mockito:mockito-core:jar:2.19.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.8.10:test
[INFO] |  \- net.bytebuddy:byte-buddy-agent:jar:1.8.10:test
[INFO] +- jline:jline:jar:2.12.1:compile
[INFO] +- io.confluent:common-utils:jar:5.5.16-SNAPSHOT:compile
[INFO] \- io.confluent:assembly-plugin-boilerplate:zip:resources:5.5.16-SNAPSHOT:provided
[INFO]
[INFO] -------------------< io.confluent:kafka-connect-s3 >--------------------
[INFO] Building kafka-connect-s3 5.5.16-SNAPSHOT                          [2/2]
[INFO]   from kafka-connect-s3/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.0.2:tree (default-cli) @ kafka-connect-s3 ---
[INFO] io.confluent:kafka-connect-s3:jar:5.5.16-SNAPSHOT
[INFO] +- com.amazonaws:aws-java-sdk-s3:jar:1.12.268:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-kms:jar:1.12.268:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-core:jar:1.12.268:compile
[INFO] |  |  \- software.amazon.ion:ion-java:jar:1.0.2:compile
[INFO] |  \- com.amazonaws:jmespath-java:jar:1.12.268:compile
[INFO] +- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.13.4:compile
[INFO] +- com.amazonaws:aws-java-sdk-sts:jar:1.12.268:compile
[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- commons-codec:commons-codec:jar:1.15:compile
[INFO] +- io.findify:s3mock_2.12:jar:0.2.5:test
[INFO] |  +- com.typesafe.akka:akka-stream_2.12:jar:2.5.11:test
[INFO] |  |  +- com.typesafe.akka:akka-actor_2.12:jar:2.5.11:test
[INFO] |  |  |  \- com.typesafe:config:jar:1.3.2:test
[INFO] |  |  +- com.typesafe.akka:akka-protobuf_2.12:jar:2.5.11:test
[INFO] |  |  +- org.reactivestreams:reactive-streams:jar:1.0.2:test
[INFO] |  |  \- com.typesafe:ssl-config-core_2.12:jar:0.2.2:test
[INFO] |  |     \- org.scala-lang.modules:scala-parser-combinators_2.12:jar:1.0.4:test
[INFO] |  +- com.typesafe.akka:akka-http_2.12:jar:10.1.0:test
[INFO] |  |  \- com.typesafe.akka:akka-http-core_2.12:jar:10.1.0:test
[INFO] |  |     \- com.typesafe.akka:akka-parsing_2.12:jar:10.1.0:test
[INFO] |  +- org.scala-lang.modules:scala-xml_2.12:jar:1.1.0:test
[INFO] |  +- com.github.pathikrit:better-files_2.12:jar:3.4.0:test
[INFO] |  +- com.typesafe.scala-logging:scala-logging_2.12:jar:3.8.0:test
[INFO] |  \- org.iq80.leveldb:leveldb:jar:0.10:test
[INFO] |     \- org.iq80.leveldb:leveldb-api:jar:0.10:test
[INFO] +- org.apache.kafka:connect-runtime:test-jar:test:5.5.16-ccs-SNAPSHOT:test
[INFO] |  +- org.apache.kafka:kafka-clients:jar:5.5.16-ccs-SNAPSHOT:compile
[INFO] |  +- org.apache.kafka:kafka-tools:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  |  +- org.apache.kafka:kafka-log4j-appender:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  |  \- net.sourceforge.argparse4j:argparse4j:jar:0.7.0:provided
[INFO] |  +- org.apache.kafka:connect-transforms:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.36:compile
[INFO] |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.13.4:provided
[INFO] |  |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.13.4:provided
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.13.4:provided
[INFO] |  |     +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.3:provided
[INFO] |  |     \- jakarta.activation:jakarta.activation-api:jar:1.2.1:provided
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.34:provided
[INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.34:provided
[INFO] |  |  |  \- org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:provided
[INFO] |  |  +- org.glassfish.jersey.core:jersey-common:jar:2.34:provided
[INFO] |  |  |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:provided
[INFO] |  |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:provided
[INFO] |  |  +- org.glassfish.jersey.core:jersey-server:jar:2.34:provided
[INFO] |  |  |  +- org.glassfish.jersey.core:jersey-client:jar:2.34:provided
[INFO] |  |  |  \- jakarta.validation:jakarta.validation-api:jar:2.0.2:provided
[INFO] |  |  \- jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:provided
[INFO] |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.34:provided
[INFO] |  |  +- org.glassfish.hk2:hk2-locator:jar:2.6.1:provided
[INFO] |  |  |  +- org.glassfish.hk2.external:aopalliance-repackaged:jar:2.6.1:provided
[INFO] |  |  |  +- org.glassfish.hk2:hk2-api:jar:2.6.1:provided
[INFO] |  |  |  \- org.glassfish.hk2:hk2-utils:jar:2.6.1:provided
[INFO] |  |  \- org.javassist:javassist:jar:3.25.0-GA:provided
[INFO] |  +- javax.xml.bind:jaxb-api:jar:2.3.0:compile
[INFO] |  +- javax.activation:activation:jar:1.1.1:provided
[INFO] |  +- org.eclipse.jetty:jetty-servlets:jar:9.4.48.v20220622:provided
[INFO] |  |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.48.v20220622:provided
[INFO] |  +- org.reflections:reflections:jar:0.9.12:provided
[INFO] |  \- org.apache.maven:maven-artifact:jar:3.8.1:provided
[INFO] |     \- org.codehaus.plexus:plexus-utils:jar:3.2.1:provided
[INFO] +- org.apache.kafka:kafka_2.12:jar:5.5.16-ccs-SNAPSHOT:test
[INFO] |  +- com.fasterxml.jackson.module:jackson-module-scala_2.12:jar:2.13.4:test
[INFO] |  |  \- com.thoughtworks.paranamer:paranamer:jar:2.8:test
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:jar:2.13.4:test
[INFO] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.13.4:provided
[INFO] |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
[INFO] |  +- com.yammer.metrics:metrics-core:jar:2.2.0:test
[INFO] |  +- org.scala-lang.modules:scala-collection-compat_2.12:jar:2.1.3:test
[INFO] |  +- org.scala-lang.modules:scala-java8-compat_2.12:jar:0.9.0:test
[INFO] |  +- org.scala-lang:scala-library:jar:2.12.10:test
[INFO] |  +- org.scala-lang:scala-reflect:jar:2.12.10:test
[INFO] |  +- org.apache.zookeeper:zookeeper:jar:3.5.8:compile
[INFO] |  |  +- org.apache.zookeeper:zookeeper-jute:jar:3.5.8:compile
[INFO] |  |  \- org.apache.yetus:audience-annotations:jar:0.5.0:compile
[INFO] |  \- commons-cli:commons-cli:jar:1.4:compile
[INFO] +- org.apache.kafka:kafka_2.12:test-jar:test:5.5.16-ccs-SNAPSHOT:test
[INFO] +- org.apache.kafka:kafka-clients:test-jar:test:5.5.16-ccs-SNAPSHOT:test
[INFO] |  +- com.github.luben:zstd-jni:jar:1.4.4-7:compile
[INFO] |  \- org.lz4:lz4-java:jar:1.7.1:compile
[INFO] +- org.apache.parquet:parquet-tools:jar:1.11.1:test
[INFO] +- org.testcontainers:testcontainers:jar:1.15.0:test
[INFO] |  +- org.apache.commons:commons-compress:jar:1.21:compile
[INFO] |  +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO] |  +- org.rnorth.visible-assertions:visible-assertions:jar:2.1.2:test
[INFO] |  |  \- net.java.dev.jna:jna:jar:5.2.0:test
[INFO] |  +- com.github.docker-java:docker-java-api:jar:3.2.5:test
[INFO] |  \- com.github.docker-java:docker-java-transport-zerodep:jar:3.2.5:test
[INFO] |     \- com.github.docker-java:docker-java-transport:jar:3.2.5:test
[INFO] +- com.google.guava:guava:jar:30.1.1-jre:test
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.1:test
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:test
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.checkerframework:checker-qual:jar:3.8.0:test
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.5.1:test
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:1.3:test
[INFO] +- org.apache.kafka:connect-api:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] |  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:provided
[INFO] +- org.apache.kafka:connect-runtime:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] +- org.apache.kafka:connect-json:jar:5.5.16-ccs-SNAPSHOT:provided
[INFO] +- io.confluent:kafka-connect-storage-common:jar:5.5.16-SNAPSHOT:compile
[INFO] +- io.confluent:kafka-connect-storage-core:jar:5.5.16-SNAPSHOT:compile
[INFO] |  +- io.confluent:kafka-connect-avro-data:jar:5.5.16-SNAPSHOT:compile
[INFO] |  |  +- org.apache.avro:avro:jar:1.9.2:compile
[INFO] |  |  \- io.confluent:kafka-avro-serializer:jar:5.5.16-SNAPSHOT:compile
[INFO] |  |     +- io.confluent:kafka-schema-serializer:jar:5.5.16-SNAPSHOT:compile
[INFO] |  |     +- io.confluent:kafka-schema-registry-client:jar:5.5.16-SNAPSHOT:compile
[INFO] |  |     |  +- org.yaml:snakeyaml:jar:2.0:compile
[INFO] |  |     |  +- io.swagger:swagger-annotations:jar:1.6.2:compile
[INFO] |  |     |  \- io.swagger:swagger-core:jar:1.6.2:compile
[INFO] |  |     |     +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.13.4:compile
[INFO] |  |     |     \- io.swagger:swagger-models:jar:1.6.2:compile
[INFO] |  |     \- io.confluent:common-config:jar:5.5.16-SNAPSHOT:compile
[INFO] |  \- joda-time:joda-time:jar:2.9.6:compile
[INFO] +- io.confluent:kafka-connect-storage-format:jar:5.5.16-SNAPSHOT:compile
[INFO] |  +- org.apache.parquet:parquet-column:jar:1.11.2:compile
[INFO] |  |  +- org.apache.parquet:parquet-common:jar:1.11.2:compile
[INFO] |  |  \- org.apache.parquet:parquet-encoding:jar:1.11.2:compile
[INFO] |  \- org.apache.parquet:parquet-avro:jar:1.11.2:compile
[INFO] |     +- org.apache.parquet:parquet-hadoop:jar:1.11.2:compile
[INFO] |     |  \- commons-pool:commons-pool:jar:1.6:compile
[INFO] |     \- org.apache.parquet:parquet-format-structures:jar:1.11.2:compile
[INFO] |        \- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- io.confluent:kafka-connect-storage-partitioner:jar:5.5.16-SNAPSHOT:compile
[INFO] +- io.confluent:kafka-connect-storage-common-htrace-core4-shaded:jar:5.5.16-SNAPSHOT:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.13.4.2:compile
[INFO] |  \- com.fasterxml.jackson.core:jackson-annotations:jar:2.13.4:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.15.0:compile
[INFO] +- org.xerial.snappy:snappy-java:jar:1.1.10.1:compile
[INFO] +- org.codehaus.jettison:jettison:jar:1.5.4:compile
[INFO] +- com.fasterxml.woodstox:woodstox-core:jar:5.4.0:compile
[INFO] |  \- org.codehaus.woodstox:stax2-api:jar:4.2:compile
[INFO] +- org.apache.hadoop:hadoop-common:jar:3.2.4:compile
[INFO] |  +- org.apache.hadoop:hadoop-annotations:jar:3.2.4:compile
[INFO] |  +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] |  +- commons-io:commons-io:jar:2.7:compile
[INFO] |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] |  +- javax.servlet:javax.servlet-api:jar:3.1.0:compile
[INFO] |  +- javax.activation:javax.activation-api:jar:1.2.0:runtime
[INFO] |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  +- com.sun.jersey:jersey-core:jar:1.19:compile
[INFO] |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
[INFO] |  +- com.sun.jersey:jersey-servlet:jar:1.19:compile
[INFO] |  +- com.sun.jersey:jersey-json:jar:1.19:compile
[INFO] |  |  +- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-core-asl:jar:1.9.2:compile
[INFO] |  |  +- org.codehaus.jackson:jackson-jaxrs:jar:1.9.2:compile
[INFO] |  |  \- org.codehaus.jackson:jackson-xc:jar:1.9.2:compile
[INFO] |  +- com.sun.jersey:jersey-server:jar:1.19:compile
[INFO] |  +- ch.qos.reload4j:reload4j:jar:1.2.19:compile
[INFO] |  +- org.apache.commons:commons-configuration2:jar:2.1.1:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.7:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.4:compile
[INFO] |  +- com.google.re2j:re2j:jar:1.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.19.6:compile
[INFO] |  +- com.google.code.gson:gson:jar:2.9.0:compile
[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.2.4:compile
[INFO] |  |  +- net.minidev:json-smart:jar:2.4.10:compile
[INFO] |  |  |  \- net.minidev:accessors-smart:jar:2.4.9:compile
[INFO] |  |  |     \- org.ow2.asm:asm:jar:9.3:compile
[INFO] |  |  \- org.apache.curator:curator-framework:jar:2.13.0:compile
[INFO] |  +- com.jcraft:jsch:jar:0.1.55:compile
[INFO] |  +- org.apache.curator:curator-client:jar:2.13.0:compile
[INFO] |  +- org.apache.curator:curator-recipes:jar:2.13.0:compile
[INFO] |  +- org.apache.kerby:kerb-simplekdc:jar:1.0.1:compile
[INFO] |  |  +- org.apache.kerby:kerb-client:jar:1.0.1:compile
[INFO] |  |  |  +- org.apache.kerby:kerby-config:jar:1.0.1:compile
[INFO] |  |  |  +- org.apache.kerby:kerb-core:jar:1.0.1:compile
[INFO] |  |  |  |  \- org.apache.kerby:kerby-pkix:jar:1.0.1:compile
[INFO] |  |  |  |     +- org.apache.kerby:kerby-asn1:jar:1.0.1:compile
[INFO] |  |  |  |     \- org.apache.kerby:kerby-util:jar:1.0.1:compile
[INFO] |  |  |  +- org.apache.kerby:kerb-common:jar:1.0.1:compile
[INFO] |  |  |  |  \- org.apache.kerby:kerb-crypto:jar:1.0.1:compile
[INFO] |  |  |  +- org.apache.kerby:kerb-util:jar:1.0.1:compile
[INFO] |  |  |  \- org.apache.kerby:token-provider:jar:1.0.1:compile
[INFO] |  |  \- org.apache.kerby:kerb-admin:jar:1.0.1:compile
[INFO] |  |     +- org.apache.kerby:kerb-server:jar:1.0.1:compile
[INFO] |  |     |  \- org.apache.kerby:kerb-identity:jar:1.0.1:compile
[INFO] |  |     \- org.apache.kerby:kerby-xdr:jar:1.0.1:compile
[INFO] |  \- dnsjava:dnsjava:jar:2.1.7:compile
[INFO] +- org.slf4j:slf4j-reload4j:jar:1.7.36:compile
[INFO] +- io.confluent:confluent-log4j:jar:1.2.17-cp2:test
[INFO] +- org.eclipse.jetty:jetty-http:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-io:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-servlet:jar:9.4.48.v20220622:test
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:9.4.48.v20220622:test
[INFO] |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-server:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-client:jar:9.4.48.v20220622:test
[INFO] +- org.eclipse.jetty:jetty-util:jar:9.4.48.v20220622:test
[INFO] +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:3.2.4:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-client:jar:3.2.4:test
[INFO] |  |  \- org.apache.hadoop:hadoop-yarn-api:jar:3.2.4:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-common:jar:3.2.4:test
[INFO] |  |  +- com.sun.jersey:jersey-client:jar:1.19:test
[INFO] |  |  +- com.google.inject:guice:jar:4.0:test
[INFO] |  |  |  +- javax.inject:javax.inject:jar:1:test
[INFO] |  |  |  \- aopalliance:aopalliance:jar:1.0:test
[INFO] |  |  \- com.sun.jersey.contribs:jersey-guice:jar:1.19:test
[INFO] |  +- org.apache.hadoop:hadoop-hdfs-client:jar:3.2.4:test
[INFO] |  |  \- com.squareup.okhttp:okhttp:jar:2.7.5:test
[INFO] |  |     \- com.squareup.okio:okio:jar:1.6.0:test
[INFO] |  +- com.google.inject.extensions:guice-servlet:jar:4.0:test
[INFO] |  \- io.netty:netty:jar:3.10.6.Final:test
[INFO] +- junit:junit:jar:4.13.1:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.easymock:easymock:jar:4.0.1:test
[INFO] |  \- org.objenesis:objenesis:jar:3.0.1:test
[INFO] +- org.powermock:powermock-module-junit4:jar:2.0.0:test
[INFO] |  \- org.powermock:powermock-module-junit4-common:jar:2.0.0:test
[INFO] |     +- org.powermock:powermock-reflect:jar:2.0.0:test
[INFO] |     \- org.powermock:powermock-core:jar:2.0.0:test
[INFO] +- org.powermock:powermock-api-easymock:jar:2.0.0:test
[INFO] |  +- org.powermock:powermock-api-support:jar:2.0.0:test
[INFO] |  \- cglib:cglib-nodep:jar:3.2.9:test
[INFO] +- org.powermock:powermock-api-mockito2:jar:2.0.0:test
[INFO] +- org.mockito:mockito-core:jar:2.19.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.8.10:test
[INFO] |  \- net.bytebuddy:byte-buddy-agent:jar:1.8.10:test
[INFO] +- jline:jline:jar:2.12.1:compile
[INFO] +- io.confluent:common-utils:jar:5.5.16-SNAPSHOT:compile
[INFO] \- io.confluent:assembly-plugin-boilerplate:zip:resources:5.5.16-SNAPSHOT:provided
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-storage-cloud 5.5.16-SNAPSHOT:
[INFO]
[INFO] kafka-connect-storage-cloud ........................ SUCCESS [ 11.516 s]
[INFO] kafka-connect-s3 ................................... SUCCESS [  0.094 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.050 s
[INFO] Finished at: 2023-08-10T17:43:30+05:30
```

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
