### PR TITLE
CC-31172: Bump hadoop-common to 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <!-- temporary fix by pinning the version until we upgrade to a version of common that contains this or newer version.
             See https://github.com/confluentinc/common/pull/332 for details -->
         <dependency.check.version>6.1.6</dependency.check.version>
-        <hadoop.version>3.4.0</hadoop.version>
+        <hadoop.version>3.4.1</hadoop.version>
         <jettison.version>1.5.4</jettison.version>
         <snakeyaml.version>2.0</snakeyaml.version>
         <woodstox.version>5.4.0</woodstox.version>


### PR DESCRIPTION
## Problem
Hadoop-common's dependency `org.bouncycastle:bcprov-jdk15on:1.70` has CVEs CVE-2024-30171 and CVE-2024-29857.

## Solution
Bump up hadoop-common to 3.4.1
This will switch the dependency to `org.bouncycastle:bcprov-jdk18on:jar:1.78`. 
(jdk15on has been moved to jdk18on - https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk15on)

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [X] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [X] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
