### PR TITLE
Bump AWS version

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -33,7 +33,7 @@
     </description>
 
     <properties>
-        <aws.version>1.12.650</aws.version>
+        <aws.version>1.12.750</aws.version>
         <s3mock.version>0.2.5</s3mock.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
         <parquet.tools.version>1.11.1</parquet.tools.version>


### PR DESCRIPTION
## Problem
Bumping AWS version to `1.12.750` to support eksPodIdentity for IAM Role assumption

## Testing
Validated in devel canary, connector is working fine with this change