### PR TITLE
MINOR: Adds possibility to use custom FilenameCreator

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -24,6 +24,8 @@ import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.SSEAlgorithm;
+import io.confluent.connect.s3.storage.FilenameCreator;
+import io.confluent.connect.s3.storage.TopicPartitionFilenameCreator;
 import io.confluent.connect.storage.common.util.StringUtils;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -217,6 +219,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   private static final GenericRecommender SCHEMA_PARTITION_AFFIX_TYPE_RECOMMENDER =
       new GenericRecommender();
+  public static final String S3_FILENAME_CREATOR_CLASS = "s3.filename.creator.class";
+  public static final Class<? extends FilenameCreator> S3_FILENAME_CREATOR_CLASS_DEFAULT =
+      TopicPartitionFilenameCreator.class;
 
   private final String name;
 
@@ -810,6 +815,17 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Width.LONG,
           "Elastic buffer initial capacity"
       );
+
+      configDef.define(
+          S3_FILENAME_CREATOR_CLASS,
+          Type.CLASS,
+          S3_FILENAME_CREATOR_CLASS_DEFAULT,
+          Importance.LOW,
+          "Which class to use when generating file name",
+          group,
+          ++orderInGroup,
+          Width.NONE,
+          "Which class to use when generating file name");
 
     }
     return configDef;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.s3;
 
 import com.amazonaws.SdkClientException;
+import io.confluent.connect.s3.storage.FilenameCreator;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.s3.util.FileRotationTracker;
 import io.confluent.connect.s3.util.RetryUtil;
@@ -48,7 +49,6 @@ import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
 import io.confluent.connect.storage.StorageSinkConnectorConfig;
 import io.confluent.connect.storage.common.StorageCommonConfig;
-import io.confluent.connect.storage.common.util.StringUtils;
 import io.confluent.connect.storage.format.RecordWriter;
 import io.confluent.connect.storage.format.RecordWriterProvider;
 import io.confluent.connect.storage.partitioner.Partitioner;
@@ -71,6 +71,8 @@ public class TopicPartitionWriter {
   private final TopicPartition tp;
   private final S3Storage storage;
   private final Partitioner<?> partitioner;
+
+  private final FilenameCreator filenameCreator;
   private TimestampExtractor timestampExtractor;
   private String topicsDir;
   private State state;
@@ -98,9 +100,7 @@ public class TopicPartitionWriter {
   private long failureTime;
   private final StorageSchemaCompatibility compatibility;
   private final String extension;
-  private final String zeroPadOffsetFormat;
-  private final String dirDelim;
-  private final String fileDelim;
+
   private final Time time;
   private DateTimeZone timeZone;
   private final S3SinkConnectorConfig connectorConfig;
@@ -115,13 +115,21 @@ public class TopicPartitionWriter {
                               Partitioner<?> partitioner,
                               S3SinkConnectorConfig connectorConfig,
                               SinkTaskContext context,
-                              ErrantRecordReporter reporter) {
-    this(tp, storage, writerProvider, partitioner, connectorConfig, context, SYSTEM_TIME, reporter);
+                              ErrantRecordReporter reporter, FilenameCreator filenameCreator) {
+    this(tp, storage,
+        filenameCreator,
+        writerProvider,
+        partitioner,
+        connectorConfig,
+        context,
+        SYSTEM_TIME,
+        reporter);
   }
 
   // Visible for testing
   TopicPartitionWriter(TopicPartition tp,
                        S3Storage storage,
+                       FilenameCreator filenameCreator,
                        RecordWriterProvider<S3SinkConnectorConfig> writerProvider,
                        Partitioner<?> partitioner,
                        S3SinkConnectorConfig connectorConfig,
@@ -129,6 +137,7 @@ public class TopicPartitionWriter {
                        Time time,
                        ErrantRecordReporter reporter
   ) {
+    this.filenameCreator = filenameCreator;
     this.connectorConfig = connectorConfig;
     this.time = time;
     this.tp = tp;
@@ -140,7 +149,7 @@ public class TopicPartitionWriter {
     this.timestampExtractor = null;
 
     if (partitioner instanceof TimeBasedPartitioner) {
-      this.timestampExtractor = ((TimeBasedPartitioner) partitioner).getTimestampExtractor();
+      this.timestampExtractor = ((TimeBasedPartitioner<?>) partitioner).getTimestampExtractor();
       if (connectorConfig.isTombstoneWriteEnabled()) {
         this.timestampExtractor = new TombstoneTimestampExtractor(timestampExtractor);
       }
@@ -184,12 +193,7 @@ public class TopicPartitionWriter {
     state = State.WRITE_STARTED;
     failureTime = -1L;
     currentOffset = -1L;
-    dirDelim = connectorConfig.getString(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
-    fileDelim = connectorConfig.getString(StorageCommonConfig.FILE_DELIM_CONFIG);
     extension = writerProvider.getExtension();
-    zeroPadOffsetFormat = "%0"
-        + connectorConfig.getInt(S3SinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG)
-        + "d";
     fileRotationTracker = new FileRotationTracker();
 
     // Initialize scheduled rotation timer if applicable
@@ -541,7 +545,7 @@ public class TopicPartitionWriter {
 
   private RecordWriter newWriter(SinkRecord record, String encodedPartition)
       throws ConnectException {
-    String commitFilename = getCommitFilename(encodedPartition);
+    String commitFilename = getCommitFilename(record, encodedPartition);
     log.debug(
         "Creating new writer encodedPartition='{}' filename='{}'",
         encodedPartition,
@@ -552,34 +556,17 @@ public class TopicPartitionWriter {
     return writer;
   }
 
-  private String getCommitFilename(String encodedPartition) {
+  private String getCommitFilename(SinkRecord sinkRecord, String encodedPartition) {
     String commitFile;
     if (commitFiles.containsKey(encodedPartition)) {
       commitFile = commitFiles.get(encodedPartition);
     } else {
       long startOffset = startOffsets.get(encodedPartition);
       String prefix = getDirectoryPrefix(encodedPartition);
-      commitFile = fileKeyToCommit(prefix, startOffset);
+      commitFile = filenameCreator.createName(sinkRecord, prefix, startOffset, extension);
       commitFiles.put(encodedPartition, commitFile);
     }
     return commitFile;
-  }
-
-  private String fileKey(String topicsPrefix, String keyPrefix, String name) {
-    String suffix = keyPrefix + dirDelim + name;
-    return StringUtils.isNotBlank(topicsPrefix)
-           ? topicsPrefix + dirDelim + suffix
-           : suffix;
-  }
-
-  private String fileKeyToCommit(String dirPrefix, long startOffset) {
-    String name = tp.topic()
-                      + fileDelim
-                      + tp.partition()
-                      + fileDelim
-                      + String.format(zeroPadOffsetFormat, startOffset)
-                      + extension;
-    return fileKey(topicsDir, dirPrefix, name);
   }
 
   private boolean writeRecord(SinkRecord record, String encodedPartition) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/FilenameCreator.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/FilenameCreator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.storage;
+
+import org.apache.kafka.connect.sink.SinkRecord;
+import java.util.Map;
+
+/**
+ * Interface for creating custom filename in bucket.
+ * @author Pierre Stridsberg
+ */
+public interface FilenameCreator {
+  void configure(Map<String, Object> var1);
+
+  String createName(SinkRecord sinkRecord, String dirPrefix, long startOffset, String extension);
+}

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/TopicPartitionFilenameCreator.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/TopicPartitionFilenameCreator.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.storage;
+
+import io.confluent.connect.storage.StorageSinkConnectorConfig;
+import io.confluent.connect.storage.common.StorageCommonConfig;
+import io.confluent.connect.storage.common.util.StringUtils;
+import org.apache.kafka.connect.sink.SinkRecord;
+
+import java.util.Map;
+
+/**
+ * Default FilenameCreator if none specified.
+ * It creates a filename based on the topic, partition, and offset.
+ * implements FilenameCreator interface.
+ * @author Pierre Stridsberg
+ */
+public class TopicPartitionFilenameCreator implements FilenameCreator {
+  private String fileDelim;
+  private String dirDelim;
+  private String zeroPadOffsetFormat;
+  private String topicsDir;
+
+  @Override
+  public void configure(Map<String, Object> config) {
+    dirDelim = (String) config.get(StorageCommonConfig.DIRECTORY_DELIM_CONFIG);
+    fileDelim = (String) config.get(StorageCommonConfig.FILE_DELIM_CONFIG);
+    zeroPadOffsetFormat = "%0"
+        + config.get(StorageSinkConnectorConfig.FILENAME_OFFSET_ZERO_PAD_WIDTH_CONFIG)
+        + "d";
+    topicsDir = (String) config.get(StorageCommonConfig.TOPICS_DIR_CONFIG);
+  }
+
+  @Override
+  public String createName(SinkRecord sinkRecord,
+                           String dirPrefix,
+                           long startOffset,
+                           String extension) {
+    String name = sinkRecord.topic()
+        + fileDelim
+        + sinkRecord.kafkaPartition()
+        + fileDelim
+        + String.format(zeroPadOffsetFormat, startOffset)
+        + extension;
+    return fileKey(topicsDir, dirPrefix, name);
+  }
+
+  private String fileKey(String topicsPrefix, String keyPrefix, String name) {
+    String suffix = keyPrefix + dirDelim + name;
+    return StringUtils.isNotBlank(topicsPrefix)
+        ? topicsPrefix + dirDelim + suffix
+        : suffix;
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -135,7 +135,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
   @Test
   public void testWriteRecords() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecords(7);
     // Perform write
@@ -153,7 +153,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     localProps.put(StorageSinkConnectorConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, "true");
     localProps.put(StorageSinkConnectorConfig.CONNECT_META_DATA_CONFIG, "true");
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsWithEnums(7, 0, Collections.singleton(new TopicPartition(TOPIC, PARTITION)));
 
     // Perform write
@@ -170,7 +170,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     localProps.put(StorageSinkConnectorConfig.ENHANCED_AVRO_SCHEMA_SUPPORT_CONFIG, "true");
     localProps.put(StorageSinkConnectorConfig.CONNECT_META_DATA_CONFIG, "true");
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsWithUnion(7, 0, Collections.singleton(new TopicPartition (TOPIC, PARTITION)));
 
     // Perform write
@@ -187,7 +187,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     String avroCodec = "snappy";
     localProps.put(StorageSinkConnectorConfig.AVRO_CODEC_CONFIG, avroCodec);
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecords(7);
     // Perform write
@@ -223,7 +223,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     // Accumulate rest of the records.
     sinkRecords.addAll(createRecords(5, 2));
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     // Perform write
     task.put(sinkRecords);
     task.close(context.assignment());
@@ -238,7 +238,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "10000");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecords(11000);
 
@@ -254,7 +254,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
   @Test
   public void testWriteRecordsInMultiplePartitions() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecords(7, 0, context.assignment());
     // Perform write
@@ -269,7 +269,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
   @Test
   public void testWriteInterleavedRecordsInMultiplePartitions() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsInterleaved(7 * context.assignment().size(), 0, context.assignment());
     // Perform write
@@ -284,7 +284,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
   @Test
   public void testWriteInterleavedRecordsInMultiplePartitionsNonZeroInitialOffset() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsInterleaved(7 * context.assignment().size(), 9, context.assignment());
     // Perform write
@@ -300,7 +300,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
   public void testPreCommitOnSizeRotation() throws Exception {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "3");
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords1 = createRecordsInterleaved(3 * context.assignment().size(), 0, context.assignment());
 
@@ -346,7 +346,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "2");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(2, 0);
 
     // Perform write
@@ -393,7 +393,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
         time
     );
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time, filenameCreator);
 
     // Perform write
     task.put(sinkRecords.subList(0, 3));
@@ -450,7 +450,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
         time
     );
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time, filenameCreator);
 
     // Perform write
     task.put(sinkRecords);
@@ -508,7 +508,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
         time
     );
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time, filenameCreator);
 
     // Perform write
     task.put(sinkRecords);
@@ -563,7 +563,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
   @Test
   public void testRebalance() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsInterleaved(7 * context.assignment().size(), 0, context.assignment());
     // Starts with TOPIC_PARTITION and TOPIC_PARTITION2
@@ -614,7 +614,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     localProps.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(7, 0);
 
     // Perform write
@@ -631,7 +631,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "2");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(7, 0);
 
     // Perform write
@@ -649,7 +649,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     localProps.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "FORWARD");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     // By excluding the first element we get a list starting with record having the new schema.
     List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(8, 0).subList(1, 8);
 
@@ -668,7 +668,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     localProps.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsNoVersion(1, 0);
     sinkRecords.addAll(createRecordsWithAlteringSchemas(7, 0));
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterByteArrayTest.java
@@ -88,7 +88,7 @@ public class DataWriterByteArrayTest extends DataWriterTestBase<ByteArrayFormat>
   public void testNoSchema() throws Exception {
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);
@@ -105,7 +105,7 @@ public class DataWriterByteArrayTest extends DataWriterTestBase<ByteArrayFormat>
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, ByteArrayFormat.class.getName());
     localProps.put(S3SinkConnectorConfig.COMPRESSION_TYPE_CONFIG, compressionType.name);
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);
@@ -123,7 +123,7 @@ public class DataWriterByteArrayTest extends DataWriterTestBase<ByteArrayFormat>
     localProps.put(S3SinkConnectorConfig.COMPRESSION_TYPE_CONFIG, compressionType.name);
     localProps.put(S3SinkConnectorConfig.COMPRESSION_LEVEL_CONFIG, String.valueOf(Deflater.BEST_COMPRESSION));
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);
@@ -141,7 +141,7 @@ public class DataWriterByteArrayTest extends DataWriterTestBase<ByteArrayFormat>
     localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_LINE_SEPARATOR_CONFIG, "SEPARATOR");
     localProps.put(S3SinkConnectorConfig.FORMAT_BYTEARRAY_EXTENSION_CONFIG, extension);
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createByteArrayRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterJsonTest.java
@@ -81,7 +81,7 @@ public class DataWriterJsonTest extends DataWriterTestBase<JsonFormat> {
   public void testWithSchema() throws Exception {
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsInterleaved(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);
@@ -96,7 +96,7 @@ public class DataWriterJsonTest extends DataWriterTestBase<JsonFormat> {
   public void testNoSchema() throws Exception {
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createJsonRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);
@@ -113,7 +113,7 @@ public class DataWriterJsonTest extends DataWriterTestBase<JsonFormat> {
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
     localProps.put(S3SinkConnectorConfig.COMPRESSION_TYPE_CONFIG, compressionType.name);
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsInterleaved(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);
@@ -130,7 +130,7 @@ public class DataWriterJsonTest extends DataWriterTestBase<JsonFormat> {
     localProps.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
     localProps.put(S3SinkConnectorConfig.COMPRESSION_TYPE_CONFIG, compressionType.name);
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createJsonRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);
@@ -148,7 +148,7 @@ public class DataWriterJsonTest extends DataWriterTestBase<JsonFormat> {
     localProps.put(S3SinkConnectorConfig.COMPRESSION_TYPE_CONFIG, compressionType.name);
     localProps.put(S3SinkConnectorConfig.COMPRESSION_LEVEL_CONFIG, String.valueOf(Deflater.BEST_COMPRESSION));
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createJsonRecordsWithoutSchema(7 * context.assignment().size(), 0, context.assignment());
     task.put(sinkRecords);

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterParquetTest.java
@@ -127,7 +127,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     // Accumulate rest of the records.
     sinkRecords.addAll(createRecords(5, 2));
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     // Perform write
     task.put(sinkRecords);
     task.close(context.assignment());
@@ -142,7 +142,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "10000");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecords(11000);
 
@@ -158,7 +158,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
   @Test
   public void testWriteRecordsInMultiplePartitions() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecords(7, 0, context.assignment());
     // Perform write
@@ -173,7 +173,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
   @Test
   public void testWriteInterleavedRecordsInMultiplePartitions() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsInterleaved(7, 0, context.assignment());
     // Perform write
@@ -193,7 +193,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
   @Test
   public void testWriteRecordsInMultiplePartitionsWithArrayOfOptionalString() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsWithArrayOfOptionalString(
         7,
@@ -212,7 +212,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
   @Test
   public void testWriteInterleavedRecordsInMultiplePartitionsNonZeroInitialOffset() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsInterleaved(7, 9, context.assignment());
     // Perform write
@@ -228,7 +228,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
   public void testPreCommitOnSizeRotation() throws Exception {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "3");
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords1 = createRecordsInterleaved(3, 0, context.assignment());
 
@@ -272,7 +272,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "2");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(2, 0);
 
     // Perform write
@@ -319,7 +319,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
             time
     );
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time, filenameCreator);
 
     // Perform write
     task.put(sinkRecords.subList(0, 3));
@@ -361,7 +361,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
 
     List<SinkRecord> sinkRecords = createRecords(3, 0);
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, time, filenameCreator);
 
     // Perform write
     task.put(sinkRecords);
@@ -391,7 +391,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
   @Test
   public void testRebalance() throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecordsInterleaved(7, 0, context.assignment());
     // Starts with TOPIC_PARTITION and TOPIC_PARTITION2
@@ -442,7 +442,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     localProps.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(7, 0);
 
     // Perform write
@@ -459,7 +459,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     localProps.put(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG, "2");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(7, 0);
 
     // Perform write
@@ -477,7 +477,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     localProps.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "FORWARD");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     // By excluding the first element we get a list starting with record having the new schema.
     List<SinkRecord> sinkRecords = createRecordsWithAlteringSchemas(8, 0).subList(1, 8);
 
@@ -496,7 +496,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
     localProps.put(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG, "BACKWARD");
     setUp();
 
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
     List<SinkRecord> sinkRecords = createRecordsNoVersion(1, 0);
     sinkRecords.addAll(createRecordsWithAlteringSchemas(7, 0));
 
@@ -977,7 +977,7 @@ public class DataWriterParquetTest extends DataWriterTestBase<ParquetFormat> {
 
   protected void writeRecordsWithExtensionAndVerifyResult(String extension) throws Exception {
     setUp();
-    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME, filenameCreator);
 
     List<SinkRecord> sinkRecords = createRecords(7);
     // Perform write

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorTestBase.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorTestBase.java
@@ -74,6 +74,7 @@ public class S3SinkConnectorTestBase extends StorageSinkTestBase {
     props.put(S3SinkConnectorConfig.FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
     props.put(S3SinkConnectorConfig.S3_PATH_STYLE_ACCESS_ENABLED_CONFIG, "false");
     props.put(PartitionerConfig.PARTITIONER_CLASS_CONFIG, PartitionerConfig.PARTITIONER_CLASS_DEFAULT.getName());
+    props.put(S3SinkConnectorConfig.S3_FILENAME_CREATOR_CLASS, S3SinkConnectorConfig.S3_FILENAME_CREATOR_CLASS_DEFAULT.getName());
     props.put(PartitionerConfig.PARTITION_FIELD_NAME_CONFIG, "int");
     props.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'year'=YYYY_'month'=MM_'day'=dd_'hour'=HH");
     props.put(PartitionerConfig.LOCALE_CONFIG, "en");

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -28,6 +28,8 @@ import io.confluent.connect.s3.format.RecordViews.HeaderRecordView;
 import io.confluent.connect.s3.format.RecordViews.KeyRecordView;
 import io.confluent.connect.s3.format.json.JsonFormat;
 import io.confluent.connect.s3.storage.CompressionType;
+import io.confluent.connect.s3.storage.FilenameCreator;
+import io.confluent.connect.s3.storage.TopicPartitionFilenameCreator;
 import io.confluent.connect.s3.util.SchemaPartitioner;
 import io.confluent.connect.storage.errors.PartitionException;
 import io.confluent.kafka.serializers.NonRecordContainer;
@@ -210,8 +212,11 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -243,8 +248,11 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -276,9 +284,11 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new FieldPartitioner<>();
     partitioner.configure(parsedConfig);
-
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -334,8 +344,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
         PartitionerConfig.PATH_FORMAT_CONFIG, "'year'=YYYY_'month'=MM_'day'=dd_'hour'=HH_'min'=mm_'sec'=ss");
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -392,8 +406,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     parsedConfig.put(
         PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockedWallclockTimestampExtractor.class.getName());
     partitioner.configure(parsedConfig);
+
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -464,8 +482,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     parsedConfig.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "Record");
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -521,8 +543,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     parsedConfig.put(PartitionerConfig.PATH_FORMAT_CONFIG, "'year'=YYYY_'month'=MM_'day'=dd");
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -578,8 +604,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     parsedConfig.put(PartitionerConfig.PARTITION_DURATION_MS_CONFIG, TimeUnit.DAYS.toMillis(1));
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -609,8 +639,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
 
     Time systemTime = EasyMock.createMock(SystemTime.class);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, systemTime, null);
+        TOPIC_PARTITION, storage, filenameCreator, writerProvider, partitioner, connectorConfig, context, systemTime, null);
 
     // Freeze clock passed into topicPartitionWriter, so we know what time it will use for "now"
     long freezeTime = 3599000L;
@@ -682,8 +716,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Bring the clock to present.
     time.sleep(SYSTEM.milliseconds());
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time,
+        TOPIC_PARTITION, storage, filenameCreator, writerProvider, partitioner, connectorConfig, context, time,
         null);
 
     // sleep for 11 minutes after startup
@@ -746,8 +784,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Bring the clock to present.
     time.sleep(SYSTEM.milliseconds());
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time,
+        TOPIC_PARTITION, storage, filenameCreator, writerProvider, partitioner, connectorConfig, context, time,
         null);
 
     // sleep for 11 minutes after startup
@@ -837,12 +879,16 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
         PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockedWallclockTimestampExtractor.class.getName());
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     MockTime time = ((MockedWallclockTimestampExtractor) partitioner.getTimestampExtractor()).time;
 
     // Bring the clock to present.
     time.sleep(SYSTEM.milliseconds());
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time, null);
+        TOPIC_PARTITION, storage, filenameCreator, writerProvider, partitioner, connectorConfig, context, time, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -915,12 +961,16 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
         PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, MockedWallclockTimestampExtractor.class.getName());
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     MockTime time = ((MockedWallclockTimestampExtractor) partitioner.getTimestampExtractor()).time;
 
     // Bring the clock to present.
     time.sleep(SYSTEM.milliseconds());
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, time, null);
+        TOPIC_PARTITION, storage, filenameCreator, writerProvider, partitioner, connectorConfig, context, time, null);
 
     String key = "key";
     Schema schema = createSchema();
@@ -955,8 +1005,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     parsedConfig.put(PartitionerConfig.TIMESTAMP_EXTRACTOR_CLASS_CONFIG, "RecordField");
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchemaWithTimestampField();
@@ -1027,8 +1081,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -1061,8 +1119,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -1090,8 +1152,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -1124,8 +1190,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -1163,8 +1233,11 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();
@@ -1282,10 +1355,14 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     parsedConfig.put(PARTITION_FIELD_NAME_CONFIG, Arrays.asList(field));
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     SinkTaskContext mockContext = mock(SinkTaskContext.class);
     ErrantRecordReporter mockReporter = mock(ErrantRecordReporter.class);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, mockContext, mockReporter);
+        TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, mockContext, mockReporter, filenameCreator);
 
     Schema schema = SchemaBuilder.struct().field(field, Schema.STRING_SCHEMA);
     Struct struct = new Struct(schema).put(field, "a");
@@ -1336,8 +1413,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, getKeyHeaderValueProvider(), partitioner,  connectorConfig, context, null);
+        TOPIC_PARTITION, storage, getKeyHeaderValueProvider(), partitioner,  connectorConfig, context, null, filenameCreator);
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, 3, 3);
@@ -1379,8 +1460,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, getKeyHeaderValueProviderJsonHeaders(), partitioner,  connectorConfig, context, null);
+        TOPIC_PARTITION, storage, getKeyHeaderValueProviderJsonHeaders(), partitioner,  connectorConfig, context, null, filenameCreator);
 
     Schema schema = createSchema();
     List<Struct> records = createRecordBatches(schema, 3, 3);
@@ -1425,11 +1510,15 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     SinkTaskContext mockContext = mock(SinkTaskContext.class);
     ErrantRecordReporter mockReporter = mock(ErrantRecordReporter.class);
 
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, getKeyHeaderValueProvider(), partitioner,  connectorConfig, mockContext, mockReporter);
+        TOPIC_PARTITION, storage, getKeyHeaderValueProvider(), partitioner,  connectorConfig, mockContext, mockReporter, filenameCreator);
 
     // create sample records to write
     Schema schema = createSchema();
@@ -1539,9 +1628,13 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     Partitioner<?> partitioner = new SchemaPartitioner<>(basePartitioner);
     partitioner.configure(parsedConfig);
 
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
+
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null
-    );
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null,
+        filenameCreator);
 
     List<Object> testData;
     if (testWithSchemaData) {
@@ -2045,8 +2138,12 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     // Define the partitioner
     Partitioner<?> partitioner = new DefaultPartitioner<>();
     partitioner.configure(parsedConfig);
+
+    // Define the file name creator
+    FilenameCreator filenameCreator = new TopicPartitionFilenameCreator();
+    filenameCreator.configure(parsedConfig);
     TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
-            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null);
+            TOPIC_PARTITION, storage, writerProvider, partitioner,  connectorConfig, context, null, filenameCreator);
 
     String key = "key";
     Schema schema = createSchema();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/parquet/ParquetUtils.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/format/parquet/ParquetUtils.java
@@ -16,6 +16,7 @@ import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.io.DelegatingSeekableInputStream;
 import org.apache.parquet.io.InputFile;
+import org.apache.parquet.io.OutputFile;
 import org.apache.parquet.io.SeekableInputStream;
 
 import java.io.ByteArrayOutputStream;
@@ -55,6 +56,7 @@ public class ParquetUtils {
     }
     return records;
   }
+
 
   public static byte[] putRecords(Collection<SinkRecord> records, AvroData avroData) throws IOException {
     ParquetWriter<GenericRecord> writer = null;

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -155,7 +155,7 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
     testTombstoneRecordsWritten(JSON_EXTENSION, false);
   }
 
-
+  @Test
   public void testFilesWrittenToBucketAvroWithExtInTopic() throws Throwable {
     //add test specific props
     props.put(FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
@@ -243,7 +243,6 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
     // to the producer (they're all the same content)
     assertTrue(fileContentsAsExpected(TEST_BUCKET_NAME, FLUSH_SIZE_STANDARD, recordValueStruct));
   }
-
   private void testTombstoneRecordsWritten(
       String expectedFileExtension,
       boolean addExtensionInTopic


### PR DESCRIPTION
## Problem
When writing to S3 there is no possibility to decide on the actual filename that ends up in the bucket. Sometimes, we want to be able to do this to make it more clear on what the file contains and to have more control.
I have described it in this: https://github.com/confluentinc/kafka-connect-storage-cloud/issues/631 issue

## Solution
I have added an interface called FilenameCreator. This interface can be implemented on a custom class and added as config. If none is provided we fall back to TopicPartitionFilenameCreator that preserves the way that file names where created before this change. So no breaking changes.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x ] yes
- [ ] no

##### If yes, where?
TopicPartitionWriter now uses a fileName creator, but the change does not affect previous behaviour.
S3SinkConnectorConfig now has a new key: s3.filename.creator.class for specifying your own FilenameCreator

## Test Strategy
Changed existing tests to use new FilenameCreator


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ x] Unit tests
- [ x] Integration tests
- [ ] System tests
- [x ] Manual tests

## Release Plan
Merging to master
