### PR TITLE
CC-29502: Bumped kakfa-connect-storage-cloud

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.18</version>
+        <version>11.2.19</version>
     </parent>
 
     <groupId>io.confluent</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,6 @@
         <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox.version>5.4.0</woodstox.version>
         <guava.version>32.1.2-jre</guava.version>
-        <avro.version>1.11.3</avro.version>
         <zookeeper.version>3.8.4</zookeeper.version>
         <dnsjava.version>3.6.1</dnsjava.version>
     </properties>


### PR DESCRIPTION
## Problem
CC-29502: Vulnerable dependency "org.apache.avro_avro:1.11.3" for kafka-connect-[storage-cloud](https://confluentinc.atlassian.net/browse/STORAGE-cloud):master-latest

## Solution
Bump apache avro to 1.11.4
<img width="1364" alt="Screenshot 2024-10-22 at 10 46 34 AM" src="https://github.com/user-attachments/assets/13399b7e-2ffb-4914-b6ad-11de2404ebc8">

Docker Playground Run
<img width="1364" alt="Screenshot 2024-10-22 at 11 18 37 AM" src="https://github.com/user-attachments/assets/0c99d465-e1f2-4350-996a-27fcecabd221">


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
