### PR TITLE
MINOR: Replace Kafka Utils.join() with JDK API

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -20,6 +20,7 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.regions.Region;
 import com.amazonaws.regions.RegionUtils;
 import com.amazonaws.regions.Regions;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
@@ -34,7 +35,6 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigDef.Width;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
-import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.json.DecimalFormat;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
@@ -1143,14 +1143,14 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
         throw new ConfigException(
             name,
             region,
-            "Value must be one of: " + Utils.join(RegionUtils.getRegions(), ", ")
+            "Value must be one of: " + RegionUtils.getRegions().stream().map((Region::toString)).collect(Collectors.joining(", "))
         );
       }
     }
 
     @Override
     public String toString() {
-      return "[" + Utils.join(RegionUtils.getRegions(), ", ") + "]";
+      return "[" + RegionUtils.getRegions().stream().map((Region::toString)).collect(Collectors.joining(", ")) + "]";
     }
   }
 
@@ -1164,7 +1164,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
         TYPES_BY_NAME.put(compressionType.name, compressionType);
         names.add(compressionType.name);
       }
-      ALLOWED_VALUES = Utils.join(names, ", ");
+      ALLOWED_VALUES = String.join(", ", names);
     }
 
     @Override
@@ -1240,7 +1240,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
     @Override
     public String toString() {
-      return "[" + Utils.join(ALLOWED_VALUES, ", ") + "]";
+      return "[" + String.join(", ", ALLOWED_VALUES) + "]";
     }
   }
 
@@ -1254,7 +1254,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
         ACLS_BY_HEADER_VALUE.put(acl.toString(), acl);
         aclHeaderValues.add(acl.toString());
       }
-      ALLOWED_VALUES = Utils.join(aclHeaderValues, ", ");
+      ALLOWED_VALUES = String.join(", ", aclHeaderValues);
     }
 
     @Override


### PR DESCRIPTION
## Problem

The Kafka commons Utils class removed the "join" method in https://github.com/apache/kafka/pull/15823 in Kafka 3.8. Due to this reason the connector stopped working on Kafka Connect 3.8 as well.

## Solution

Following the example in the upstream PR, I'm replacing the usage of Utils.join with the JDK API of String.join, and updating the code accordingly.

This fixes https://github.com/confluentinc/kafka-connect-storage-cloud/issues/781

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan

Its safe to merge to master
