### PR TITLE
s3.send.digest option, default false

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -133,6 +133,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String COMPRESSION_TYPE_CONFIG = "s3.compression.type";
   public static final String COMPRESSION_TYPE_DEFAULT = "none";
 
+  public static final String SEND_DIGEST_CONFIG = "s3.send.digest";
+  public static final boolean SEND_DIGEST_DEFAULT = false;
+
   public static final String COMPRESSION_LEVEL_CONFIG = "s3.compression.level";
   public static final int COMPRESSION_LEVEL_DEFAULT = Deflater.DEFAULT_COMPRESSION;
   private static final CompressionLevelValidator COMPRESSION_LEVEL_VALIDATOR =
@@ -700,6 +703,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           "Schema Partition Affix Type",
           SCHEMA_PARTITION_AFFIX_TYPE_RECOMMENDER
       );
+
+      configDef.define(
+          SEND_DIGEST_CONFIG,
+          Type.BOOLEAN,
+          SEND_DIGEST_DEFAULT,
+          Importance.LOW,
+          "Enable or disable sending MD5 digest with S3 multipart upload request.",
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          "S3 Send Upload Message Digest"
+      );
     }
 
     {
@@ -922,6 +937,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public int getCompressionLevel() {
     return getInt(COMPRESSION_LEVEL_CONFIG);
+  }
+
+  public boolean isSendDigestEnabled() {
+    return getBoolean(SEND_DIGEST_CONFIG);
   }
 
   public String getJsonDecimalFormat() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -30,6 +30,8 @@ import com.amazonaws.services.s3.model.SSECustomerKey;
 import com.amazonaws.services.s3.model.UploadPartRequest;
 import io.confluent.connect.s3.S3SinkConnectorConfig;
 import io.confluent.connect.storage.common.util.StringUtils;
+
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.parquet.io.PositionOutputStream;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,6 +40,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -64,6 +67,7 @@ public class S3OutputStream extends PositionOutputStream {
   private final int compressionLevel;
   private volatile OutputStream compressionFilter;
   private Long position;
+  private final boolean enableDigest;
 
   public S3OutputStream(String key, S3SinkConnectorConfig conf, AmazonS3 s3) {
     this.s3 = s3;
@@ -78,6 +82,7 @@ public class S3OutputStream extends PositionOutputStream {
     this.partSize = conf.getPartSize();
     this.cannedAcl = conf.getCannedAcl();
     this.closed = false;
+    this.enableDigest = conf.isSendDigestEnabled();
 
     final boolean elasticBufEnable = conf.getElasticBufferEnable();
     if (elasticBufEnable) {
@@ -264,8 +269,31 @@ public class S3OutputStream extends PositionOutputStream {
                                             .withPartNumber(currentPartNumber)
                                             .withPartSize(partSize)
                                             .withGeneralProgressListener(progressListener);
+
+      if (enableDigest) {
+        request = request.withMD5Digest(computeDigest(inputStream, partSize));
+      }
+
       log.debug("Uploading part {} for id '{}'", currentPartNumber, uploadId);
       partETags.add(s3.uploadPart(request).getPartETag());
+    }
+
+    /**
+     * Consumes {@code partSize} bytes from the provided {@code inputStream} and computes the MD5 digest
+     *
+     * Resets the {@code inputStream} before returning digest.
+     *
+     * @param inputStream {@link ByteArrayInputStream} for upload part request payload
+     * @param partSize upload part size byte count
+     * @return MD5 digest of the provided input stream
+     */
+    private String computeDigest(ByteArrayInputStream inputStream, int partSize) {
+      byte[] streamBytes = new byte[partSize];
+      inputStream.read(streamBytes, 0, partSize);
+      String digest = Base64.getEncoder().encodeToString(DigestUtils.md5(streamBytes));
+      inputStream.reset();
+      log.debug("Computed digest {} for id '{}'", digest, uploadId);
+      return digest;
     }
 
     public void complete() throws IOException {

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -58,6 +58,7 @@ import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS
 import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
 
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SEND_DIGEST_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -627,6 +628,30 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
   @Test(expected = ConfigException.class)
   public void testSchemaPartitionerAffixTypeExceptionOnWrongValue() {
     properties.put(SCHEMA_PARTITION_AFFIX_TYPE_CONFIG, "Random");
+    new S3SinkConnectorConfig(properties);
+  }
+
+  @Test
+  public void testSendDigestConfigDefault() {
+    properties.remove(SEND_DIGEST_CONFIG);
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertFalse(connectorConfig.isSendDigestEnabled());
+  }
+
+  @Test
+  public void testSendDigestConfig() {
+    properties.put(SEND_DIGEST_CONFIG, "true");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertTrue(connectorConfig.isSendDigestEnabled());
+
+    properties.put(SEND_DIGEST_CONFIG, "false");
+    connectorConfig = new S3SinkConnectorConfig(properties);
+    assertFalse(connectorConfig.isSendDigestEnabled());
+  }
+
+  @Test(expected = ConfigException.class)
+  public void testSendDigestConfigOnWrongValue() {
+    properties.put(SEND_DIGEST_CONFIG, "Random");
     new S3SinkConnectorConfig(properties);
   }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -18,6 +18,7 @@ package io.confluent.connect.s3.integration;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_BUCKET_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.SEND_DIGEST_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_ACCESS_KEY_ID_CONFIG;
@@ -141,6 +142,30 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
   public void testBasicRecordsWrittenJson() throws Throwable {
     //add test specific props
     props.put(FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
+    testBasicRecordsWritten(JSON_EXTENSION, false);
+  }
+
+  @Test
+  public void testBasicRecordsWrittenWithDigestAvro() throws Throwable {
+    //add test specific props
+    props.put(FORMAT_CLASS_CONFIG, AvroFormat.class.getName());
+    props.put(SEND_DIGEST_CONFIG, "true");
+    testBasicRecordsWritten(AVRO_EXTENSION, false);
+  }
+
+  @Test
+  public void testBasicRecordsWrittenWithDigestParquet() throws Throwable {
+    //add test specific props
+    props.put(FORMAT_CLASS_CONFIG, ParquetFormat.class.getName());
+    props.put(SEND_DIGEST_CONFIG, "true");
+    testBasicRecordsWritten(PARQUET_EXTENSION, false);
+  }
+
+  @Test
+  public void testBasicRecordsWrittenWithDigestJson() throws Throwable {
+    //add test specific props
+    props.put(FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
+    props.put(SEND_DIGEST_CONFIG, "true");
     testBasicRecordsWritten(JSON_EXTENSION, false);
   }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamDigestTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/storage/S3OutputStreamDigestTest.java
@@ -1,0 +1,124 @@
+package io.confluent.connect.s3.storage;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.commons.codec.digest.DigestUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.shaded.org.bouncycastle.util.Arrays;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.amazonaws.services.s3.model.UploadPartResult;
+
+import io.confluent.common.utils.SystemTime;
+import io.confluent.common.utils.Time;
+import io.confluent.connect.s3.S3SinkConnectorConfig;
+import io.confluent.connect.s3.S3SinkConnectorTestBase;
+import io.confluent.connect.s3.S3SinkTaskTest;
+import io.confluent.connect.storage.schema.SchemaCompatibility;
+
+public class S3OutputStreamDigestTest extends S3SinkConnectorTestBase {
+
+  private AmazonS3 s3Mock;
+  private S3OutputStream stream;
+  final static String S3_TEST_KEY_NAME = "key";
+  final static String S3_EXCEPTION_MESSAGE = "this is an s3 exception";
+  private Map<String,String> localProps = new HashMap<>();
+
+  @Override
+  public void setUp() throws Exception {
+    super.setUp();
+    s3Mock = mock(AmazonS3.class);
+    properties.putAll(localProps);
+    connectorConfig = PowerMockito.spy(new S3SinkConnectorConfig(properties));
+    stream = new S3OutputStream(S3_TEST_KEY_NAME, connectorConfig, s3Mock);
+
+    InitiateMultipartUploadResult initiateResult = mock(InitiateMultipartUploadResult.class);
+    when(s3Mock.initiateMultipartUpload(Mockito.any())).thenReturn(initiateResult);
+    when(initiateResult.getUploadId()).thenReturn("upload-id");
+
+    UploadPartResult result = mock(UploadPartResult.class);
+    when(s3Mock.uploadPart(Mockito.any())).thenReturn(result);
+    when(result.getPartETag()).thenReturn(mock(PartETag.class));
+  }
+
+  @Override
+  protected Map<String,String> createProps() {
+    Map<String,String> props = super.createProps();
+    props.putAll(localProps);
+    props.put(S3SinkConnectorConfig.SEND_DIGEST_CONFIG, "true");
+    return props;
+  }
+
+  @Test
+  public void testDigestOnePartIsCorrect() throws Exception {
+    int size = 5242880;
+    localProps.put(S3SinkConnectorConfig.PART_SIZE_CONFIG, String.valueOf(size));
+    setUp();
+
+    byte[] payload = new byte[size - 1];
+    Random r = new Random(1);
+    r.nextBytes(payload);
+
+    stream.write(payload);
+    stream.commit();
+
+    ArgumentCaptor<UploadPartRequest> uploadPartRequestArgumentCaptor = ArgumentCaptor.forClass(
+        UploadPartRequest.class);
+    Mockito.verify(s3Mock, times(1)).uploadPart(uploadPartRequestArgumentCaptor.capture());
+
+    UploadPartRequest request = uploadPartRequestArgumentCaptor.getValue();
+    Assert.assertNotNull(request);
+    Assert.assertEquals(request.getMd5Digest(), Base64.getEncoder().encodeToString(DigestUtils.md5(payload)));
+  }
+
+  @Test
+  public void testDigestMultiPartIsCorrect() throws Exception {
+    int size = 5242880;
+    localProps.put(S3SinkConnectorConfig.PART_SIZE_CONFIG, String.valueOf(size));
+    setUp();
+
+    byte[] payload = new byte[size + 1];
+    Random r = new Random(1);
+    r.nextBytes(payload);
+
+    stream.write(payload);
+    stream.commit();
+
+    ArgumentCaptor<UploadPartRequest> uploadPartRequestArgumentCaptor = ArgumentCaptor.forClass(
+        UploadPartRequest.class);
+    Mockito.verify(s3Mock, times(2)).uploadPart(uploadPartRequestArgumentCaptor.capture());
+
+    Assert.assertEquals(2, uploadPartRequestArgumentCaptor.getAllValues().size());
+
+    UploadPartRequest request1 = uploadPartRequestArgumentCaptor.getAllValues().get(0);
+    Assert.assertNotNull(request1);
+    Assert.assertEquals(request1.getMd5Digest(),
+        Base64.getEncoder().encodeToString(DigestUtils.md5(Arrays.copyOf(payload, size))));
+
+    UploadPartRequest request2 = uploadPartRequestArgumentCaptor.getAllValues().get(1);
+    Assert.assertNotNull(request2);
+
+    byte[] payloadEnd = new byte[1];
+    payloadEnd[0] = payload[size];
+    Assert.assertEquals(request2.getMd5Digest(),
+        Base64.getEncoder().encodeToString(DigestUtils.md5(payloadEnd)));
+  }
+}


### PR DESCRIPTION
## Problem
https://github.com/confluentinc/kafka-connect-storage-cloud/issues/760, https://github.com/confluentinc/kafka-connect-storage-cloud/issues/710: S3 Object Locking requires an MD5 digest to be sent with the multipart upload request, otherwise it will be rejected.

## Solution
Include new option, `s3.send.digest`, that when set to `true` will include MD5 digest with upload parts.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [X] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Merge to master.

Developed in conjunction with @paul-dellinger 
