### PR TITLE
Fedramp CVE fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -279,6 +279,18 @@
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop.thirdparty</groupId>
+                    <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <!-- Pin transitive dependency of hadoop-common to fix CC-26361 since current latest version of hadoop-common does not include this.
@@ -357,6 +369,10 @@
                 <exclusion>
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop.thirdparty</groupId>
+                    <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
                 </exclusion>
             </exclusions>
             <scope>test</scope>


### PR DESCRIPTION
Removing protobuf-shaded and netty-common dependencies.

Tested with docker playground with AVRO and parquet formats. 

<img width="1621" alt="Screenshot 2025-01-21 at 3 03 51 PM" src="https://github.com/user-attachments/assets/7b1517e0-dc99-49f7-b339-59d53b0b0688" />

