### PR TITLE
CC-32742 Add additional checks to confirm file exists in S3

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3OutputStream.java
@@ -341,8 +341,8 @@ public class S3OutputStream extends PositionOutputStream {
                 if (exists) {
                   throw new FileExistsException("File already exists");
                 }
-                throw new ConnectException("Unexpected state - Contradicting response from " +
-                    "conditional upload and file exists call in S3");
+                throw new ConnectException("Unexpected state - Contradicting response from "
+                    + "conditional upload and file exists call in S3");
               }
               throw e;
             }
@@ -357,7 +357,8 @@ public class S3OutputStream extends PositionOutputStream {
         if (e.getStatusCode() == 403) {
           log.warn("Connector failed with 403 error. Defaulting as file exists", e);
           // To avoid failing connector due to missing ACL, we consider as file exists.
-          // We should be fine to assume file exists here since the call is being made only as an additional sanity check after file upload failed with 412
+          // We should be fine to assume file exists here since the call is being made only as an
+          // additional sanity check after file upload failed with 412
           return true;
         }
         throw e;


### PR DESCRIPTION
## Problem
Add additional checks to confirm file exists in S3 after a 412 error from S3

## Solution
- Add additional call to S3 to confirm file exists in S3 before returning a FileExistsException. Even though this adds an additional api call, it should be fine since the subsequent scanning for files in S3 will anyways happen to get next available offset.
- This also fixes the condition where s3 returned 200 ok status with PreConditionFailed error
```
com.amazonaws.services.s3.model.AmazonS3Exception: At least one of the pre-conditions you specified did not hold (Service: Amazon S3; Status Code: 200; Error Code: PreconditionFailed; Request ID: 8F1YK0DTDWAY6277; S3 Extended Request ID: yyiZ80A38ykXjJ2HgAMUayESZ4Cfte2HPoxYtpwgT+H8EAbiUsD72EWWH1nxHbraTxG5Fkv+680=; Proxy: null), S3 Extended Request ID: yyiZ80A38ykXjJ2HgAMUayESZ4Cfte2HPoxYtpwgT+H8EAbiUsD72EWWH1nxHbraTxG5Fkv+680=
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
