### PR TITLE
stop rotating on partition change when rotate.interval.ms is set

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -419,7 +419,6 @@ public class TopicPartitionWriter {
         && timestampExtractor != null
         && (
         recordTimestamp - baseRecordTimestamp >= rotateIntervalMs
-            || !encodedPartition.equals(currentEncodedPartition)
     );
 
     log.trace(

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -560,6 +560,122 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
   }
 
   @Test
+  public void testWriteRecordTimeBasedPartitionRecordTimestampHoursOutOfOrder() throws Exception {
+    // Do not roll on size, only based on time.
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.MINUTES.toMillis(10))
+    );
+    setUp();
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new HourlyPartitioner<>();
+    parsedConfig.put(S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG, TimeUnit.MINUTES.toMillis(10));
+    parsedConfig.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record");
+    partitioner.configure(parsedConfig);
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null
+    );
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 1, 5);
+
+    DateTime hour = new DateTime(2017, 3, 2, 10, 0, DateTimeZone.forID("America/Los_Angeles"));
+
+    Collection<SinkRecord> sinkRecords = new ArrayList<>();
+    sinkRecords.add(sinkRecord(key, schema, records.get(0), 0, hour.getMillis()));
+    sinkRecords.add(sinkRecord(key, schema, records.get(1), 1, hour.minusMinutes(2).getMillis()));
+    sinkRecords.add(sinkRecord(key, schema, records.get(2), 2, hour.plusMinutes(9).getMillis()));
+    sinkRecords.add(sinkRecord(key, schema, records.get(3), 3, hour.minusMinutes(5).getMillis()));
+
+    sinkRecords.add(sinkRecord(key, schema, records.get(4), 4, hour.plusMinutes(10).getMillis()));
+
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    String dirPrefixFirst = partitioner.generatePartitionedPath(
+        TOPIC,
+        getTimebasedEncodedPartition(hour.minusMinutes(1).getMillis())
+    );
+    String dirPrefixLater = partitioner.generatePartitionedPath(TOPIC, getTimebasedEncodedPartition(hour.getMillis()));
+    List<String> expectedFiles = Arrays.asList(
+        FileUtils.fileKeyToCommit(topicsDir, dirPrefixLater, TOPIC_PARTITION, 0, extension, ZERO_PAD_FMT),
+        FileUtils.fileKeyToCommit(topicsDir, dirPrefixFirst, TOPIC_PARTITION, 1, extension, ZERO_PAD_FMT)
+    );
+
+    verify(expectedFiles, 2, schema, records);
+  }
+
+  @Test
+  public void testWriteRecordTimeBasedPartitionRecordTimestampHoursDailyRotationInterval() throws Exception {
+    // Do not roll on size, only based on time.
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    localProps.put(
+        S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG,
+        String.valueOf(TimeUnit.DAYS.toMillis(1))
+    );
+    setUp();
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new HourlyPartitioner<>();
+    parsedConfig.put(S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG, TimeUnit.DAYS.toMillis(1));
+    parsedConfig.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record");
+    partitioner.configure(parsedConfig);
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null
+    );
+
+    String key = "key";
+    Schema schema = createSchema();
+
+    List<Struct> records = createRecordBatches(schema, 1, 5);
+
+    DateTime firstDay = new DateTime(2017, 3, 1, 10, 0, DateTimeZone.forID("America/Los_Angeles"));
+    DateTime nextDay = new DateTime(2017, 3, 2, 5, 0, DateTimeZone.forID("America/Los_Angeles"));
+
+    List<SinkRecord> sinkRecords = new ArrayList<>();
+    sinkRecords.add(sinkRecord(key, schema, records.get(0), 0, firstDay.getMillis()));
+    sinkRecords.add(sinkRecord(key, schema, records.get(1), 1, firstDay.minusHours(2).getMillis()));
+    sinkRecords.add(sinkRecord(key, schema, records.get(2), 2, nextDay.plusHours(2).getMillis()));
+    sinkRecords.add(sinkRecord(key, schema, records.get(3), 3, nextDay.getMillis()));
+
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    topicPartitionWriter.write();
+    verify(Collections.emptyList(), 0, schema, records);
+
+    topicPartitionWriter.buffer(
+        sinkRecord(key, schema, records.get(4), 4, nextDay.plusHours(5).getMillis())
+    );
+
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    List<String> expectedFiles = new ArrayList<>();
+
+    for (SinkRecord record : sinkRecords) {
+      String prefix = partitioner.generatePartitionedPath(TOPIC, getTimebasedEncodedPartition(record.timestamp()));
+      expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, prefix, TOPIC_PARTITION, record.kafkaOffset(), extension, ZERO_PAD_FMT));
+    }
+
+    verify(expectedFiles, 1, schema, records);
+  }
+
+  private SinkRecord sinkRecord(String key, Schema schema, Object value, long offset, long time) {
+    return new SinkRecord(TOPIC, PARTITION, Schema.STRING_SCHEMA, key, schema, value, offset, time, TimestampType.CREATE_TIME);
+  }
+
+  @Test
   public void testWallclockUsesBatchTimePartitionBoundary() throws Exception {
     localProps.put(FLUSH_SIZE_CONFIG, "6");
     setUp();


### PR DESCRIPTION
## Problem

Committing open files on partition change results in creating a lot of small files when records belonging to different partitioned are interleaved.  We have a use case where we aggregate raw events into sessions spanning for 5-15 minutes with session time being the time of the first event in it. We use hourly partitioning and observe  up to 10x increase in number of files per hour due to this.

The issue has been reported multiple time previously:
- https://github.com/confluentinc/kafka-connect-storage-cloud/issues/380
- https://github.com/confluentinc/kafka-connect-storage-cloud/issues/529

And even had an attempted fix:
- https://github.com/confluentinc/kafka-connect-storage-cloud/pull/574

## Solution

Removing rotation on partition changes makes the semantics of `rotate.interval.ms` similar to `flush.size`.
It now defines constrains not for a single file, but for a "segment" of a stream:
records are accumulated in appropriate partitions until partition time advances at least `rotate.interval.ms` from the first time of the message in the "segment", at which point all files are flushed.

## Testing
We have been running the patched version in our staging environment for more then a week now with constant consistency checks and have not seen any issues neither with number of files per hour nor with the consistency of the results.

Finally documentation for 'rotate.interval.ms' might need to be adjusted.  Would appreciate any advice on how to do that.