### PR TITLE
CC-26046: Pinned zookeeper version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <woodstox.version>5.4.0</woodstox.version>
         <guava.version>32.1.2-jre</guava.version>
         <avro.version>1.11.3</avro.version>
+        <zookeeper.version>3.8.4</zookeeper.version>
     </properties>
 
     <repositories>
@@ -174,6 +175,11 @@
             <artifactId>woodstox-core</artifactId>
             <version>${woodstox.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.zookeeper</groupId>
+            <artifactId>zookeeper</artifactId>
+            <version>${zookeeper.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -259,6 +265,10 @@
                 <exclusion>
                     <groupId>org.apache.hadoop.thirdparty </groupId>
                     <artifactId>hadoop-shaded-guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.zookeeper</groupId>
+                    <artifactId>zookeeper</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>


### PR DESCRIPTION
## Problem
CVE-2024-23944: It allows an attacker to monitor child znodes by attaching a persistent watcher (addWatch command) to a parent which the attacker has already access to. ZooKeeper server doesn\'t do ACL check when the persistent watcher is triggered and as a consequence, the full path of znodes that a watch event gets triggered upon is exposed to the owner of the watcher. It\'s important to note that only the path is exposed by this vulnerability, not the data of znode, but since znode path can contain sensitive information like user name or login ID, this issue is potentially critical. 

## Solution
Users are recommended to upgrade to version 3.9.2, 3.8.4 which fixes the issue. But since zookeeper dependency comes from hadoop-common, and we do not have any version which have this cve fixed, so we have to exclude the zookeeper dependency from hadoop-common and pin the zookeeper to the required version.

#### tl;dr
bumped zookeeper from 3.8.3 to 3.8.4

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
