### PR TITLE
Fix for regression from CVE fix in PR #660

### DIFF
--- a/kafka-connect-s3/src/assembly/package.xml
+++ b/kafka-connect-s3/src/assembly/package.xml
@@ -66,14 +66,5 @@
                 <exclude>io.confluent:kafka-connect-storage-partitioner</exclude>
             </excludes>
         </dependencySet>
-        <dependencySet>
-        <outputDirectory>share/java/kafka-connect-s3</outputDirectory>
-        <useProjectArtifact>true</useProjectArtifact>
-            <includes>
-                <!-- Specifically included as excluding kafka-connect-storage-common with
-                useTransitiveFiltering filters the below dependency as well. -->
-                <include>io.confluent:kafka-connect-storage-common-hadoop-shaded-guava</include>
-            </includes>
-        </dependencySet>
     </dependencySets>
 </assembly>

--- a/kafka-connect-s3/src/assembly/package.xml
+++ b/kafka-connect-s3/src/assembly/package.xml
@@ -66,5 +66,14 @@
                 <exclude>io.confluent:kafka-connect-storage-partitioner</exclude>
             </excludes>
         </dependencySet>
+        <dependencySet>
+        <outputDirectory>share/java/kafka-connect-s3</outputDirectory>
+        <useProjectArtifact>true</useProjectArtifact>
+            <includes>
+                <!-- Specifically included as excluding kafka-connect-storage-common with
+                useTransitiveFiltering filters the below dependency as well. -->
+                <include>io.confluent:kafka-connect-storage-common-hadoop-shaded-guava</include>
+            </includes>
+        </dependencySet>
     </dependencySets>
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -178,6 +178,7 @@
             <artifactId>woodstox-core</artifactId>
             <version>${woodstox.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.1</version>
+        <version>11.2.3</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -147,6 +147,11 @@
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-storage-partitioner</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.confluent</groupId>
+            <artifactId>kafka-connect-storage-common-hadoop-shaded-guava</artifactId>
+            <version>${kafka.connect.storage.common.version}</version>
         </dependency>
         <!-- <dependency>
             <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem
Excluding `hadoop-shaded-guava` for CVE fix in commit https://github.com/confluentinc/kafka-connect-storage-cloud/commit/8a80a19363f5c8d89d7b52367352a25b1ff1de8b
resulted in a regression with `NoClassDefFoundError: org/apache/hadoop/thirdparty/com/google/common/collect/Interners`
while using the `io.confluent.connect.s3.format.parquet.ParquetFormat` for `format.class` field in config.

## Solution
[kafka-connect-storage-common](https://github.com/confluentinc/kafka-connect-storage-common/tree/master) has an updated hadoop-shaded-guava without the CVE.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
