### PR TITLE
add region option to AwsAssumeRoleCredentialsProvider

### DIFF
--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -255,6 +255,10 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
         configPrefix.concat(AwsAssumeRoleCredentialsProvider.ROLE_EXTERNAL_ID_CONFIG),
         "my-external-id"
     );
+    properties.put(
+        configPrefix.concat(AwsAssumeRoleCredentialsProvider.STS_REGION_CONFIG),
+        "us-west-2"
+    );
     connectorConfig = new S3SinkConnectorConfig(properties);
 
     AwsAssumeRoleCredentialsProvider credentialsProvider =


### PR DESCRIPTION
This adds a `region` configuration item for the
AwsAssumeRoleCredentialsProvider. It is used when building a AWSSecurityTokenServiceClient.

It not specified, uses the default region selector.

Fixes #366

