### PR TITLE
CC-21917 | Added support for decimal.format config to be passed to json formatter.

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -32,6 +32,7 @@ import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.json.DecimalFormat;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
 
 import java.util.ArrayList;
@@ -164,6 +165,13 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String S3_PATH_STYLE_ACCESS_ENABLED_CONFIG = "s3.path.style.access.enabled";
   public static final boolean S3_PATH_STYLE_ACCESS_ENABLED_DEFAULT = true;
+
+  public static final String DECIMAL_FORMAT_CONFIG = "json.decimal.format";
+  public static final String DECIMAL_FORMAT_DEFAULT = DecimalFormat.BASE64.name();
+  private static final String DECIMAL_FORMAT_DOC = "Controls which format json converter"
+      + " will serialize decimals in."
+      + " This value is case insensitive and can be either 'BASE64' (default) or 'NUMERIC'";
+  private static final String DECIMAL_FORMAT_DISPLAY = "Decimal Format";
 
   public static final String STORE_KAFKA_KEYS_CONFIG = "store.kafka.keys";
   public static final String STORE_KAFKA_HEADERS_CONFIG = "store.kafka.headers";
@@ -447,6 +455,20 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Width.LONG,
           "Compression Level",
           COMPRESSION_LEVEL_VALIDATOR
+      );
+
+      configDef.define(
+          DECIMAL_FORMAT_CONFIG,
+          ConfigDef.Type.STRING,
+          DECIMAL_FORMAT_DEFAULT,
+          ConfigDef.CaseInsensitiveValidString.in(
+                  DecimalFormat.BASE64.name(), DecimalFormat.NUMERIC.name()),
+          Importance.MEDIUM,
+          DECIMAL_FORMAT_DOC,
+          group,
+          ++orderInGroup,
+          Width.MEDIUM,
+          DECIMAL_FORMAT_DISPLAY
       );
 
       configDef.define(
@@ -766,6 +788,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public int getCompressionLevel() {
     return getInt(COMPRESSION_LEVEL_CONFIG);
+  }
+
+  public String getJsonDecimalFormat() {
+    return getString(DECIMAL_FORMAT_CONFIG);
   }
 
   public CompressionCodecName parquetCompressionCodecName() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonFormat.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonFormat.java
@@ -39,6 +39,10 @@ public class JsonFormat implements Format<S3SinkConnectorConfig, String> {
         "schemas.cache.size",
         String.valueOf(storage.conf().get(S3SinkConnectorConfig.SCHEMA_CACHE_SIZE_CONFIG))
     );
+    converterConfig.put(
+        "decimal.format",
+        String.valueOf(storage.conf().getJsonDecimalFormat())
+    );
     this.converter.configure(converterConfig, false);
   }
 


### PR DESCRIPTION
## Problem


## Solution
Added support for decimal.format config to be passed to json formatter.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
