### PR TITLE
Pass region into credentials provider

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -896,6 +896,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
         configs.put(AWS_ACCESS_KEY_ID_CONFIG, awsAccessKeyId());
         configs.put(AWS_SECRET_ACCESS_KEY_CONFIG, awsSecretKeyId().value());
+        configs.put(REGION_CONFIG, getString(REGION_CONFIG));
 
         ((Configurable) provider).configure(configs);
       } else {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -226,7 +226,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     );
     properties.put(
         configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME),
-        "5"
+        "6"
     );
     connectorConfig = new S3SinkConnectorConfig(properties);
 
@@ -255,6 +255,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
         configPrefix.concat(AwsAssumeRoleCredentialsProvider.ROLE_EXTERNAL_ID_CONFIG),
         "my-external-id"
     );
+    properties.put(S3SinkConnectorConfig.REGION_CONFIG, "us-west-2");
     connectorConfig = new S3SinkConnectorConfig(properties);
 
     AwsAssumeRoleCredentialsProvider credentialsProvider =

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3StorageTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3StorageTest.java
@@ -142,7 +142,7 @@ public class S3StorageTest extends S3SinkConnectorTestBase {
     String configPrefix = S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CONFIG_PREFIX;
     localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.ACCESS_KEY_NAME), "foo_key");
     localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.SECRET_KEY_NAME), "bar_secret");
-    localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME), "5");
+    localProps.put(configPrefix.concat(DummyAssertiveCredentialsProvider.CONFIGS_NUM_KEY_NAME), "6");
     localProps.put(
         S3SinkConnectorConfig.CREDENTIALS_PROVIDER_CLASS_CONFIG,
         DummyAssertiveCredentialsProvider.class.getName()


### PR DESCRIPTION
This passes the `s3.region` configuration value into credential providers. It also updates the AwsAssumeRoleCredentialsProvider to specify a region when building a AWSSecurityTokenServiceClient.

Fixes #366

