### PR TITLE
feat: prevent clearing assigned topic partitions

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -328,14 +328,14 @@ public class S3SinkTask extends SinkTask {
 
   @Override
   public void close(Collection<TopicPartition> partitions) {
-    for (TopicPartition tp : topicPartitionWriters.keySet()) {
+    for (TopicPartition tp : partitions) {
       try {
         topicPartitionWriters.get(tp).close();
       } catch (ConnectException e) {
         log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
       }
+      topicPartitionWriters.remove(tp);
     }
-    topicPartitionWriters.clear();
   }
 
   @Override


### PR DESCRIPTION
## Problem
This is a duplication of the work done in https://github.com/confluentinc/kafka-connect-storage-cloud/pull/648 fixing the issue described in  https://github.com/confluentinc/kafka-connect-storage-cloud/issues/649

In order to use CooperativeStickyAssignor as the `partition.assignment.strategy` we need to adjust how the connector clears all the assigned topicPartitionWriters on close(). 

## Solution


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
