### PR TITLE
Add suport for custom S3 object tagging

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -84,6 +84,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String S3_OBJECT_TAGGING_CONFIG = "s3.object.tagging";
   public static final boolean S3_OBJECT_TAGGING_DEFAULT = false;
+  public static final String S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY = "s3.object.tagging.key";
+  public static final String S3_OBJECT_TAGGING_EXTRA_KEY_DEFAULT = "";
+  public static final String S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE = "s3.object.tagging.value";
+  public static final String S3_OBJECT_TAGGING_EXTRA_VALUE_DEFAULT = "";
 
   public static final String S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG =
           "s3.object.behavior.on.tagging.error";
@@ -316,6 +320,30 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.LONG,
           "S3 Object Tagging"
+      );
+
+      configDef.define(
+          S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY,
+          Type.LIST,
+          S3_OBJECT_TAGGING_EXTRA_KEY_DEFAULT,
+          Importance.LOW,
+          "Additional S3 tag keys",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "S3 Object Tagging Extra Key"
+      );
+
+      configDef.define(
+          S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE,
+          Type.LIST,
+          S3_OBJECT_TAGGING_EXTRA_VALUE_DEFAULT,
+          Importance.LOW,
+          "Additional S3 tag values",
+          group,
+          ++orderInGroup,
+          Width.LONG,
+          "S3 Object Tagging Extra Value"
       );
 
       configDef.define(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -84,10 +84,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String S3_OBJECT_TAGGING_CONFIG = "s3.object.tagging";
   public static final boolean S3_OBJECT_TAGGING_DEFAULT = false;
-  public static final String S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY = "s3.object.tagging.key";
-  public static final String S3_OBJECT_TAGGING_EXTRA_KEY_DEFAULT = "";
-  public static final String S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE = "s3.object.tagging.value";
-  public static final String S3_OBJECT_TAGGING_EXTRA_VALUE_DEFAULT = "";
+  public static final String S3_OBJECT_TAGGING_EXTRA_KV = "s3.object.tagging.key.value.pairs";
+  public static final String S3_OBJECT_TAGGING_EXTRA_KV_DEFAULT = "";
 
   public static final String S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG =
           "s3.object.behavior.on.tagging.error";
@@ -323,27 +321,15 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       );
 
       configDef.define(
-          S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY,
-          Type.LIST,
-          S3_OBJECT_TAGGING_EXTRA_KEY_DEFAULT,
-          Importance.LOW,
-          "Additional S3 tag keys",
-          group,
-          ++orderInGroup,
-          Width.LONG,
-          "S3 Object Tagging Extra Key"
-      );
-
-      configDef.define(
-          S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE,
-          Type.LIST,
-          S3_OBJECT_TAGGING_EXTRA_VALUE_DEFAULT,
-          Importance.LOW,
-          "Additional S3 tag values",
-          group,
-          ++orderInGroup,
-          Width.LONG,
-          "S3 Object Tagging Extra Value"
+              S3_OBJECT_TAGGING_EXTRA_KV,
+              Type.LIST,
+              S3_OBJECT_TAGGING_EXTRA_KV_DEFAULT,
+              Importance.LOW,
+              "Additional S3 tag key value pairs",
+              group,
+              ++orderInGroup,
+              Width.LONG,
+              "S3 Object Tagging Extra Key Value pairs"
       );
 
       configDef.define(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -77,8 +77,7 @@ public class TopicPartitionWriter {
   private final Queue<SinkRecord> buffer;
   private final SinkTaskContext context;
   private final boolean isTaggingEnabled;
-  private final List<String> extraTagKey;
-  private final List<String> extraTagValue;
+  private final List<String> extraTagKeyValuePair;
   private HashMap<String, String> hashMapTag;
   private final boolean ignoreTaggingErrors;
   private int recordCount;
@@ -148,10 +147,7 @@ public class TopicPartitionWriter {
     }
 
     isTaggingEnabled = connectorConfig.getBoolean(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG);
-    extraTagKey = connectorConfig.getList(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY);
-    extraTagValue = connectorConfig.getList(
-      S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE
-    );
+    extraTagKeyValuePair = connectorConfig.getList(S3SinkConnectorConfig.S3_OBJECT_TAGGING_EXTRA_KV);
     getS3Tag();
     ignoreTaggingErrors = connectorConfig.getString(
             S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG)
@@ -201,14 +197,10 @@ public class TopicPartitionWriter {
 
   private void getS3Tag() {
     hashMapTag = new HashMap<>();
-    if (extraTagKey.size() != extraTagValue.size()) {
-      log.warn("s3.object.tagging.key and s3.object.tagging.value are different in length. This"
-          + "is ignored.");
-    } else if (extraTagKey.size() != 0 || extraTagValue.size() != 0) {
-      for (int i = 0; i < extraTagKey.size(); i++) {
-        String key = extraTagKey.get(i);
-        String value = extraTagValue.get(i);
-        hashMapTag.put(key, value);
+    if (extraTagKeyValuePair.size() != 0) {
+      for (int i = 0; i < extraTagKeyValuePair.size(); i++) {
+        String[] singleKv = extraTagKeyValuePair.get(i).split(":");
+        hashMapTag.put(singleKv[0], singleKv[1]);
       }
     }
   }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -13,53 +13,57 @@
  * specific language governing permissions and limitations under the License.
  */
 
-package io.confluent.connect.s3;
+ package io.confluent.connect.s3;
 
-import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
-import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
-import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
-import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.ConfigValue;
-import org.apache.kafka.connect.json.DecimalFormat;
-import org.apache.kafka.connect.sink.SinkRecord;
-import org.apache.parquet.hadoop.metadata.CompressionCodecName;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
-import com.amazonaws.ClientConfiguration;
-import com.amazonaws.auth.AWSCredentialsProvider;
-
-import io.confluent.connect.avro.AvroDataConfig;
-import io.confluent.connect.s3.S3SinkConnectorConfig.AffixType;
-import io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider;
-import io.confluent.connect.s3.format.avro.AvroFormat;
-import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
-import io.confluent.connect.s3.format.json.JsonFormat;
-import io.confluent.connect.s3.format.parquet.ParquetFormat;
-import io.confluent.connect.s3.storage.S3Storage;
-import io.confluent.connect.storage.common.StorageCommonConfig;
-import io.confluent.connect.storage.partitioner.DailyPartitioner;
-import io.confluent.connect.storage.partitioner.DefaultPartitioner;
-import io.confluent.connect.storage.partitioner.FieldPartitioner;
-import io.confluent.connect.storage.partitioner.HourlyPartitioner;
-import io.confluent.connect.storage.partitioner.Partitioner;
-import io.confluent.connect.storage.partitioner.PartitionerConfig;
-import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
+ import com.amazonaws.ClientConfiguration;
+ import com.amazonaws.auth.AWSCredentialsProvider;
+ 
+ import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
+ import io.confluent.connect.s3.format.parquet.ParquetFormat;
+ 
+ import org.apache.kafka.common.config.ConfigException;
+ import org.apache.kafka.common.config.ConfigValue;
+ import org.apache.kafka.connect.json.DecimalFormat;
+ import org.apache.kafka.connect.sink.SinkRecord;
+ import org.junit.After;
+ import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+ import org.junit.Before;
+ import org.junit.Test;
+ 
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+ import java.util.stream.Collectors;
+ import java.util.stream.IntStream;
+ 
+ import io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider;
+ import io.confluent.connect.s3.format.avro.AvroFormat;
+ import io.confluent.connect.s3.format.json.JsonFormat;
+ import io.confluent.connect.s3.storage.S3Storage;
+ import io.confluent.connect.storage.common.StorageCommonConfig;
+ import io.confluent.connect.storage.partitioner.DailyPartitioner;
+ import io.confluent.connect.storage.partitioner.DefaultPartitioner;
+ import io.confluent.connect.storage.partitioner.FieldPartitioner;
+ import io.confluent.connect.storage.partitioner.HourlyPartitioner;
+ import io.confluent.connect.storage.partitioner.Partitioner;
+ import io.confluent.connect.storage.partitioner.PartitionerConfig;
+ import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
+ import io.confluent.connect.avro.AvroDataConfig;
+ 
+ import static io.confluent.connect.s3.S3SinkConnectorConfig.AffixType;
+ import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_CONFIG;
+ import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_DEFAULT;
+ import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
+ import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
+ import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
+ 
+ import static org.junit.Assert.assertEquals;
+ import static org.junit.Assert.assertNull;
+ import static org.junit.Assert.assertThrows;
+ import static org.junit.Assert.assertTrue;
+ import static org.junit.Assert.assertFalse;
 
 public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -13,57 +13,57 @@
  * specific language governing permissions and limitations under the License.
  */
 
- package io.confluent.connect.s3;
+package io.confluent.connect.s3;
 
- import com.amazonaws.ClientConfiguration;
- import com.amazonaws.auth.AWSCredentialsProvider;
- 
- import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
- import io.confluent.connect.s3.format.parquet.ParquetFormat;
- 
- import org.apache.kafka.common.config.ConfigException;
- import org.apache.kafka.common.config.ConfigValue;
- import org.apache.kafka.connect.json.DecimalFormat;
- import org.apache.kafka.connect.sink.SinkRecord;
- import org.junit.After;
- import org.apache.parquet.hadoop.metadata.CompressionCodecName;
- import org.junit.Before;
- import org.junit.Test;
- 
- import java.util.ArrayList;
- import java.util.Arrays;
- import java.util.HashMap;
- import java.util.List;
- import java.util.Map;
- import java.util.stream.Collectors;
- import java.util.stream.IntStream;
- 
- import io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider;
- import io.confluent.connect.s3.format.avro.AvroFormat;
- import io.confluent.connect.s3.format.json.JsonFormat;
- import io.confluent.connect.s3.storage.S3Storage;
- import io.confluent.connect.storage.common.StorageCommonConfig;
- import io.confluent.connect.storage.partitioner.DailyPartitioner;
- import io.confluent.connect.storage.partitioner.DefaultPartitioner;
- import io.confluent.connect.storage.partitioner.FieldPartitioner;
- import io.confluent.connect.storage.partitioner.HourlyPartitioner;
- import io.confluent.connect.storage.partitioner.Partitioner;
- import io.confluent.connect.storage.partitioner.PartitionerConfig;
- import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
- import io.confluent.connect.avro.AvroDataConfig;
- 
- import static io.confluent.connect.s3.S3SinkConnectorConfig.AffixType;
- import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_CONFIG;
- import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_DEFAULT;
- import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
- import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
- import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
- 
- import static org.junit.Assert.assertEquals;
- import static org.junit.Assert.assertNull;
- import static org.junit.Assert.assertThrows;
- import static org.junit.Assert.assertTrue;
- import static org.junit.Assert.assertFalse;
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
+import io.confluent.connect.s3.format.parquet.ParquetFormat;
+
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.common.config.ConfigValue;
+import org.apache.kafka.connect.json.DecimalFormat;
+import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.After;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider;
+import io.confluent.connect.s3.format.avro.AvroFormat;
+import io.confluent.connect.s3.format.json.JsonFormat;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.storage.common.StorageCommonConfig;
+import io.confluent.connect.storage.partitioner.DailyPartitioner;
+import io.confluent.connect.storage.partitioner.DefaultPartitioner;
+import io.confluent.connect.storage.partitioner.FieldPartitioner;
+import io.confluent.connect.storage.partitioner.HourlyPartitioner;
+import io.confluent.connect.storage.partitioner.Partitioner;
+import io.confluent.connect.storage.partitioner.PartitionerConfig;
+import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
+import io.confluent.connect.avro.AvroDataConfig;
+
+import static io.confluent.connect.s3.S3SinkConnectorConfig.AffixType;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_DEFAULT;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -338,22 +338,15 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     properties.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "true");
     connectorConfig = new S3SinkConnectorConfig(properties);
     assertEquals(true, connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG));
-    assertEquals(new ArrayList<String>(), connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY));
-    assertEquals(new ArrayList<String>(), connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE));
+    assertEquals(new ArrayList<String>(), connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_EXTRA_KV));
 
-    properties.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY, "key1,key2");
-    properties.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE, "value1,value2");
-    List<String> expectedConfigKey = new ArrayList<String>() {{
-      add("key1");
-      add("key2");
-    }};
-    List<String> expectedConfigValue = new ArrayList<String>() {{
-      add("value1");
-      add("value2");
+    properties.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_EXTRA_KV, "key1:value1,key2:value2");
+    List<String> expectedConfigKeyValuePair = new ArrayList<String>() {{
+      add("key1:value1");
+      add("key2:value2");
     }};
     connectorConfig = new S3SinkConnectorConfig(properties);
-    assertEquals(expectedConfigKey, connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY));
-    assertEquals(expectedConfigValue, connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE));
+    assertEquals(expectedConfigKeyValuePair, connectorConfig.get(S3SinkConnectorConfig.S3_OBJECT_TAGGING_EXTRA_KV));
 
     properties.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "false");
     connectorConfig = new S3SinkConnectorConfig(properties);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -1157,8 +1157,7 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   public void testAddingAdditionalS3ObjectTags() throws Exception{
     // Setting size-based rollup to 10 but will produce fewer records. Commit should not happen.
     localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "true");
-    localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY, "key1,key2");
-    localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE, "value1,value2");
+    localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_EXTRA_KV, "key1:value1,key2:value2");
     setUp();
 
     // Define the partitioner

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -1154,6 +1154,45 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   }
 
   @Test
+  public void testAddingAdditionalS3ObjectTags() throws Exception{
+    // Setting size-based rollup to 10 but will produce fewer records. Commit should not happen.
+    localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG, "true");
+    localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_KEY, "key1,key2");
+    localProps.put(S3SinkConnectorConfig.S3_OBJECT_TAGGING_CONFIG_EXTRA_VALUE, "value1,value2");
+    setUp();
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new DefaultPartitioner<>();
+    partitioner.configure(parsedConfig);
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 3, 3);
+
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // Test actual write
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    // Check expected s3 object tags
+    String dirPrefix = partitioner.generatePartitionedPath(TOPIC, "partition=" + PARTITION);
+    Map<String, List<Tag>> expectedTaggedFiles = new HashMap<>();
+    expectedTaggedFiles.put(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 0, extension, ZERO_PAD_FMT),
+            Arrays.asList(new Tag("startOffset", "0"), new Tag("endOffset", "2"), new Tag("recordCount", "3"), new Tag("key1", "value1"), new Tag("key2", "value2")));
+    expectedTaggedFiles.put(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 3, extension, ZERO_PAD_FMT),
+            Arrays.asList(new Tag("startOffset", "3"), new Tag("endOffset", "5"), new Tag("recordCount", "3"), new Tag("key1", "value1"), new Tag("key2", "value2")));
+    expectedTaggedFiles.put(FileUtils.fileKeyToCommit(topicsDir, dirPrefix, TOPIC_PARTITION, 6, extension, ZERO_PAD_FMT),
+            Arrays.asList(new Tag("startOffset", "6"), new Tag("endOffset", "8"), new Tag("recordCount", "3")));
+    verifyTags(expectedTaggedFiles);
+  }
+  @Test
   public void testIgnoreS3ObjectTaggingSdkClientException() throws Exception {
     // Tagging error occurred (SdkClientException) but getting ignored.
     testS3ObjectTaggingErrorHelper(true, true);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkDataFormatIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkDataFormatIT.java
@@ -146,7 +146,7 @@ public class S3SinkDataFormatIT extends BaseConnectorIT {
     props.put(FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
     final String topicNameWithExt = "other." + AVRO_EXTENSION + ".topic." + AVRO_EXTENSION;
 
-    // Add an extra topic with this extension inside of the name
+    // Add an extra topic with this extension inside the name
     // Use a TreeSet for test determinism
     Set<String> topicNames = new TreeSet<>(Collections.singletonList(topicName));
 


### PR DESCRIPTION
## Problem
Currently, there is a boolean field `s3.object.tagging` in the Kafka Connect sink to S3 config. If set to `true`,connector adds s3 object level tags for starting offset, ending offset, and total record count of a given file. Furthermore, we would like to make Kafka Connect sink to S3 able to sink S3 object with configurable tags. This is extremely valuable if users want to manage S3 Object lifecyle based on S3 tags.
Ultimately, this PR solve issue https://github.com/confluentinc/kafka-connect-storage-cloud/issues/68

## Solution
To add two extra fields `s3.object.tagging.key` and `s3.object.tagging.value` for users to specify their own key value pairs. `s3.object.tagging` must also be set to `true` as pre-requisite

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 