### PR TITLE
[CC-21863] CVE fixes

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -84,11 +84,11 @@
             <version>${httpclient.version}</version>
         </dependency>
         <!--Pin snappy-java version to fix CVE-2023-34455 -->
-        <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>${snappy.java.version}</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.xerial.snappy</groupId>-->
+<!--            <artifactId>snappy-java</artifactId>-->
+<!--            <version>${snappy.java.version}</version>-->
+<!--        </dependency>-->
         <dependency>
             <groupId>io.findify</groupId>
             <artifactId>s3mock_2.12</artifactId>
@@ -141,6 +141,12 @@
             <version>${kafka.version}</version>
             <classifier>test</classifier>
             <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.xerial.snappy</groupId>
+                    <artifactId>snappy-java</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -165,7 +171,7 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
 
     <properties>
         <jackson.core.version>2.15.0</jackson.core.version>
-        <snappy.java>1.1.10.1</snappy.java>
         <checkstyle.suppressions.location>checkstyle/suppressions.xml</checkstyle.suppressions.location>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
@@ -69,7 +68,8 @@
         <jettison.version>1.5.4</jettison.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox.version>5.4.0</woodstox.version>
-        <snappy.java.version>1.1.10.3</snappy.java.version>
+        <snappy.java.version>1.1.10.4</snappy.java.version>
+        <avro.version>1.11.3</avro.version>
     </properties>
 
     <repositories>
@@ -89,11 +89,11 @@
                 <version>${snakeyaml.version}</version>
             </dependency>
             <!-- band aid until the connector catches up with updated pom parent -->
-            <dependency>
-                <groupId>org.xerial.snappy</groupId>
-                <artifactId>snappy-java</artifactId>
-                <version>${snappy.java.version}</version>
-            </dependency>
+<!--            <dependency>-->
+<!--                <groupId>org.xerial.snappy</groupId>-->
+<!--                <artifactId>snappy-java</artifactId>-->
+<!--                <version>${snappy.java.version}</version>-->
+<!--            </dependency>-->
             <dependency>
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>
@@ -373,11 +373,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.xerial.snappy</groupId>
-            <artifactId>snappy-java</artifactId>
-            <version>${snappy.java}</version>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.core.version}</version>
@@ -386,18 +381,36 @@
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-avro-converter</artifactId>
             <version>${confluent.version.range}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-protobuf-converter</artifactId>
             <version>${confluent.version.range}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-connect-json-schema-converter</artifactId>
             <version>${confluent.version.range}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -405,12 +418,24 @@
             <artifactId>kafka-schema-registry</artifactId>
             <version>${confluent.version.range}</version>
             <type>test-jar</type>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.confluent</groupId>
             <artifactId>kafka-schema-registry</artifactId>
             <version>${confluent.version.range}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.google.guava</groupId>
+                    <artifactId>guava</artifactId>
+                </exclusion>
+            </exclusions>
             <scope>test</scope>
         </dependency>
         <!-- Temporary addition until powermock updates its mockito version -->
@@ -420,6 +445,12 @@
             <version>2.19.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.avro</groupId>
+            <artifactId>avro</artifactId>
+            <version>${avro.version}</version>
+        </dependency>
+
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Problem


## Solution

```
[INFO] --- dependency:3.2.0:tree (default-cli) @ kafka-connect-storage-cloud ---
[INFO] io.confluent:kafka-connect-storage-cloud:pom:10.0.27-SNAPSHOT
[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- commons-codec:commons-codec:jar:1.15:compile
[INFO] +- org.apache.kafka:connect-api:jar:7.2.4-12-ccs:provided
[INFO] |  +- org.apache.kafka:kafka-clients:jar:7.2.4-12-ccs:compile
[INFO] |  |  +- com.github.luben:zstd-jni:jar:1.5.2-1:runtime
[INFO] |  |  \- org.lz4:lz4-java:jar:1.8.0:runtime
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.36:compile
[INFO] |  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:provided
[INFO] +- org.apache.kafka:connect-runtime:jar:7.2.4-12-ccs:provided
[INFO] |  +- org.apache.kafka:connect-transforms:jar:7.2.4-12-ccs:provided
[INFO] |  +- org.apache.kafka:kafka-tools:jar:7.2.4-12-ccs:provided
[INFO] |  |  +- org.apache.kafka:kafka-log4j-appender:jar:7.2.4-12-ccs:provided
[INFO] |  |  \- net.sourceforge.argparse4j:argparse4j:jar:0.7.0:provided
[INFO] |  +- org.bitbucket.b_c:jose4j:jar:0.9.3:provided
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:compile
[INFO] |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.15.2:provided
[INFO] |  |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.15.2:provided
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.15.2:provided
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.34:provided
[INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.34:provided
[INFO] |  |  +- org.glassfish.jersey.core:jersey-common:jar:2.34:provided
[INFO] |  |  |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:provided
[INFO] |  |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:provided
[INFO] |  |  +- org.glassfish.jersey.core:jersey-server:jar:2.34:provided
[INFO] |  |  |  \- org.glassfish.jersey.core:jersey-client:jar:2.34:provided
[INFO] |  |  \- jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:provided
[INFO] |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.34:provided
[INFO] |  |  +- org.glassfish.hk2:hk2-locator:jar:2.6.1:provided
[INFO] |  |  |  +- org.glassfish.hk2.external:aopalliance-repackaged:jar:2.6.1:provided
[INFO] |  |  |  +- org.glassfish.hk2:hk2-api:jar:2.6.1:provided
[INFO] |  |  |  \- org.glassfish.hk2:hk2-utils:jar:2.6.1:provided
[INFO] |  |  \- org.javassist:javassist:jar:3.25.0-GA:provided
[INFO] |  +- javax.xml.bind:jaxb-api:jar:2.3.0:compile
[INFO] |  +- javax.activation:activation:jar:1.1.1:provided
[INFO] |  +- org.eclipse.jetty:jetty-servlets:jar:9.4.48.v20220622:provided
[INFO] |  |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.48.v20220622:provided
[INFO] |  +- org.reflections:reflections:jar:0.9.12:provided
[INFO] |  \- org.apache.maven:maven-artifact:jar:3.8.4:provided
[INFO] |     \- org.codehaus.plexus:plexus-utils:jar:3.3.0:provided
[INFO] +- org.apache.kafka:connect-json:jar:7.2.4-12-ccs:provided
[INFO] |  \- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.15.2:provided
[INFO] +- io.confluent:kafka-connect-storage-common:jar:11.2.3:compile
[INFO] +- io.confluent:kafka-connect-storage-core:jar:11.2.3:compile
[INFO] |  +- io.confluent:kafka-connect-avro-data:jar:7.2.4-34:compile (version selected from constraint [7.2.4-0,7.2.5-0))
[INFO] |  \- joda-time:joda-time:jar:2.9.6:compile
[INFO] +- io.confluent:kafka-connect-storage-format:jar:11.2.3:compile
[INFO] |  +- org.apache.parquet:parquet-column:jar:1.11.2:compile
[INFO] |  |  +- org.apache.parquet:parquet-common:jar:1.11.2:compile
[INFO] |  |  \- org.apache.parquet:parquet-encoding:jar:1.11.2:compile
[INFO] |  \- org.apache.parquet:parquet-avro:jar:1.11.2:compile
[INFO] |     +- org.apache.parquet:parquet-hadoop:jar:1.11.2:compile
[INFO] |     |  \- commons-pool:commons-pool:jar:1.6:compile
[INFO] |     \- org.apache.parquet:parquet-format-structures:jar:1.11.2:compile
[INFO] |        \- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- io.confluent:kafka-connect-storage-partitioner:jar:11.2.3:compile
[INFO] +- io.confluent:kafka-connect-storage-common-hadoop-shaded-guava:jar:11.2.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.15.0:compile
[INFO] +- org.codehaus.jettison:jettison:jar:1.5.4:compile
[INFO] +- com.fasterxml.woodstox:woodstox-core:jar:5.4.0:compile
[INFO] |  \- org.codehaus.woodstox:stax2-api:jar:4.2:compile
[INFO] +- org.apache.hadoop:hadoop-common:jar:3.3.6:compile
[INFO] |  +- org.apache.hadoop:hadoop-annotations:jar:3.3.6:compile
[INFO] |  +- commons-cli:commons-cli:jar:1.2:compile
[INFO] |  +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] |  +- commons-io:commons-io:jar:2.8.0:compile
[INFO] |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] |  +- javax.servlet:javax.servlet-api:jar:3.1.0:compile
[INFO] |  +- jakarta.activation:jakarta.activation-api:jar:1.2.1:runtime
[INFO] |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  +- com.sun.jersey:jersey-core:jar:1.19.4:compile
[INFO] |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
[INFO] |  +- com.sun.jersey:jersey-servlet:jar:1.19.4:compile
[INFO] |  +- com.github.pjfanning:jersey-json:jar:1.20:compile
[INFO] |  |  \- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
[INFO] |  +- com.sun.jersey:jersey-server:jar:1.19.4:compile
[INFO] |  +- org.apache.commons:commons-configuration2:jar:2.8.0:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.10.0:compile
[INFO] |  +- com.google.re2j:re2j:jar:1.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.19.6:compile
[INFO] |  +- com.google.code.gson:gson:jar:2.9.0:compile
[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.3.6:compile
[INFO] |  |  +- org.apache.curator:curator-framework:jar:5.2.0:compile
[INFO] |  |  \- org.apache.kerby:kerb-simplekdc:jar:1.0.1:compile
[INFO] |  |     +- org.apache.kerby:kerb-client:jar:1.0.1:compile
[INFO] |  |     |  +- org.apache.kerby:kerby-config:jar:1.0.1:compile
[INFO] |  |     |  +- org.apache.kerby:kerb-common:jar:1.0.1:compile
[INFO] |  |     |  |  \- org.apache.kerby:kerb-crypto:jar:1.0.1:compile
[INFO] |  |     |  +- org.apache.kerby:kerb-util:jar:1.0.1:compile
[INFO] |  |     |  \- org.apache.kerby:token-provider:jar:1.0.1:compile
[INFO] |  |     \- org.apache.kerby:kerb-admin:jar:1.0.1:compile
[INFO] |  |        +- org.apache.kerby:kerb-server:jar:1.0.1:compile
[INFO] |  |        |  \- org.apache.kerby:kerb-identity:jar:1.0.1:compile
[INFO] |  |        \- org.apache.kerby:kerby-xdr:jar:1.0.1:compile
[INFO] |  +- com.jcraft:jsch:jar:0.1.55:compile
[INFO] |  +- org.apache.curator:curator-client:jar:5.2.0:compile
[INFO] |  +- org.apache.curator:curator-recipes:jar:5.2.0:compile
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.apache.zookeeper:zookeeper:jar:3.6.3:compile
[INFO] |  |  +- org.apache.zookeeper:zookeeper-jute:jar:3.6.3:compile
[INFO] |  |  \- org.apache.yetus:audience-annotations:jar:0.5.0:compile
[INFO] |  +- io.dropwizard.metrics:metrics-core:jar:3.2.4:compile
[INFO] |  +- org.apache.commons:commons-compress:jar:1.21:compile
[INFO] |  +- org.apache.kerby:kerb-core:jar:1.0.1:compile
[INFO] |  |  \- org.apache.kerby:kerby-pkix:jar:1.0.1:compile
[INFO] |  |     +- org.apache.kerby:kerby-asn1:jar:1.0.1:compile
[INFO] |  |     \- org.apache.kerby:kerby-util:jar:1.0.1:compile
[INFO] |  +- dnsjava:dnsjava:jar:2.1.7:compile
[INFO] |  \- org.xerial.snappy:snappy-java:jar:1.1.10.4:compile
[INFO] +- org.slf4j:slf4j-reload4j:jar:1.7.36:compile
[INFO] +- net.minidev:json-smart:jar:2.4.10:compile
[INFO] |  \- net.minidev:accessors-smart:jar:2.4.9:compile
[INFO] |     \- org.ow2.asm:asm:jar:9.3:compile
[INFO] +- org.eclipse.jetty:jetty-http:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-io:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-servlet:jar:9.4.51.v20230217:test
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:9.4.51.v20230217:test
[INFO] |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-server:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-client:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-util:jar:9.4.51.v20230217:test
[INFO] +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:3.3.6:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-client:jar:3.3.6:test
[INFO] |  |  +- org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:1.1.1:test
[INFO] |  |  +- org.eclipse.jetty.websocket:websocket-client:jar:9.4.51.v20230217:test
[INFO] |  |  |  \- org.eclipse.jetty.websocket:websocket-common:jar:9.4.51.v20230217:test
[INFO] |  |  |     \- org.eclipse.jetty.websocket:websocket-api:jar:9.4.51.v20230217:test
[INFO] |  |  +- org.apache.hadoop:hadoop-yarn-api:jar:3.3.6:test
[INFO] |  |  |  \- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:jar:1.1.1:test
[INFO] |  |  \- org.jline:jline:jar:3.9.0:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-common:jar:3.3.6:test
[INFO] |  |  +- com.sun.jersey:jersey-client:jar:1.19.4:test
[INFO] |  |  +- com.google.inject:guice:jar:4.0:test
[INFO] |  |  |  +- javax.inject:javax.inject:jar:1:test
[INFO] |  |  |  \- aopalliance:aopalliance:jar:1.0:test
[INFO] |  |  \- com.sun.jersey.contribs:jersey-guice:jar:1.19.4:test
[INFO] |  +- org.apache.hadoop:hadoop-hdfs-client:jar:3.3.6:test
[INFO] |  |  +- com.squareup.okhttp3:okhttp:jar:4.9.3:test
[INFO] |  |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.4.10:test
[INFO] |  +- com.google.inject.extensions:guice-servlet:jar:4.0:test
[INFO] |  \- io.netty:netty:jar:3.10.6.Final:test
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.junit.jupiter:junit-jupiter-engine:jar:5.8.2:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:1.8.2:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.8.2:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.8.2:test
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] +- org.easymock:easymock:jar:4.3:test
[INFO] |  \- org.objenesis:objenesis:jar:3.2:test
[INFO] +- org.powermock:powermock-module-junit4:jar:2.0.9:test
[INFO] |  \- org.powermock:powermock-module-junit4-common:jar:2.0.9:test
[INFO] |     +- org.powermock:powermock-reflect:jar:2.0.9:test
[INFO] |     \- org.powermock:powermock-core:jar:2.0.9:test
[INFO] +- org.powermock:powermock-api-easymock:jar:2.0.9:test
[INFO] |  +- org.powermock:powermock-api-support:jar:2.0.9:test
[INFO] |  \- cglib:cglib-nodep:jar:3.2.9:test
[INFO] +- org.powermock:powermock-api-mockito2:jar:2.0.9:test
[INFO] +- io.confluent:kafka-connect-avro-converter:jar:7.2.4-34:test
[INFO] |  +- io.confluent:kafka-avro-serializer:jar:7.2.4-34:compile
[INFO] |  \- io.confluent:kafka-schema-registry-client:jar:7.2.4-34:compile
[INFO] |     \- org.yaml:snakeyaml:jar:2.0:compile
[INFO] +- io.confluent:kafka-connect-protobuf-converter:jar:7.2.4-34:test
[INFO] |  +- io.confluent:kafka-protobuf-provider:jar:7.2.4-34:test
[INFO] |  |  +- com.squareup.wire:wire-runtime-jvm:jar:4.3.0:test
[INFO] |  |  \- com.google.api.grpc:proto-google-common-protos:jar:2.5.1:test
[INFO] |  +- io.confluent:kafka-protobuf-serializer:jar:7.2.4-34:test
[INFO] |  +- io.confluent:kafka-protobuf-types:jar:7.2.4-34:test
[INFO] |  +- com.squareup.wire:wire-schema-jvm:jar:4.3.0:test
[INFO] |  |  +- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.6.10:test
[INFO] |  |  |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.6.10:test
[INFO] |  |  \- com.squareup.okio:okio:jar:3.0.0:test
[INFO] |  +- com.squareup.okio:okio-jvm:jar:3.0.0:test
[INFO] |  +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.0:test
[INFO] |  |  \- org.jetbrains:annotations:jar:13.0:test
[INFO] |  +- io.confluent:kafka-schema-converter:jar:7.2.4-34:compile
[INFO] |  +- io.confluent:kafka-schema-serializer:jar:7.2.4-34:compile
[INFO] |  \- com.google.protobuf:protobuf-java-util:jar:3.19.6:test
[INFO] +- io.confluent:kafka-connect-json-schema-converter:jar:7.2.4-34:test
[INFO] |  +- io.confluent:kafka-json-schema-provider:jar:7.2.4-34:test
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.15.2:test
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.15.2:test
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.2:test
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.15.2:test
[INFO] |  |  +- com.kjetland:mbknor-jackson-jsonschema_2.13:jar:1.0.39:test
[INFO] |  |  |  +- javax.validation:validation-api:jar:2.0.1.Final:test
[INFO] |  |  |  \- io.github.classgraph:classgraph:jar:4.8.21:test
[INFO] |  |  +- org.jetbrains.kotlin:kotlin-scripting-jvm:jar:1.6.0:test
[INFO] |  |  |  +- org.jetbrains.kotlin:kotlin-script-runtime:jar:1.6.0:test
[INFO] |  |  |  \- org.jetbrains.kotlin:kotlin-scripting-common:jar:1.6.0:test
[INFO] |  |  \- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:jar:1.6.0:test
[INFO] |  |     \- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:jar:1.6.0:test
[INFO] |  +- io.confluent:kafka-json-schema-serializer:jar:7.2.4-34:test
[INFO] |  |  \- io.confluent:kafka-json-serializer:jar:7.2.4-34:test
[INFO] |  |     \- io.confluent:common-config:jar:7.2.4-30:test
[INFO] |  \- com.github.erosb:everit-json-schema:jar:1.14.1:test
[INFO] |     +- org.json:json:jar:20220320:test
[INFO] |     +- commons-validator:commons-validator:jar:1.7:test
[INFO] |     |  \- commons-digester:commons-digester:jar:2.1:test
[INFO] |     \- com.damnhandy:handy-uri-templates:jar:2.1.8:test
[INFO] +- io.confluent:kafka-schema-registry:test-jar:tests:7.2.4-34:test
[INFO] |  +- org.apache.kafka:kafka_2.13:jar:7.2.4-12-ccs:test
[INFO] |  |  +- org.scala-lang:scala-library:jar:2.13.10:test
[INFO] |  |  +- org.apache.kafka:kafka-server-common:jar:7.2.4-12-ccs:test
[INFO] |  |  +- org.apache.kafka:kafka-metadata:jar:7.2.4-12-ccs:test
[INFO] |  |  +- org.apache.kafka:kafka-raft:jar:7.2.4-12-ccs:test
[INFO] |  |  +- org.apache.kafka:kafka-storage:jar:7.2.4-12-ccs:test
[INFO] |  |  |  \- org.apache.kafka:kafka-storage-api:jar:7.2.4-12-ccs:test
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-scala_2.13:jar:2.15.2:test
[INFO] |  |  |  \- com.thoughtworks.paranamer:paranamer:jar:2.8:test
[INFO] |  |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:jar:2.15.2:test
[INFO] |  |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
[INFO] |  |  +- com.yammer.metrics:metrics-core:jar:2.2.0:test
[INFO] |  |  +- org.scala-lang.modules:scala-collection-compat_2.13:jar:2.6.0:test
[INFO] |  |  +- org.scala-lang.modules:scala-java8-compat_2.13:jar:1.0.2:test
[INFO] |  |  +- org.scala-lang:scala-reflect:jar:2.13.10:test
[INFO] |  |  \- com.typesafe.scala-logging:scala-logging_2.13:jar:3.9.4:test
[INFO] |  +- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.36:test
[INFO] |  |  +- org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:provided
[INFO] |  |  +- jakarta.validation:jakarta.validation-api:jar:2.0.2:provided
[INFO] |  |  +- jakarta.el:jakarta.el-api:jar:3.0.3:test
[INFO] |  |  \- org.glassfish:jakarta.el:jar:3.0.4:test
[INFO] |  +- org.hibernate.validator:hibernate-validator:jar:6.1.7.Final:test
[INFO] |  |  +- org.jboss.logging:jboss-logging:jar:3.3.2.Final:test
[INFO] |  |  \- com.fasterxml:classmate:jar:1.3.4:test
[INFO] |  +- io.confluent:rest-utils:jar:7.2.4-30:test
[INFO] |  |  +- org.eclipse.jetty.websocket:javax-websocket-server-impl:jar:9.4.48.v20220622:test
[INFO] |  |  |  +- org.eclipse.jetty:jetty-annotations:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  +- org.eclipse.jetty:jetty-plus:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-jndi:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  +- org.eclipse.jetty:jetty-webapp:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-xml:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  \- org.ow2.asm:asm-commons:jar:9.3:test
[INFO] |  |  |  |     +- org.ow2.asm:asm-tree:jar:9.3:test
[INFO] |  |  |  |     \- org.ow2.asm:asm-analysis:jar:9.3:test
[INFO] |  |  |  +- org.eclipse.jetty.websocket:javax-websocket-client-impl:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  \- javax.websocket:javax.websocket-client-api:jar:1.0:test
[INFO] |  |  |  +- org.eclipse.jetty.websocket:websocket-server:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  \- org.eclipse.jetty.websocket:websocket-servlet:jar:9.4.48.v20220622:test
[INFO] |  |  |  \- javax.websocket:javax.websocket-api:jar:1.0:test
[INFO] |  |  +- org.eclipse.jetty:jetty-jmx:jar:9.4.48.v20220622:test
[INFO] |  |  +- org.eclipse.jetty.http2:http2-server:jar:9.4.48.v20220622:test
[INFO] |  |  |  \- org.eclipse.jetty.http2:http2-common:jar:9.4.48.v20220622:test
[INFO] |  |  |     \- org.eclipse.jetty.http2:http2-hpack:jar:9.4.48.v20220622:test
[INFO] |  |  +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.48.v20220622:test
[INFO] |  |  +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.48.v20220622:test
[INFO] |  |  \- org.eclipse.jetty:jetty-jaas:jar:9.4.48.v20220622:test
[INFO] |  +- io.confluent:logredactor:jar:1.0.11:compile
[INFO] |  |  +- io.confluent:logredactor-metrics:jar:1.0.11:compile
[INFO] |  |  \- com.eclipsesource.minimal-json:minimal-json:jar:0.9.5:compile
[INFO] |  +- io.netty:netty-codec:jar:4.1.86.Final:test
[INFO] |  |  +- io.netty:netty-common:jar:4.1.86.Final:test
[INFO] |  |  +- io.netty:netty-buffer:jar:4.1.86.Final:test
[INFO] |  |  \- io.netty:netty-transport:jar:4.1.86.Final:test
[INFO] |  |     \- io.netty:netty-resolver:jar:4.1.86.Final:test
[INFO] |  +- io.swagger.core.v3:swagger-annotations:jar:2.1.10:compile
[INFO] |  \- io.swagger.core.v3:swagger-core:jar:2.1.10:test
[INFO] |     +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2:provided
[INFO] |     +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.15.2:test
[INFO] |     \- io.swagger.core.v3:swagger-models:jar:2.1.10:test
[INFO] +- io.confluent:kafka-schema-registry:jar:7.2.4-34:test
[INFO] +- org.mockito:mockito-core:jar:2.19.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.8.10:test
[INFO] |  \- net.bytebuddy:byte-buddy-agent:jar:1.8.10:test
[INFO] +- com.google.guava:guava:jar:32.1.2-jre:test
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.1:test
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:test
[INFO] |  +- org.checkerframework:checker-qual:jar:3.33.0:test
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.18.0:test
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:2.8:test
[INFO] +- org.apache.avro:avro:jar:1.11.3:compile
[INFO] +- jline:jline:jar:2.12.1:compile
[INFO] +- ch.qos.reload4j:reload4j:jar:1.2.19:test
[INFO] +- io.confluent:common-utils:jar:7.2.4-30:compile
[INFO] \- io.confluent:assembly-plugin-boilerplate:zip:resources:7.2.4-30:provided
[INFO]
[INFO] -------------------< io.confluent:kafka-connect-s3 >--------------------
[INFO] Building kafka-connect-s3 10.0.27-SNAPSHOT                         [2/2]
[INFO]   from kafka-connect-s3/pom.xml
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- dependency:3.2.0:tree (default-cli) @ kafka-connect-s3 ---
[INFO] io.confluent:kafka-connect-s3:jar:10.0.27-SNAPSHOT
[INFO] +- com.amazonaws:aws-java-sdk-s3:jar:1.12.524:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-kms:jar:1.12.524:compile
[INFO] |  +- com.amazonaws:aws-java-sdk-core:jar:1.12.524:compile
[INFO] |  |  +- software.amazon.ion:ion-java:jar:1.0.2:compile
[INFO] |  |  \- com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:jar:2.13.4:compile
[INFO] |  \- com.amazonaws:jmespath-java:jar:1.12.524:compile
[INFO] +- com.amazonaws:aws-java-sdk-sts:jar:1.12.524:compile
[INFO] +- org.apache.httpcomponents:httpclient:jar:4.5.13:compile
[INFO] |  +- org.apache.httpcomponents:httpcore:jar:4.4.4:compile
[INFO] |  +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |  \- commons-codec:commons-codec:jar:1.15:compile
[INFO] +- org.xerial.snappy:snappy-java:jar:1.1.10.4:compile
[INFO] +- io.findify:s3mock_2.12:jar:0.2.5:test
[INFO] |  +- com.typesafe.akka:akka-stream_2.12:jar:2.5.11:test
[INFO] |  |  +- com.typesafe.akka:akka-actor_2.12:jar:2.5.11:test
[INFO] |  |  |  \- com.typesafe:config:jar:1.3.2:test
[INFO] |  |  +- com.typesafe.akka:akka-protobuf_2.12:jar:2.5.11:test
[INFO] |  |  +- org.reactivestreams:reactive-streams:jar:1.0.2:test
[INFO] |  |  \- com.typesafe:ssl-config-core_2.12:jar:0.2.2:test
[INFO] |  |     \- org.scala-lang.modules:scala-parser-combinators_2.12:jar:1.0.4:test
[INFO] |  +- com.typesafe.akka:akka-http_2.12:jar:10.1.0:test
[INFO] |  |  \- com.typesafe.akka:akka-http-core_2.12:jar:10.1.0:test
[INFO] |  |     \- com.typesafe.akka:akka-parsing_2.12:jar:10.1.0:test
[INFO] |  +- org.scala-lang.modules:scala-xml_2.12:jar:1.1.0:test
[INFO] |  +- com.github.pathikrit:better-files_2.12:jar:3.4.0:test
[INFO] |  +- com.typesafe.scala-logging:scala-logging_2.12:jar:3.8.0:test
[INFO] |  \- org.iq80.leveldb:leveldb:jar:0.10:test
[INFO] |     \- org.iq80.leveldb:leveldb-api:jar:0.10:test
[INFO] +- javax.el:javax.el-api:jar:3.0.0:test
[INFO] +- org.glassfish:javax.el:jar:3.0.0:test
[INFO] +- org.apache.kafka:connect-runtime:test-jar:test:7.2.4-12-ccs:test
[INFO] |  +- org.apache.kafka:kafka-clients:jar:7.2.4-12-ccs:compile
[INFO] |  +- org.apache.kafka:connect-transforms:jar:7.2.4-12-ccs:provided
[INFO] |  +- org.apache.kafka:kafka-tools:jar:7.2.4-12-ccs:provided
[INFO] |  |  \- org.apache.kafka:kafka-log4j-appender:jar:7.2.4-12-ccs:provided
[INFO] |  +- org.slf4j:slf4j-api:jar:1.7.36:compile
[INFO] |  +- org.bitbucket.b_c:jose4j:jar:0.9.3:provided
[INFO] |  +- com.fasterxml.jackson.core:jackson-annotations:jar:2.15.2:compile
[INFO] |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.15.2:provided
[INFO] |  |  +- com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.15.2:provided
[INFO] |  |  \- com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.15.2:provided
[INFO] |  +- org.glassfish.jersey.containers:jersey-container-servlet:jar:2.34:provided
[INFO] |  |  +- org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.34:provided
[INFO] |  |  +- org.glassfish.jersey.core:jersey-common:jar:2.34:provided
[INFO] |  |  |  +- jakarta.annotation:jakarta.annotation-api:jar:1.3.5:provided
[INFO] |  |  |  \- org.glassfish.hk2:osgi-resource-locator:jar:1.0.3:provided
[INFO] |  |  +- org.glassfish.jersey.core:jersey-server:jar:2.34:provided
[INFO] |  |  |  \- org.glassfish.jersey.core:jersey-client:jar:2.34:provided
[INFO] |  |  \- jakarta.ws.rs:jakarta.ws.rs-api:jar:2.1.6:provided
[INFO] |  +- org.glassfish.jersey.inject:jersey-hk2:jar:2.34:provided
[INFO] |  |  +- org.glassfish.hk2:hk2-locator:jar:2.6.1:provided
[INFO] |  |  |  +- org.glassfish.hk2.external:aopalliance-repackaged:jar:2.6.1:provided
[INFO] |  |  |  +- org.glassfish.hk2:hk2-api:jar:2.6.1:provided
[INFO] |  |  |  \- org.glassfish.hk2:hk2-utils:jar:2.6.1:provided
[INFO] |  |  \- org.javassist:javassist:jar:3.25.0-GA:provided
[INFO] |  +- javax.xml.bind:jaxb-api:jar:2.3.0:compile
[INFO] |  +- javax.activation:activation:jar:1.1.1:provided
[INFO] |  +- org.eclipse.jetty:jetty-servlets:jar:9.4.48.v20220622:provided
[INFO] |  |  \- org.eclipse.jetty:jetty-continuation:jar:9.4.48.v20220622:provided
[INFO] |  +- org.reflections:reflections:jar:0.9.12:provided
[INFO] |  \- org.apache.maven:maven-artifact:jar:3.8.4:provided
[INFO] |     \- org.codehaus.plexus:plexus-utils:jar:3.3.0:provided
[INFO] +- org.apache.kafka:kafka_2.12:jar:7.2.4-12-ccs:test
[INFO] |  +- org.apache.kafka:kafka-server-common:jar:7.2.4-12-ccs:test
[INFO] |  +- org.apache.kafka:kafka-metadata:jar:7.2.4-12-ccs:test
[INFO] |  +- org.apache.kafka:kafka-raft:jar:7.2.4-12-ccs:test
[INFO] |  +- org.apache.kafka:kafka-storage:jar:7.2.4-12-ccs:test
[INFO] |  |  \- org.apache.kafka:kafka-storage-api:jar:7.2.4-12-ccs:test
[INFO] |  +- net.sourceforge.argparse4j:argparse4j:jar:0.7.0:provided
[INFO] |  +- com.fasterxml.jackson.module:jackson-module-scala_2.12:jar:2.15.2:test
[INFO] |  |  \- com.thoughtworks.paranamer:paranamer:jar:2.8:test
[INFO] |  +- com.fasterxml.jackson.dataformat:jackson-dataformat-csv:jar:2.15.2:test
[INFO] |  +- com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.15.2:provided
[INFO] |  +- net.sf.jopt-simple:jopt-simple:jar:5.0.4:test
[INFO] |  +- com.yammer.metrics:metrics-core:jar:2.2.0:test
[INFO] |  +- org.scala-lang.modules:scala-collection-compat_2.12:jar:2.6.0:test
[INFO] |  +- org.scala-lang.modules:scala-java8-compat_2.12:jar:1.0.2:test
[INFO] |  +- org.scala-lang:scala-reflect:jar:2.13.10:test
[INFO] |  +- io.dropwizard.metrics:metrics-core:jar:4.1.12.1:compile
[INFO] |  +- org.apache.zookeeper:zookeeper:jar:3.6.3:compile
[INFO] |  |  +- org.apache.zookeeper:zookeeper-jute:jar:3.6.3:compile
[INFO] |  |  \- org.apache.yetus:audience-annotations:jar:0.5.0:compile
[INFO] |  \- commons-cli:commons-cli:jar:1.4:compile
[INFO] +- org.apache.kafka:kafka_2.12:test-jar:test:7.2.4-12-ccs:test
[INFO] +- org.apache.kafka:kafka-clients:test-jar:test:7.2.4-12-ccs:test
[INFO] |  +- com.github.luben:zstd-jni:jar:1.5.2-1:runtime
[INFO] |  \- org.lz4:lz4-java:jar:1.8.0:runtime
[INFO] +- org.apache.parquet:parquet-tools:jar:1.11.1:test
[INFO] +- org.scala-lang:scala-library:jar:2.12.10:test
[INFO] +- org.testcontainers:testcontainers:jar:1.15.0:test
[INFO] |  +- org.apache.commons:commons-compress:jar:1.21:compile
[INFO] |  +- org.rnorth.duct-tape:duct-tape:jar:1.0.8:test
[INFO] |  +- org.rnorth.visible-assertions:visible-assertions:jar:2.1.2:test
[INFO] |  |  \- net.java.dev.jna:jna:jar:5.2.0:test
[INFO] |  +- com.github.docker-java:docker-java-api:jar:3.2.5:test
[INFO] |  \- com.github.docker-java:docker-java-transport-zerodep:jar:3.2.5:test
[INFO] |     \- com.github.docker-java:docker-java-transport:jar:3.2.5:test
[INFO] +- com.google.guava:guava:jar:32.1.2-jre:test
[INFO] |  +- com.google.guava:failureaccess:jar:1.0.1:test
[INFO] |  +- com.google.guava:listenablefuture:jar:9999.0-empty-to-avoid-conflict-with-guava:test
[INFO] |  +- com.google.code.findbugs:jsr305:jar:3.0.2:compile
[INFO] |  +- org.checkerframework:checker-qual:jar:3.33.0:test
[INFO] |  +- com.google.errorprone:error_prone_annotations:jar:2.18.0:test
[INFO] |  \- com.google.j2objc:j2objc-annotations:jar:2.8:test
[INFO] +- com.github.tomakehurst:wiremock-jre8-standalone:jar:2.31.0:test
[INFO] +- org.assertj:assertj-core:jar:3.20.2:test
[INFO] +- org.apache.kafka:connect-api:jar:7.2.4-12-ccs:provided
[INFO] |  \- javax.ws.rs:javax.ws.rs-api:jar:2.1.1:provided
[INFO] +- org.apache.kafka:connect-runtime:jar:7.2.4-12-ccs:provided
[INFO] +- org.apache.kafka:connect-json:jar:7.2.4-12-ccs:provided
[INFO] +- io.confluent:kafka-connect-storage-common:jar:11.2.3:compile
[INFO] +- io.confluent:kafka-connect-storage-core:jar:11.2.3:compile
[INFO] |  +- io.confluent:kafka-connect-avro-data:jar:7.2.4-34:compile (version selected from constraint [7.2.4-0,7.2.5-0))
[INFO] |  \- joda-time:joda-time:jar:2.9.6:compile
[INFO] +- io.confluent:kafka-connect-storage-format:jar:11.2.3:compile
[INFO] |  +- org.apache.parquet:parquet-column:jar:1.11.2:compile
[INFO] |  |  +- org.apache.parquet:parquet-common:jar:1.11.2:compile
[INFO] |  |  \- org.apache.parquet:parquet-encoding:jar:1.11.2:compile
[INFO] |  \- org.apache.parquet:parquet-avro:jar:1.11.2:compile
[INFO] |     +- org.apache.parquet:parquet-hadoop:jar:1.11.2:compile
[INFO] |     |  \- commons-pool:commons-pool:jar:1.6:compile
[INFO] |     \- org.apache.parquet:parquet-format-structures:jar:1.11.2:compile
[INFO] |        \- javax.annotation:javax.annotation-api:jar:1.3.2:compile
[INFO] +- io.confluent:kafka-connect-storage-partitioner:jar:11.2.3:compile
[INFO] +- io.confluent:kafka-connect-storage-common-hadoop-shaded-guava:jar:11.2.3:compile
[INFO] +- com.fasterxml.jackson.core:jackson-databind:jar:2.15.2:compile
[INFO] +- com.fasterxml.jackson.core:jackson-core:jar:2.15.0:compile
[INFO] +- org.codehaus.jettison:jettison:jar:1.5.4:compile
[INFO] +- com.fasterxml.woodstox:woodstox-core:jar:5.4.0:compile
[INFO] |  \- org.codehaus.woodstox:stax2-api:jar:4.2:compile
[INFO] +- org.apache.hadoop:hadoop-common:jar:3.3.6:compile
[INFO] |  +- org.apache.hadoop:hadoop-annotations:jar:3.3.6:compile
[INFO] |  +- org.apache.commons:commons-math3:jar:3.1.1:compile
[INFO] |  +- commons-io:commons-io:jar:2.8.0:compile
[INFO] |  +- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] |  +- javax.servlet:javax.servlet-api:jar:3.1.0:compile
[INFO] |  +- jakarta.activation:jakarta.activation-api:jar:1.2.1:runtime
[INFO] |  +- javax.servlet.jsp:jsp-api:jar:2.1:runtime
[INFO] |  +- com.sun.jersey:jersey-core:jar:1.19.4:compile
[INFO] |  |  \- javax.ws.rs:jsr311-api:jar:1.1.1:compile
[INFO] |  +- com.sun.jersey:jersey-servlet:jar:1.19.4:compile
[INFO] |  +- com.github.pjfanning:jersey-json:jar:1.20:compile
[INFO] |  |  \- com.sun.xml.bind:jaxb-impl:jar:2.2.3-1:compile
[INFO] |  +- com.sun.jersey:jersey-server:jar:1.19.4:compile
[INFO] |  +- org.apache.commons:commons-configuration2:jar:2.8.0:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.12.0:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.10.0:compile
[INFO] |  +- com.google.re2j:re2j:jar:1.1:compile
[INFO] |  +- com.google.protobuf:protobuf-java:jar:3.19.6:compile
[INFO] |  +- com.google.code.gson:gson:jar:2.9.0:compile
[INFO] |  +- org.apache.hadoop:hadoop-auth:jar:3.3.6:compile
[INFO] |  |  +- org.apache.curator:curator-framework:jar:5.2.0:compile
[INFO] |  |  \- org.apache.kerby:kerb-simplekdc:jar:1.0.1:compile
[INFO] |  |     +- org.apache.kerby:kerb-client:jar:1.0.1:compile
[INFO] |  |     |  +- org.apache.kerby:kerby-config:jar:1.0.1:compile
[INFO] |  |     |  +- org.apache.kerby:kerb-common:jar:1.0.1:compile
[INFO] |  |     |  |  \- org.apache.kerby:kerb-crypto:jar:1.0.1:compile
[INFO] |  |     |  +- org.apache.kerby:kerb-util:jar:1.0.1:compile
[INFO] |  |     |  \- org.apache.kerby:token-provider:jar:1.0.1:compile
[INFO] |  |     \- org.apache.kerby:kerb-admin:jar:1.0.1:compile
[INFO] |  |        +- org.apache.kerby:kerb-server:jar:1.0.1:compile
[INFO] |  |        |  \- org.apache.kerby:kerb-identity:jar:1.0.1:compile
[INFO] |  |        \- org.apache.kerby:kerby-xdr:jar:1.0.1:compile
[INFO] |  +- com.jcraft:jsch:jar:0.1.55:compile
[INFO] |  +- org.apache.curator:curator-client:jar:5.2.0:compile
[INFO] |  +- org.apache.curator:curator-recipes:jar:5.2.0:compile
[INFO] |  +- org.apache.kerby:kerb-core:jar:1.0.1:compile
[INFO] |  |  \- org.apache.kerby:kerby-pkix:jar:1.0.1:compile
[INFO] |  |     +- org.apache.kerby:kerby-asn1:jar:1.0.1:compile
[INFO] |  |     \- org.apache.kerby:kerby-util:jar:1.0.1:compile
[INFO] |  \- dnsjava:dnsjava:jar:2.1.7:compile
[INFO] +- org.slf4j:slf4j-reload4j:jar:1.7.36:compile
[INFO] +- net.minidev:json-smart:jar:2.4.10:compile
[INFO] |  \- net.minidev:accessors-smart:jar:2.4.9:compile
[INFO] |     \- org.ow2.asm:asm:jar:9.3:compile
[INFO] +- org.eclipse.jetty:jetty-http:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-io:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-servlet:jar:9.4.51.v20230217:test
[INFO] |  +- org.eclipse.jetty:jetty-security:jar:9.4.51.v20230217:test
[INFO] |  \- org.eclipse.jetty:jetty-util-ajax:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-server:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-client:jar:9.4.51.v20230217:test
[INFO] +- org.eclipse.jetty:jetty-util:jar:9.4.51.v20230217:test
[INFO] +- commons-beanutils:commons-beanutils:jar:1.9.4:compile
[INFO] +- org.apache.hadoop:hadoop-mapreduce-client-core:jar:3.3.6:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-client:jar:3.3.6:test
[INFO] |  |  +- org.apache.hadoop.thirdparty:hadoop-shaded-guava:jar:1.1.1:test
[INFO] |  |  +- org.eclipse.jetty.websocket:websocket-client:jar:9.4.51.v20230217:test
[INFO] |  |  |  \- org.eclipse.jetty.websocket:websocket-common:jar:9.4.51.v20230217:test
[INFO] |  |  |     \- org.eclipse.jetty.websocket:websocket-api:jar:9.4.51.v20230217:test
[INFO] |  |  +- org.apache.hadoop:hadoop-yarn-api:jar:3.3.6:test
[INFO] |  |  |  \- org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7:jar:1.1.1:test
[INFO] |  |  \- org.jline:jline:jar:3.9.0:test
[INFO] |  +- org.apache.hadoop:hadoop-yarn-common:jar:3.3.6:test
[INFO] |  |  +- com.sun.jersey:jersey-client:jar:1.19.4:test
[INFO] |  |  +- com.google.inject:guice:jar:4.0:test
[INFO] |  |  |  +- javax.inject:javax.inject:jar:1:test
[INFO] |  |  |  \- aopalliance:aopalliance:jar:1.0:test
[INFO] |  |  \- com.sun.jersey.contribs:jersey-guice:jar:1.19.4:test
[INFO] |  +- org.apache.hadoop:hadoop-hdfs-client:jar:3.3.6:test
[INFO] |  |  +- com.squareup.okhttp3:okhttp:jar:4.9.3:test
[INFO] |  |  \- org.jetbrains.kotlin:kotlin-stdlib-common:jar:1.4.10:test
[INFO] |  +- com.google.inject.extensions:guice-servlet:jar:4.0:test
[INFO] |  \- io.netty:netty:jar:3.10.6.Final:test
[INFO] +- junit:junit:jar:4.13.2:test
[INFO] |  \- org.hamcrest:hamcrest-core:jar:1.3:test
[INFO] +- org.junit.jupiter:junit-jupiter-engine:jar:5.8.2:test
[INFO] |  +- org.junit.platform:junit-platform-engine:jar:1.8.2:test
[INFO] |  |  +- org.opentest4j:opentest4j:jar:1.2.0:test
[INFO] |  |  \- org.junit.platform:junit-platform-commons:jar:1.8.2:test
[INFO] |  +- org.junit.jupiter:junit-jupiter-api:jar:5.8.2:test
[INFO] |  \- org.apiguardian:apiguardian-api:jar:1.1.2:test
[INFO] +- org.easymock:easymock:jar:4.3:test
[INFO] |  \- org.objenesis:objenesis:jar:3.2:test
[INFO] +- org.powermock:powermock-module-junit4:jar:2.0.9:test
[INFO] |  \- org.powermock:powermock-module-junit4-common:jar:2.0.9:test
[INFO] |     +- org.powermock:powermock-reflect:jar:2.0.9:test
[INFO] |     \- org.powermock:powermock-core:jar:2.0.9:test
[INFO] +- org.powermock:powermock-api-easymock:jar:2.0.9:test
[INFO] |  +- org.powermock:powermock-api-support:jar:2.0.9:test
[INFO] |  \- cglib:cglib-nodep:jar:3.2.9:test
[INFO] +- org.powermock:powermock-api-mockito2:jar:2.0.9:test
[INFO] +- io.confluent:kafka-connect-avro-converter:jar:7.2.4-34:test
[INFO] |  +- io.confluent:kafka-avro-serializer:jar:7.2.4-34:compile
[INFO] |  \- io.confluent:kafka-schema-registry-client:jar:7.2.4-34:compile
[INFO] |     \- org.yaml:snakeyaml:jar:2.0:compile
[INFO] +- io.confluent:kafka-connect-protobuf-converter:jar:7.2.4-34:test
[INFO] |  +- io.confluent:kafka-protobuf-provider:jar:7.2.4-34:test
[INFO] |  |  +- com.squareup.wire:wire-runtime-jvm:jar:4.3.0:test
[INFO] |  |  \- com.google.api.grpc:proto-google-common-protos:jar:2.5.1:test
[INFO] |  +- io.confluent:kafka-protobuf-serializer:jar:7.2.4-34:test
[INFO] |  +- io.confluent:kafka-protobuf-types:jar:7.2.4-34:test
[INFO] |  +- com.squareup.wire:wire-schema-jvm:jar:4.3.0:test
[INFO] |  |  +- org.jetbrains.kotlin:kotlin-stdlib-jdk8:jar:1.6.10:test
[INFO] |  |  |  \- org.jetbrains.kotlin:kotlin-stdlib-jdk7:jar:1.6.10:test
[INFO] |  |  \- com.squareup.okio:okio:jar:3.0.0:test
[INFO] |  +- com.squareup.okio:okio-jvm:jar:3.0.0:test
[INFO] |  +- org.jetbrains.kotlin:kotlin-stdlib:jar:1.6.0:test
[INFO] |  |  \- org.jetbrains:annotations:jar:13.0:test
[INFO] |  +- io.confluent:kafka-schema-converter:jar:7.2.4-34:compile
[INFO] |  +- io.confluent:kafka-schema-serializer:jar:7.2.4-34:compile
[INFO] |  \- com.google.protobuf:protobuf-java-util:jar:3.19.6:test
[INFO] +- io.confluent:kafka-connect-json-schema-converter:jar:7.2.4-34:test
[INFO] |  +- io.confluent:kafka-json-schema-provider:jar:7.2.4-34:test
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.15.2:test
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.15.2:test
[INFO] |  |  +- com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.15.2:test
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-parameter-names:jar:2.15.2:test
[INFO] |  |  +- com.kjetland:mbknor-jackson-jsonschema_2.13:jar:1.0.39:test
[INFO] |  |  |  +- javax.validation:validation-api:jar:2.0.1.Final:test
[INFO] |  |  |  \- io.github.classgraph:classgraph:jar:4.8.21:test
[INFO] |  |  +- org.jetbrains.kotlin:kotlin-scripting-jvm:jar:1.6.0:test
[INFO] |  |  |  +- org.jetbrains.kotlin:kotlin-script-runtime:jar:1.6.0:test
[INFO] |  |  |  \- org.jetbrains.kotlin:kotlin-scripting-common:jar:1.6.0:test
[INFO] |  |  \- org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:jar:1.6.0:test
[INFO] |  |     \- org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:jar:1.6.0:test
[INFO] |  +- io.confluent:kafka-json-schema-serializer:jar:7.2.4-34:test
[INFO] |  |  \- io.confluent:kafka-json-serializer:jar:7.2.4-34:test
[INFO] |  |     \- io.confluent:common-config:jar:7.2.4-30:test
[INFO] |  \- com.github.erosb:everit-json-schema:jar:1.14.1:test
[INFO] |     +- org.json:json:jar:20220320:test
[INFO] |     +- commons-validator:commons-validator:jar:1.7:test
[INFO] |     |  \- commons-digester:commons-digester:jar:2.1:test
[INFO] |     \- com.damnhandy:handy-uri-templates:jar:2.1.8:test
[INFO] +- io.confluent:kafka-schema-registry:test-jar:tests:7.2.4-34:test
[INFO] |  +- org.apache.kafka:kafka_2.13:jar:7.2.4-12-ccs:test
[INFO] |  |  +- com.fasterxml.jackson.module:jackson-module-scala_2.13:jar:2.15.2:test
[INFO] |  |  +- org.scala-lang.modules:scala-collection-compat_2.13:jar:2.6.0:test
[INFO] |  |  +- org.scala-lang.modules:scala-java8-compat_2.13:jar:1.0.2:test
[INFO] |  |  \- com.typesafe.scala-logging:scala-logging_2.13:jar:3.9.4:test
[INFO] |  +- org.glassfish.jersey.ext:jersey-bean-validation:jar:2.36:test
[INFO] |  |  +- org.glassfish.hk2.external:jakarta.inject:jar:2.6.1:provided
[INFO] |  |  +- jakarta.validation:jakarta.validation-api:jar:2.0.2:provided
[INFO] |  |  +- jakarta.el:jakarta.el-api:jar:3.0.3:test
[INFO] |  |  \- org.glassfish:jakarta.el:jar:3.0.4:test
[INFO] |  +- org.hibernate.validator:hibernate-validator:jar:6.1.7.Final:test
[INFO] |  |  +- org.jboss.logging:jboss-logging:jar:3.3.2.Final:test
[INFO] |  |  \- com.fasterxml:classmate:jar:1.3.4:test
[INFO] |  +- io.confluent:rest-utils:jar:7.2.4-30:test
[INFO] |  |  +- org.eclipse.jetty.websocket:javax-websocket-server-impl:jar:9.4.48.v20220622:test
[INFO] |  |  |  +- org.eclipse.jetty:jetty-annotations:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  +- org.eclipse.jetty:jetty-plus:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-jndi:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  +- org.eclipse.jetty:jetty-webapp:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  |  \- org.eclipse.jetty:jetty-xml:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  \- org.ow2.asm:asm-commons:jar:9.3:test
[INFO] |  |  |  |     +- org.ow2.asm:asm-tree:jar:9.3:test
[INFO] |  |  |  |     \- org.ow2.asm:asm-analysis:jar:9.3:test
[INFO] |  |  |  +- org.eclipse.jetty.websocket:javax-websocket-client-impl:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  \- javax.websocket:javax.websocket-client-api:jar:1.0:test
[INFO] |  |  |  +- org.eclipse.jetty.websocket:websocket-server:jar:9.4.48.v20220622:test
[INFO] |  |  |  |  \- org.eclipse.jetty.websocket:websocket-servlet:jar:9.4.48.v20220622:test
[INFO] |  |  |  \- javax.websocket:javax.websocket-api:jar:1.0:test
[INFO] |  |  +- org.eclipse.jetty:jetty-jmx:jar:9.4.48.v20220622:test
[INFO] |  |  +- org.eclipse.jetty.http2:http2-server:jar:9.4.48.v20220622:test
[INFO] |  |  |  \- org.eclipse.jetty.http2:http2-common:jar:9.4.48.v20220622:test
[INFO] |  |  |     \- org.eclipse.jetty.http2:http2-hpack:jar:9.4.48.v20220622:test
[INFO] |  |  +- org.eclipse.jetty:jetty-alpn-server:jar:9.4.48.v20220622:test
[INFO] |  |  +- org.eclipse.jetty:jetty-alpn-java-server:jar:9.4.48.v20220622:test
[INFO] |  |  \- org.eclipse.jetty:jetty-jaas:jar:9.4.48.v20220622:test
[INFO] |  +- io.confluent:logredactor:jar:1.0.11:compile
[INFO] |  |  +- io.confluent:logredactor-metrics:jar:1.0.11:compile
[INFO] |  |  \- com.eclipsesource.minimal-json:minimal-json:jar:0.9.5:compile
[INFO] |  +- io.netty:netty-codec:jar:4.1.86.Final:test
[INFO] |  |  +- io.netty:netty-common:jar:4.1.86.Final:test
[INFO] |  |  +- io.netty:netty-buffer:jar:4.1.86.Final:test
[INFO] |  |  \- io.netty:netty-transport:jar:4.1.86.Final:test
[INFO] |  |     \- io.netty:netty-resolver:jar:4.1.86.Final:test
[INFO] |  +- io.swagger.core.v3:swagger-annotations:jar:2.1.10:compile
[INFO] |  \- io.swagger.core.v3:swagger-core:jar:2.1.10:test
[INFO] |     +- jakarta.xml.bind:jakarta.xml.bind-api:jar:2.3.2:provided
[INFO] |     +- com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.15.2:test
[INFO] |     \- io.swagger.core.v3:swagger-models:jar:2.1.10:test
[INFO] +- io.confluent:kafka-schema-registry:jar:7.2.4-34:test
[INFO] +- org.mockito:mockito-core:jar:2.19.0:test
[INFO] |  +- net.bytebuddy:byte-buddy:jar:1.8.10:test
[INFO] |  \- net.bytebuddy:byte-buddy-agent:jar:1.8.10:test
[INFO] +- org.apache.avro:avro:jar:1.11.3:compile
[INFO] +- jline:jline:jar:2.12.1:compile
[INFO] +- ch.qos.reload4j:reload4j:jar:1.2.19:test
[INFO] +- io.confluent:common-utils:jar:7.2.4-30:compile
[INFO] \- io.confluent:assembly-plugin-boilerplate:zip:resources:7.2.4-30:provided
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for kafka-connect-storage-cloud 10.0.27-SNAPSHOT:
[INFO]
[INFO] kafka-connect-storage-cloud ........................ SUCCESS [  1.218 s]
[INFO] kafka-connect-s3 ................................... SUCCESS [  0.175 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.838 s
[INFO] Finished at: 2023-10-16T16:34:34+05:30
[INFO] ------------------------------------------------------------------------
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
