### PR TITLE
CC-31153 Enable conditional writes in connector

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -33,7 +33,7 @@
     </description>
 
     <properties>
-        <aws.version>1.12.650</aws.version>
+        <aws.version>1.12.779</aws.version>
         <s3mock.version>0.2.5</s3mock.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <parquet.tools.version>1.11.1</parquet.tools.version>

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -107,6 +107,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String WAN_MODE_CONFIG = "s3.wan.mode";
   private static final boolean WAN_MODE_DEFAULT = false;
 
+  private static final String ENABLE_CONDITIONAL_WRITES_CONFIG = "enable.conditional.writes";
+  private static final boolean ENABLE_CONDITIONAL_WRITES_DEFAULT = true;
+
   public static final String CREDENTIALS_PROVIDER_CLASS_CONFIG = "s3.credentials.provider.class";
   public static final Class<? extends AWSCredentialsProvider> CREDENTIALS_PROVIDER_CLASS_DEFAULT =
       DefaultAWSCredentialsProviderChain.class;
@@ -769,6 +772,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Width.SHORT,
           "S3 Send Upload Message Digest"
       );
+
+      configDef.define(
+          ENABLE_CONDITIONAL_WRITES_CONFIG,
+          Type.BOOLEAN,
+          ENABLE_CONDITIONAL_WRITES_DEFAULT,
+          Importance.LOW,
+          "Enable conditional writes during multipart upload",
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          "Enable conditional writes during multipart upload"
+      );
     }
 
     {
@@ -1050,6 +1065,11 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public int getElasticBufferInitCap() {
     return getInt(ELASTIC_BUFFER_INIT_CAPACITY);
+  }
+
+  public boolean shouldEnableConditionalWrites() {
+    return getBoolean(ENABLE_CONDITIONAL_WRITES_CONFIG)
+        && getLong(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG) != -1;
   }
 
   public boolean isTombstoneWriteEnabled() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -109,6 +109,13 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String ENABLE_CONDITIONAL_WRITES_CONFIG = "enable.conditional.writes";
   private static final boolean ENABLE_CONDITIONAL_WRITES_DEFAULT = true;
+  private static final String ENABLE_CONDITIONAL_WRITES_DOC = "Flag to control whether to enable "
+      + "conditional writes during multipart upload. The config will be ignored if scheduled "
+      + "rotation is disabled by setting `rotate.schedule.interval.ms` to -1 or the connector is "
+      + "configured to write kafka keys or headers to S3";
+
+  public static final String MAX_FILE_SCAN_LIMIT_CONFIG = "max.files.scan.limit";
+  private static final String MAX_FILE_SCAN_LIMIT_DEFAULT = "100";
 
   public static final String CREDENTIALS_PROVIDER_CLASS_CONFIG = "s3.credentials.provider.class";
   public static final Class<? extends AWSCredentialsProvider> CREDENTIALS_PROVIDER_CLASS_DEFAULT =
@@ -778,11 +785,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           Type.BOOLEAN,
           ENABLE_CONDITIONAL_WRITES_DEFAULT,
           Importance.LOW,
-          "Enable conditional writes during multipart upload",
+          ENABLE_CONDITIONAL_WRITES_DOC,
           group,
           ++orderInGroup,
           Width.SHORT,
           "Enable conditional writes during multipart upload"
+      );
+
+      configDef.defineInternal(
+          MAX_FILE_SCAN_LIMIT_CONFIG,
+          Type.INT,
+          MAX_FILE_SCAN_LIMIT_DEFAULT,
+          Importance.LOW
       );
     }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -107,7 +107,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   public static final String WAN_MODE_CONFIG = "s3.wan.mode";
   private static final boolean WAN_MODE_DEFAULT = false;
 
-  private static final String ENABLE_CONDITIONAL_WRITES_CONFIG = "enable.conditional.writes";
+  public static final String ENABLE_CONDITIONAL_WRITES_CONFIG = "enable.conditional.writes";
   private static final boolean ENABLE_CONDITIONAL_WRITES_DEFAULT = true;
 
   public static final String CREDENTIALS_PROVIDER_CLASS_CONFIG = "s3.credentials.provider.class";

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -1069,7 +1069,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public boolean shouldEnableConditionalWrites() {
     return getBoolean(ENABLE_CONDITIONAL_WRITES_CONFIG)
-        && getLong(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG) != -1;
+        && getLong(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG) != -1
+        && !getBoolean(STORE_KAFKA_HEADERS_CONFIG)
+        && !getBoolean(STORE_KAFKA_KEYS_CONFIG);
   }
 
   public boolean isTombstoneWriteEnabled() {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -63,13 +63,13 @@ import io.confluent.connect.storage.partitioner.TimestampExtractor;
 import io.confluent.connect.storage.schema.StorageSchemaCompatibility;
 import io.confluent.connect.storage.util.DateTimeUtils;
 
+import static io.confluent.connect.s3.S3SinkConnectorConfig.MAX_FILE_SCAN_LIMIT_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_PART_RETRIES_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_RETRY_BACKOFF_CONFIG;
 
 public class TopicPartitionWriter {
 
   private static final Logger log = LoggerFactory.getLogger(TopicPartitionWriter.class);
-  private static final int MAX_SCAN_LIMIT = 100;
 
   private final Map<String, String> commitFiles;
   private final Map<String, RecordWriter> writers;
@@ -329,8 +329,7 @@ public class TopicPartitionWriter {
           }
         }
 
-        // TODO: Set appropriate upper bound
-        if (offsetToFilenameMap.size() < MAX_SCAN_LIMIT) {
+        if (offsetToFilenameMap.size() < connectorConfig.getInt(MAX_FILE_SCAN_LIMIT_CONFIG)) {
           offsetToFilenameMap.put(record.kafkaOffset(), getCommitFilename(record));
         }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -796,7 +796,7 @@ public class TopicPartitionWriter {
 
   public long findNextAvailableFile(String encodedPartition) {
     long startOffset = startOffsets.get(encodedPartition) + 1;
-    long targetEndOffset = startOffset + MAX_SCAN_LIMIT;
+    long targetEndOffset = startOffset + connectorConfig.getInt(MAX_FILE_SCAN_LIMIT_CONFIG);
     log.info("Scanning for available files for start_offset:{} and file {}",
         startOffset, commitFiles.get(encodedPartition));
     do {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/errors/FileExistsException.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/errors/FileExistsException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2018 Confluent Inc.
+ *
+ * Licensed under the Confluent Community License (the "License"); you may not use
+ * this file except in compliance with the License.  You may obtain a copy of the
+ * License at
+ *
+ * http://www.confluent.io/confluent-community-license
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package io.confluent.connect.s3.errors;
+
+import org.apache.kafka.connect.errors.RetriableException;
+
+public class FileExistsException extends RetriableException {
+  public FileExistsException(String s) {
+    super(s);
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -672,7 +672,7 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
   @Test
   public void testConditionalWritesEnabledConfig() {
 
-    // Default false -> since scheduled rotation is enabled
+    // Default false -> since scheduled rotation is not enabled
     assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
 
     // Should return false, because scheduled rotation is not enabled
@@ -683,9 +683,11 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     properties.put(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "100");
     assertTrue(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
 
+    // Both scheduled rotation and conditional write enabled. But, returns false because store kafka headers is enabled
     properties.put(STORE_KAFKA_HEADERS_CONFIG, "true");
     assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
 
+    // Both scheduled rotation and conditional write enabled. But, returns false because store kafka keys is enabled
     properties.put(STORE_KAFKA_HEADERS_CONFIG, "false");
     properties.put(STORE_KAFKA_KEYS_CONFIG, "true");
     assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -55,11 +55,13 @@ import io.confluent.connect.avro.AvroDataConfig;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.AffixType;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.DECIMAL_FORMAT_DEFAULT;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.ENABLE_CONDITIONAL_WRITES_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.HEADERS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SEND_DIGEST_CONFIG;
+import static io.confluent.connect.storage.StorageSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -663,6 +665,25 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
   public void testSendDigestConfigOnWrongValue() {
     properties.put(SEND_DIGEST_CONFIG, "Random");
     new S3SinkConnectorConfig(properties);
+  }
+
+  @Test
+  public void testConditionalWritesEnabledConfig() {
+
+    // Default false -> since scheduled rotation is enabled
+    assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
+
+    // Should return false, because scheduled rotation is not enabled
+    properties.put(ENABLE_CONDITIONAL_WRITES_CONFIG, "true");
+    assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
+
+    // Both scheduled rotation and conditional write enabled
+    properties.put(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "100");
+    assertTrue(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
+
+    // Conditional write disabled, but scheduled rotation enabled
+    properties.put(ENABLE_CONDITIONAL_WRITES_CONFIG, "false");
+    assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
   }
 }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkConnectorConfigTest.java
@@ -61,6 +61,8 @@ import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CO
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SEND_DIGEST_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.STORE_KAFKA_KEYS_CONFIG;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -681,8 +683,17 @@ public class S3SinkConnectorConfigTest extends S3SinkConnectorTestBase {
     properties.put(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "100");
     assertTrue(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
 
+    properties.put(STORE_KAFKA_HEADERS_CONFIG, "true");
+    assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
+
+    properties.put(STORE_KAFKA_HEADERS_CONFIG, "false");
+    properties.put(STORE_KAFKA_KEYS_CONFIG, "true");
+    assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
+
     // Conditional write disabled, but scheduled rotation enabled
     properties.put(ENABLE_CONDITIONAL_WRITES_CONFIG, "false");
+    properties.remove(STORE_KAFKA_HEADERS_CONFIG);
+    properties.remove(STORE_KAFKA_KEYS_CONFIG);
     assertFalse(new S3SinkConnectorConfig(properties).shouldEnableConditionalWrites());
   }
 }

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -16,6 +16,7 @@
 package io.confluent.connect.s3.integration;
 
 import static io.confluent.connect.s3.S3SinkConnectorConfig.BEHAVIOR_ON_NULL_VALUES_CONFIG;
+import static io.confluent.connect.s3.S3SinkConnectorConfig.ENABLE_CONDITIONAL_WRITES_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.KEYS_FORMAT_CLASS_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.S3_BUCKET_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SEND_DIGEST_CONFIG;
@@ -26,6 +27,7 @@ import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_SECRET_ACCESS_KE
 import static io.confluent.connect.s3.S3SinkConnectorConfig.TOMBSTONE_ENCODED_PARTITION;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FORMAT_CLASS_CONFIG;
+import static io.confluent.connect.storage.StorageSinkConnectorConfig.ROTATE_SCHEDULE_INTERVAL_MS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.CONNECTOR_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.KEY_CONVERTER_CLASS_CONFIG;
 import static org.apache.kafka.connect.runtime.ConnectorConfig.TASKS_MAX_CONFIG;
@@ -34,6 +36,7 @@ import static org.hamcrest.core.StringStartsWith.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.confluent.connect.s3.S3SinkConnector;
 import io.confluent.connect.s3.S3SinkConnectorConfig.IgnoreOrFailBehavior;
 import io.confluent.connect.s3.S3SinkConnectorConfig.OutputWriteBehavior;
@@ -41,6 +44,8 @@ import io.confluent.connect.s3.format.avro.AvroFormat;
 import io.confluent.connect.s3.format.json.JsonFormat;
 import io.confluent.connect.s3.format.parquet.ParquetFormat;
 import io.confluent.connect.s3.storage.S3Storage;
+
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,6 +59,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import io.confluent.connect.s3.util.EmbeddedConnectUtils;
+import io.confluent.connect.storage.partitioner.PartitionerConfig;
 import org.apache.commons.io.FileUtils;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -201,6 +207,74 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
     testBasicRecordsWritten(JSON_EXTENSION, true);
   }
 
+  @Test
+  public void testConnectorWithConditionalWrites() throws Throwable {
+    props.put(ENABLE_CONDITIONAL_WRITES_CONFIG, "true");
+    props.put(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "120000");
+    props.put(STORE_KAFKA_HEADERS_CONFIG, "false");
+    props.put(STORE_KAFKA_KEYS_CONFIG, "false");
+    props.put(PartitionerConfig.TIMEZONE_CONFIG, "UTC");
+    props.put(PartitionerConfig.LOCALE_CONFIG, "en-GB");
+    props.put(FORMAT_CLASS_CONFIG, JsonFormat.class.getName());
+
+    testRecordsWrittenWithConditionalWrites(JSON_EXTENSION);
+  }
+
+  private void writeDummyFile(String key) {
+    String initialFileContents = "{\"ID\":1,\"myBool\":true,\"myInt32\":32,\"myFloat32\":3.2,\"myFloat64\":64.64,\"myString\":\"theStringVal\"}\n"
+        + "{\"ID\":1,\"myBool\":true,\"myInt32\":32,\"myFloat32\":3.2,\"myFloat64\":64.64,\"myString\":\"theStringVal\"}";
+    S3Client.putObject(TEST_BUCKET_NAME, key, new ByteArrayInputStream(initialFileContents.getBytes()), new ObjectMetadata());
+  }
+
+  private void testRecordsWrittenWithConditionalWrites(String expectedFileExtension) throws InterruptedException, ExecutionException {
+
+    // Create some initial file - presumed to be created by another task instance. The file contains the first two records
+    String key = String.format("topics/%s/partition=0/%s+0+0000000000.json", DEFAULT_TEST_TOPIC_NAME, DEFAULT_TEST_TOPIC_NAME);
+    writeDummyFile(key);
+
+    // start sink connector
+    connect.configureConnector(CONNECTOR_NAME, props);
+    // wait for tasks to spin up
+    EmbeddedConnectUtils.waitForConnectorToStart(connect, CONNECTOR_NAME, Math.min(KAFKA_TOPICS.size(), MAX_TASKS));
+
+    Schema recordValueSchema = getSampleStructSchema();
+    Struct recordValueStruct = getSampleStructVal(recordValueSchema);
+
+    for (String topic : KAFKA_TOPICS) {
+      // Create and send records to Kafka using the topic name in the current 'thisTopicName'
+      SinkRecord sampleRecord = getSampleTopicRecord(topic, recordValueSchema, recordValueStruct);
+      produceRecordsNoHeaders(NUM_RECORDS_INSERT, sampleRecord);
+    }
+
+    log.info("Waiting for files in S3...");
+    int countPerTopic = NUM_RECORDS_INSERT / FLUSH_SIZE_STANDARD;
+    // Expected 1 additional file in S3
+    int expectedTotalFileCount = countPerTopic * KAFKA_TOPICS.size() + 1;
+    waitForFilesInBucket(TEST_BUCKET_NAME, expectedTotalFileCount);
+
+    Set<String> expectedTopicFilenames = new TreeSet<>();
+    for (String topic : KAFKA_TOPICS) {
+      List<String> expectedFilenames = getExpectedFilenames(
+          topic,
+          TOPIC_PARTITION,
+          FLUSH_SIZE_STANDARD,
+          1, // New files in S3 will start from offset 1, since file with offset 0 already exists in S3
+          NUM_RECORDS_INSERT,
+          expectedFileExtension
+      );
+      assertEquals(expectedFilenames.size(), countPerTopic);
+      expectedTopicFilenames.addAll(expectedFilenames);
+    }
+    expectedTopicFilenames.add(key);
+
+    assertEquals(expectedTopicFilenames.size(), expectedTotalFileCount);
+
+    // The total number of files allowed in the bucket is number of topics * # records produced for each
+    assertFileNamesValid(TEST_BUCKET_NAME, new ArrayList<>(expectedTopicFilenames));
+    // verify number of records written to S3
+    assertEquals(NUM_RECORDS_INSERT + 1, countNumberOfRecords(TEST_BUCKET_NAME)); // 1 duplicate record will be present in the seed file
+  }
+
   /**
    * Test that the expected records are written for a given file extension
    * Optionally, test that topics which have "*.{expectedFileExtension}*" in them are processed
@@ -253,6 +327,7 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
               thisTopicName,
               TOPIC_PARTITION,
               FLUSH_SIZE_STANDARD,
+              0,
               NUM_RECORDS_INSERT,
               expectedFileExtension
       );

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkConnectorIT.java
@@ -210,7 +210,7 @@ public class S3SinkConnectorIT extends BaseConnectorIT {
   @Test
   public void testConnectorWithConditionalWrites() throws Throwable {
     props.put(ENABLE_CONDITIONAL_WRITES_CONFIG, "true");
-    props.put(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "120000");
+    props.put(ROTATE_SCHEDULE_INTERVAL_MS_CONFIG, "60000");
     props.put(STORE_KAFKA_HEADERS_CONFIG, "false");
     props.put(STORE_KAFKA_KEYS_CONFIG, "false");
     props.put(PartitionerConfig.TIMEZONE_CONFIG, "UTC");

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkDataFormatIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/S3SinkDataFormatIT.java
@@ -183,6 +183,7 @@ public class S3SinkDataFormatIT extends BaseConnectorIT {
           thisTopicName,
           TOPIC_PARTITION,
           FLUSH_SIZE_STANDARD,
+          0,
           NUM_RECORDS_INSERT,
           AVRO_EXTENSION
       );


### PR DESCRIPTION
## Problem


## Solution
- Adds a config to enable conditional writes, the default being true
- The conditional write will be enabled only when scheduled interval is set and store kafka key/headers config is disabled to retain the existing delivery semantics
- On a conditional write exception, a FileExistsException is rethrown , which being a retriable exception will reset the offset and poll again accordingly
- In case of FileExistsException, connector will scan the s3 bucket for next available file which is not present in S3 by making consecutive get object requests. If the get api fails with 403 error, it will simply increment to next offset.
- To enable determining the next available file, the equivalent target file name is cached for initial few records, had the record been the first record in the file. The offset will be reset to the one whose equivalent file does not exist in S3
- Use LinkedHashMap to store `commitFiles` instead of existing `HashMap` to ensure files with smaller start offsets (i.e. the ones which were added to the map first) are written to S3 first. This is required to ensure we safely increment to next offset in case of conflict

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests
- [ ] Performance tests - TODO
- [ ] Chaos tests - TODO

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
The feature will be released as a new minor release on 10.6.x branch
