### PR TITLE
Fix S3SinkConnectorFaultyS3Test

### DIFF
--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorFaultyS3Test.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorFaultyS3Test.java
@@ -32,6 +32,7 @@ import org.junit.runners.Parameterized;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -134,8 +135,10 @@ public class S3SinkConnectorFaultyS3Test extends TestWithMockedFaultyS3 {
 
     @BeforeClass
     public static void startConnect() {
+        Map<String, String> workerProps = new HashMap<>();
+        workerProps.put("plugin.discovery","hybrid_warn");
         connect = new EmbeddedConnectCluster.Builder()
-                .name("s3-connect-cluster")
+                .name("s3-connect-cluster").workerProps(workerProps)
                 .build();
         connect.start();
         kafkaAdmin = connect.kafka().createAdminClient();


### PR DESCRIPTION


## Problem
The test is failing with error:
```
[ERROR] Errors: 
[ERROR]   S3SinkConnectorFaultyS3Test.startConnect:140 ? Connect One or more plugins are missing ServiceLoader manifests may not be usable with plugin.discovery=service_load: [
classpath       io.confluent.connect.avro.AvroConverter converter       undefined
classpath       io.confluent.connect.json.JsonSchemaConverter   converter       undefined
classpath       io.confluent.connect.protobuf.ProtobufConverter converter       undefined
classpath       io.confluent.connect.s3.S3SinkConnector sink    10.0.28-SNAPSHOT
classpath       io.confluent.connect.storage.tools.SchemaSourceConnector        source  7.6.0-207-ccs
]
```

## Solution
Set plugin.discovery to hybrid_warn, similar to [here](https://github.com/confluentinc/kafka-connect-storage-cloud/blob/f924562351fc10ac9e03d638e6c8b3997ed6745d/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java#L164)

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
