### PR TITLE
Allow null values to be set to null for jsonformat

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -24,7 +24,6 @@ import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.SSEAlgorithm;
-import io.confluent.connect.storage.common.util.StringUtils;
 import org.apache.kafka.common.Configurable;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -67,6 +66,7 @@ import io.confluent.connect.storage.common.ComposableConfig;
 import io.confluent.connect.storage.common.GenericRecommender;
 import io.confluent.connect.storage.common.ParentValueRecommender;
 import io.confluent.connect.storage.common.StorageCommonConfig;
+import io.confluent.connect.storage.common.util.StringUtils;
 import io.confluent.connect.storage.format.Format;
 import io.confluent.connect.storage.partitioner.DailyPartitioner;
 import io.confluent.connect.storage.partitioner.DefaultPartitioner;
@@ -184,6 +184,13 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       + " This value is case insensitive and can be either 'BASE64' (default) or 'NUMERIC'";
   private static final String DECIMAL_FORMAT_DISPLAY = "Decimal Format";
 
+  public static final String REPLACE_NULL_WITH_DEFAULT_CONFIG = "json.replace.null.with.default";
+  public static final boolean REPLACE_NULL_WITH_DEFAULT_DEFAULT = true;
+  private static final String REPLACE_NULL_WITH_DEFAULT_DOC = "Whether to replace fields that"
+      + " have a default value and that are null to the default value."
+      + " When set to true, the default value is used, otherwise null is used.";
+  private static final String REPLACE_NULL_WITH_DEFAULT_DISPLAY = "Replace null with default";
+
   public static final String STORE_KAFKA_KEYS_CONFIG = "store.kafka.keys";
   public static final String STORE_KAFKA_HEADERS_CONFIG = "store.kafka.headers";
   public static final String KEYS_FORMAT_CLASS_CONFIG = "keys.format.class";
@@ -300,11 +307,11 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       configDef.define(
           S3_BUCKET_CONFIG,
           Type.STRING,
-          Importance.HIGH,
+          ConfigDef.Importance.HIGH,
           "The S3 Bucket.",
           group,
           ++orderInGroup,
-          Width.LONG,
+          ConfigDef.Width.LONG,
           "S3 Bucket"
       );
 
@@ -535,6 +542,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.MEDIUM,
           DECIMAL_FORMAT_DISPLAY
+      );
+
+      configDef.define(
+          REPLACE_NULL_WITH_DEFAULT_CONFIG,
+          Type.BOOLEAN,
+          REPLACE_NULL_WITH_DEFAULT_DEFAULT,
+          Importance.LOW,
+          REPLACE_NULL_WITH_DEFAULT_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          REPLACE_NULL_WITH_DEFAULT_DISPLAY
       );
 
       configDef.define(

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonFormat.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/json/JsonFormat.java
@@ -16,11 +16,11 @@
 package io.confluent.connect.s3.format.json;
 
 import org.apache.kafka.connect.json.JsonConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.s3.storage.S3Storage;
@@ -46,6 +46,11 @@ public class JsonFormat implements Format<S3SinkConnectorConfig, String> {
         "decimal.format",
         String.valueOf(storage.conf().getJsonDecimalFormat())
     );
+    converterConfig.put(
+        "replace.null.with.default",
+        storage.conf().getBoolean(S3SinkConnectorConfig.REPLACE_NULL_WITH_DEFAULT_CONFIG)
+    );
+
     this.converter.configure(converterConfig, false);
   }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -17,16 +17,12 @@ package io.confluent.connect.s3;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
-
-import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
-import io.confluent.connect.s3.format.parquet.ParquetFormat;
-
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.ConfigValue;
 import org.apache.kafka.connect.json.DecimalFormat;
 import org.apache.kafka.connect.sink.SinkRecord;
-import org.junit.After;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -38,9 +34,12 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import io.confluent.connect.avro.AvroDataConfig;
 import io.confluent.connect.s3.auth.AwsAssumeRoleCredentialsProvider;
 import io.confluent.connect.s3.format.avro.AvroFormat;
+import io.confluent.connect.s3.format.bytearray.ByteArrayFormat;
 import io.confluent.connect.s3.format.json.JsonFormat;
+import io.confluent.connect.s3.format.parquet.ParquetFormat;
 import io.confluent.connect.s3.storage.S3Storage;
 import io.confluent.connect.storage.common.StorageCommonConfig;
 import io.confluent.connect.storage.partitioner.DailyPartitioner;
@@ -50,20 +49,16 @@ import io.confluent.connect.storage.partitioner.HourlyPartitioner;
 import io.confluent.connect.storage.partitioner.Partitioner;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import io.confluent.connect.storage.partitioner.TimeBasedPartitioner;
-import io.confluent.connect.avro.AvroDataConfig;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.AffixType;
-import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_CONFIG;
-import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_DEFAULT;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
-
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.assertFalse;
 
 public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
 
@@ -456,6 +451,16 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     properties.put(S3SinkConnectorConfig.DECIMAL_FORMAT_CONFIG, DecimalFormat.NUMERIC.name());
     connectorConfig = new S3SinkConnectorConfig(properties);
     assertEquals(DecimalFormat.NUMERIC.name(), connectorConfig.getJsonDecimalFormat());
+  }
+
+  @Test
+  public void testJsonReplaceNullWithDefault() {
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertTrue(connectorConfig.getBoolean("json.replace.null.with.default"));
+
+    properties.put(S3SinkConnectorConfig.REPLACE_NULL_WITH_DEFAULT_CONFIG, "false");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertFalse(connectorConfig.getBoolean("json.replace.null.with.default"));
   }
 
   @Test

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkDataFormatIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkDataFormatIT.java
@@ -15,33 +15,6 @@
 
 package io.confluent.connect.s3.integration;
 
-import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_BUCKET_CONFIG;
-import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
-import static io.confluent.connect.storage.StorageSinkConnectorConfig.FORMAT_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
-import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-import io.confluent.connect.avro.AvroConverter;
-import io.confluent.connect.json.JsonSchemaConverter;
-import io.confluent.connect.protobuf.ProtobufConverter;
-import io.confluent.connect.s3.S3SinkConnector;
-import io.confluent.connect.s3.format.avro.AvroFormat;
-import io.confluent.connect.s3.storage.S3Storage;
-import io.confluent.connect.s3.util.EmbeddedConnectUtils;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -64,6 +37,35 @@ import org.junit.runners.Parameterized.Parameters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.shaded.com.google.common.collect.ImmutableMap;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+
+import io.confluent.connect.avro.AvroConverter;
+import io.confluent.connect.json.JsonSchemaConverter;
+import io.confluent.connect.protobuf.ProtobufConverter;
+import io.confluent.connect.s3.S3SinkConnector;
+import io.confluent.connect.s3.format.avro.AvroFormat;
+import io.confluent.connect.s3.storage.S3Storage;
+import io.confluent.connect.s3.util.EmbeddedConnectUtils;
+
+import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_BUCKET_CONFIG;
+import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
+import static io.confluent.connect.storage.StorageSinkConnectorConfig.FORMAT_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
+import static org.apache.kafka.connect.runtime.ConnectorConfig.VALUE_CONVERTER_CLASS_CONFIG;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(Parameterized.class)
 @Category(IntegrationTest.class)
@@ -196,7 +198,7 @@ public class S3SinkDataFormatIT extends BaseConnectorIT {
     assertFileNamesValid(TEST_BUCKET_NAME, new ArrayList<>(expectedTopicFilenames));
     // Now check that all files created by the sink have the contents that were sent
     // to the producer (they're all the same content)
-    assertTrue(fileContentsAsExpected(TEST_BUCKET_NAME, FLUSH_SIZE_STANDARD, recordValueStruct));
+    assertTrue(fileContentsAsExpected(TEST_BUCKET_NAME, FLUSH_SIZE_STANDARD, recordValueStruct, true));
   }
 
   protected void produceRecords(


### PR DESCRIPTION
## Problem

Using the JsonFormat to write "from" debezium to kafka and then using
the s3sinkconnector to read from kafka and save to s3, causes null
values to be stored always with their default values.

## Solution

Therefore adding a new config property (for backwards compatibility) to
allow the value transformer inside the s3sinkconnector to be configured
correctly.

Tests for the configuration and and integration have been added as well.

This addresses #716, but for json, instead of avro

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [x] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
