### PR TITLE
CC-24623 Handle SchemaParseException and InvalidSchemaException according to errors.tolerance

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -34,6 +34,7 @@ import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.avro.SchemaParseException;
+import org.apache.parquet.schema.InvalidSchemaException;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -576,7 +577,7 @@ public class TopicPartitionWriter {
         shouldRemoveWriter = true;
       }
       writer.write(record);
-    } catch (DataException | SchemaParseException e) {
+    } catch (DataException | SchemaParseException | InvalidSchemaException e) {
       if (reporter != null) {
         if (shouldRemoveStartOffset) {
           startOffsets.remove(encodedPartition);

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -33,6 +33,7 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.avro.SchemaParseException;
 
 import java.util.Comparator;
 import java.util.HashMap;
@@ -575,7 +576,7 @@ public class TopicPartitionWriter {
         shouldRemoveWriter = true;
       }
       writer.write(record);
-    } catch (DataException e) {
+    } catch (DataException | SchemaParseException e) {
       if (reporter != null) {
         if (shouldRemoveStartOffset) {
           startOffsets.remove(encodedPartition);


### PR DESCRIPTION
## Problem
In case of any malformed record failing due to SchemaParseException or InvalidSchemaException, connector fails with an error instead of adhering to errors.tolerance parameter

## Solution
Catch the related exceptions and write the error to dlq topic based on the configured dlq and errors.tolerance

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
