### PR TITLE
Add x-amz-server-side-encryption header for AES256 SSE without customer key

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -23,6 +23,7 @@ import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
 import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PartETag;
 import com.amazonaws.services.s3.model.SSEAlgorithm;
 import com.amazonaws.services.s3.model.SSEAwsKeyManagementParams;
@@ -205,14 +206,26 @@ public class S3OutputStream extends PositionOutputStream {
     super.close();
   }
 
+  private ObjectMetadata newObjectMetadata() {
+    ObjectMetadata meta = new ObjectMetadata();
+    if (StringUtils.isNotBlank(ssea)) {
+      meta.setSSEAlgorithm(ssea);
+    }
+    return meta;
+  }
+
   private MultipartUpload newMultipartUpload() throws IOException {
     InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(
         bucket,
         key
     ).withCannedACL(cannedAcl);
 
-    if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)
-        && StringUtils.isNotBlank(sseKmsKeyId)) {
+    if (SSEAlgorithm.AES256.toString().equalsIgnoreCase(ssea)
+        && sseCustomerKey == null) {
+      log.debug("Using SSE (AES256) without customer key");
+      initRequest.setObjectMetadata(newObjectMetadata());
+    } else if (SSEAlgorithm.KMS.toString().equalsIgnoreCase(ssea)
+               && StringUtils.isNotBlank(sseKmsKeyId)) {
       log.debug("Using KMS Key ID: {}", sseKmsKeyId);
       initRequest.setSSEAwsKeyManagementParams(new SSEAwsKeyManagementParams(sseKmsKeyId));
     } else if (sseCustomerKey != null) {


### PR DESCRIPTION
## Problem
See #770 

## Solution
The code in this PR adds the `x-amz-server-side-encryption` header in cases where `SSE` is configured to be `AES256` but not customer key was provided.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [X] yes
- [ ] no

##### If yes, where?
The following versions (and onwards) are affected, I'm not sure about this repo's patch strategy so I opened it on the latest branch.
- 10.5.6
- 10.4.8
- 10.3.10
- 10.2.14
- 10.1.15
- 10.0.26

## Test Strategy
Built locally and tested on our environment.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
