### PR TITLE
CC-26094 Add config to disable writing null records to dlq (#2)

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -155,6 +155,13 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
   public static final String BEHAVIOR_ON_NULL_VALUES_DEFAULT = BehaviorOnNullValues.FAIL.toString();
 
+  public static final String REPORT_NULL_RECORDS_TO_DLQ = "report.null.values.to.dlq";
+  public static final boolean REPORT_NULL_RECORDS_TO_DLQ_DEFAULT = true;
+  public static final String REPORT_NULL_RECORDS_TO_DLQ_DOC =
+      "Determine whether to log records with null values to dlq. "
+          + "`errors.tolerance` should be set to 'all' for successfully writing into dlq";
+  public static final String REPORT_NULL_RECORDS_TO_DLQ_DISPLAY = "Report null value to dlq";
+
   /**
    * Maximum back-off time when retrying failed requests.
    */
@@ -611,6 +618,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.SHORT,
           "Behavior for null-valued records"
+      );
+
+      configDef.define(
+          REPORT_NULL_RECORDS_TO_DLQ,
+          Type.BOOLEAN,
+          REPORT_NULL_RECORDS_TO_DLQ_DEFAULT,
+          Importance.LOW,
+          REPORT_NULL_RECORDS_TO_DLQ_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          REPORT_NULL_RECORDS_TO_DLQ_DISPLAY
       );
     }
 
@@ -1120,6 +1139,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public String nullValueBehavior() {
     return getString(BEHAVIOR_ON_NULL_VALUES_CONFIG);
+  }
+
+  public boolean reportNullRecordsToDlq() {
+    return getBoolean(REPORT_NULL_RECORDS_TO_DLQ);
   }
 
   public enum BehaviorOnNullValues {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -217,7 +217,7 @@ public class S3SinkTask extends SinkTask {
       TopicPartition tp = new TopicPartition(topic, partition);
 
       if (maybeSkipOnNullValue(record)) {
-        if (reporter != null) {
+        if (reporter != null && connectorConfig.reportNullRecordsToDlq()) {
           reporter.report(record, new DataException("Skipping null value record."));
         }
         continue;


### PR DESCRIPTION
Problem:
The connector sends null records to dlq if dlq is enabled and behaviour.on.null is set to ignore. But, if errors.tolerance is set to none, the connector fails as it sends the record with DataException to dlq. In such a case, there is no way for a customer to use both dlq(for other errors) and errors.tolerance is set to noneforbehaviour.on.nullis set toignore.

Solution:
This PR adds a simple config to skip writing to dlq in such an edge case

Testing:
Manually verified on docker-playground