### PR TITLE
Update common version to fix record reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.4</version>
+        <version>11.2.5</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem
https://confluent.slack.com/archives/C06HJ2VFQ5T  
While projecting we were changing instance of record from InternalSinkRecord to SinkRecord and while reporting we were using modified records which was causing the original schema of messages to be changed while serialising again.

## Solution
Update version of common to 11.2.5. 
https://github.com/confluentinc/kafka-connect-storage-common/pull/347

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
