### PR TITLE
Removed x-amz-server-side-encryption to get SEE-C working

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -194,19 +194,10 @@ public class S3OutputStream extends PositionOutputStream {
     super.close();
   }
 
-  private ObjectMetadata newObjectMetadata() {
-    ObjectMetadata meta = new ObjectMetadata();
-    if (StringUtils.isNotBlank(ssea)) {
-      meta.setSSEAlgorithm(ssea);
-    }
-    return meta;
-  }
-
   private MultipartUpload newMultipartUpload() throws IOException {
     InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(
         bucket,
-        key,
-        newObjectMetadata()
+        key
     ).withCannedACL(cannedAcl);
 
     if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -23,7 +23,6 @@ import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.SSEAlgorithm;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;


### PR DESCRIPTION
## Problem
For [this](https://confluent.slack.com/archives/C05PEERD0A2) on call issue, [this PR](https://github.com/confluentinc/kafka-connect-storage-cloud/pull/477) fixes the problem, as a JAR was made and shared with customer to which they responded affirmatively. 

Now they want a global release for this, hence putting this patch in all branches 10.0.x onwards.

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
