### PR TITLE
Add support for AWS IAM Roles for Service Accounts (IRSA)

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsWebIdentityTokenCredentialsProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsWebIdentityTokenCredentialsProvider.java
@@ -1,0 +1,77 @@
+package io.confluent.connect.s3.auth;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.WebIdentityTokenCredentialsProvider;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+import java.util.Map;
+
+/**
+ * AWS credentials provider that uses the AWS IAM Roles for Service Accounts (IRSA) to assume a Role
+ * and create a temporary, short-lived session to use for authentication.
+ */
+public class AwsWebIdentityTokenCredentialsProvider implements AWSCredentialsProvider,
+    Configurable {
+
+  public static final String ROLE_ARN_CONFIG = "irsa.role.arn";
+  public static final String ROLE_SESSION_NAME_CONFIG = "irsa.session.name";
+  public static final String WEB_IDENTITY_TOKEN_FILE_CONFIG = "irsa.token.file";
+
+  private WebIdentityTokenCredentialsProvider webIdentityTokenCredentialsProvider;
+
+  private static final ConfigDef CONFIG_DEF = createConfigDef();
+
+  private static ConfigDef createConfigDef() {
+    return new ConfigDef()
+        .define(
+            ROLE_ARN_CONFIG,
+            ConfigDef.Type.STRING,
+            ConfigDef.Importance.HIGH,
+            "Role ARN to use when starting a session."
+        ).define(
+            ROLE_SESSION_NAME_CONFIG,
+            ConfigDef.Type.STRING,
+            ConfigDef.Importance.HIGH,
+            "Role session name to use when starting a session."
+        ).define(
+            WEB_IDENTITY_TOKEN_FILE_CONFIG,
+            ConfigDef.Type.STRING,
+            ConfigDef.Importance.HIGH,
+            "Path to the web identity token file.")
+        ;
+  }
+
+  @Override
+  public void configure(Map<String, ?> configs) {
+    AbstractConfig config = new AbstractConfig(CONFIG_DEF, configs);
+
+    String roleArn = config.getString(ROLE_ARN_CONFIG);
+    String roleSessionName = config.getString(ROLE_SESSION_NAME_CONFIG);
+    String tokenFile = config.getString(WEB_IDENTITY_TOKEN_FILE_CONFIG);
+
+    webIdentityTokenCredentialsProvider = com.amazonaws.auth.WebIdentityTokenCredentialsProvider.builder()
+        .roleArn(roleArn)
+        .roleSessionName(roleSessionName)
+        .webIdentityTokenFile(tokenFile)
+        .build();
+  }
+
+  @Override
+  public AWSCredentials getCredentials() {
+    if (webIdentityTokenCredentialsProvider == null) {
+      throw new IllegalStateException(
+          "WebIdentityTokenCredentialsProvider has not been configured.");
+    }
+    return webIdentityTokenCredentialsProvider.getCredentials();
+  }
+
+  @Override
+  public void refresh() {
+    if (webIdentityTokenCredentialsProvider != null) {
+      webIdentityTokenCredentialsProvider.refresh();
+    }
+  }
+}


### PR DESCRIPTION
## Problem
[AWS IAM roles for service accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) is a recommended approach for applications such as Kubernetes to authenticate with AWS services without managing 
static credentials.

From AWS's docs:
> In 2014, AWS Identity and Access Management added support for federated identities using OpenID Connect (OIDC). This feature allows you to authenticate AWS API calls with supported identity providers and receive a valid OIDC JSON web token (JWT). You can pass this token to the AWS STS AssumeRoleWithWebIdentity API operation and receive IAM temporary role credentials. You can use these credentials to interact with any AWS service.


## Solution
Introduce `io.confluent.connect.s3.auth.AwsWebIdentityTokenCredentialsProvider` which can be set using the `s3.credentials.provider.class` connector property.

This provider is a wrapper around AWS’s native [WebIdentityTokenCredentialsProvider](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/auth/WebIdentityTokenCredentialsProvider.html), similar to how [AwsAssumeRoleCredentialsProvider](https://github.com/rodrigo-molina/kafka-connect-storage-cloud/blob/f3f928abccee1e21ac2126b7eddfc83bff860e81/kafka-connect-s3/src/main/java/io/confluent/connect/s3/auth/AwsAssumeRoleCredentialsProvider.java#L40) is implemented. It enables configuring IRSA credentials directly via connector properties.

`AwsWebIdentityTokenCredentialsProvider` configuration properties:
- `irsa.role.arn`: Role ARN to use when starting a session.
- `irsa.session.name`: Role session name to use when starting a session.
- `irsa.token.file`: Path to the web identity token file.

##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
Any connector that supports instances of `AWSCredentialsProvider` and `Configurable` in its configurations.

## Test Strategy
The Confluent S3 Sink connector allows custom AWS credential providers via configuration. We have tested this change by deploying a JAR containing the proposed class and using it within the connector's classpath (confluentinc-kafka-connect-avro-converter-7.8.0/lib).

##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
This change has no external release dependencies.
