### PR TITLE
CC-33012 Bump parquet-avro dependency

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -36,7 +36,6 @@
         <aws.version>1.12.650</aws.version>
         <s3mock.version>0.2.5</s3mock.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <parquet.tools.version>1.15.1</parquet.tools.version>
         <formatters.version>0.2.2</formatters.version>
         <confluent.connect.testcontainers.version>1.0.1</confluent.connect.testcontainers.version>
         <org.testcontainer.version>1.15.0</org.testcontainer.version>

--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -36,7 +36,7 @@
         <aws.version>1.12.650</aws.version>
         <s3mock.version>0.2.5</s3mock.version>
         <kafka.connect.maven.plugin.version>0.11.1</kafka.connect.maven.plugin.version>
-        <parquet.tools.version>1.11.1</parquet.tools.version>
+        <parquet.tools.version>1.15.1</parquet.tools.version>
         <formatters.version>0.2.2</formatters.version>
         <confluent.connect.testcontainers.version>1.0.1</confluent.connect.testcontainers.version>
         <org.testcontainer.version>1.15.0</org.testcontainer.version>
@@ -161,12 +161,7 @@
             <version>${guava.version}</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-tools</artifactId>
-            <version>${parquet.tools.version}</version>
-            <scope>test</scope>
-        </dependency>
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8-standalone</artifactId>

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/integration/BaseConnectorIT.java
@@ -19,6 +19,7 @@ import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_ACCESS_KEY_ID_CO
 import static io.confluent.connect.s3.S3SinkConnectorConfig.AWS_SECRET_ACCESS_KEY_CONFIG;
 import static io.confluent.kafka.schemaregistry.ClusterTestHarness.KAFKASTORE_TOPIC;
 
+import org.apache.avro.generic.GenericData;
 import com.amazonaws.auth.AWSStaticCredentialsProvider;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
@@ -33,6 +34,9 @@ import com.google.common.collect.ImmutableMap;
 import io.confluent.common.utils.IntegrationTest;
 import io.confluent.kafka.schemaregistry.CompatibilityLevel;
 import io.confluent.kafka.schemaregistry.RestApp;
+import org.apache.parquet.hadoop.util.HadoopInputFile;
+import org.apache.parquet.io.InputFile;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -53,6 +57,8 @@ import java.util.stream.Collectors;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.parquet.avro.AvroParquetReader;
+
 import org.apache.avro.io.DatumReader;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -68,9 +74,6 @@ import org.apache.kafka.test.TestUtils;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
-import org.apache.parquet.tools.json.JsonRecordFormatter;
-import org.apache.parquet.tools.read.SimpleReadSupport;
-import org.apache.parquet.tools.read.SimpleRecord;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
@@ -493,18 +496,20 @@ public abstract class BaseConnectorIT {
    * @return the rows of the file as JsonNodes
    */
   private static List<JsonNode> getContentsFromParquet(String filePath) {
-    try (ParquetReader<SimpleRecord> reader = ParquetReader
-        .builder(new SimpleReadSupport(), new Path(filePath)).build()){
-      ParquetMetadata metadata = ParquetFileReader
-          .readFooter(new Configuration(), new Path(filePath));
-      JsonRecordFormatter.JsonGroupFormatter formatter = JsonRecordFormatter
-          .fromSchema(metadata.getFileMetaData().getSchema());
-      List<JsonNode> fileRows = new ArrayList<>();
-      for (SimpleRecord value = reader.read(); value != null; value = reader.read()) {
-        JsonNode jsonNode = jsonMapper.readTree(formatter.formatRecord(value));
-        fileRows.add(jsonNode);
+    List<JsonNode> fileRows = new ArrayList<JsonNode>();
+    try {
+      InputFile inputFile = HadoopInputFile.fromPath(new org.apache.hadoop.fs.Path(filePath), new Configuration());
+      try (ParquetReader<GenericData.Record> recordAvroParquetReader =
+               AvroParquetReader.<GenericData.Record>builder(inputFile)
+                   .build()) {
+        GenericData.Record record;
+        while ((record = recordAvroParquetReader.read()) != null) {
+          fileRows.add(jsonMapper.readTree(record.toString()));
+        }
+        return fileRows;
+      } catch (IOException e) {
+        throw new RuntimeException(e);
       }
-      return fileRows;
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.21</version>
+        <version>11.2.22</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION
## Problem


## Solution
Bumped parquet-avro dependency.

parquet-tools dependency used in test is not compatible with latest parquet-avro dependency and hence, it has been removed and added logic to read parquet files using parquet reader

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests - Test using docker playground writing parquet files

```
➜  kafka-connect-s3 git:(CC-33012/parquet-bump) ✗ mvn dependency:tree | grep parquet-
[INFO] |  +- org.apache.parquet:parquet-column:jar:1.15.1:compile
[INFO] |  |  +- org.apache.parquet:parquet-common:jar:1.15.1:compile
[INFO] |  |  |  \- org.apache.parquet:parquet-format-structures:jar:1.15.1:compile
[INFO] |  |  \- org.apache.parquet:parquet-encoding:jar:1.15.1:compile
[INFO] |  \- org.apache.parquet:parquet-avro:jar:1.15.1:compile
[INFO] |     \- org.apache.parquet:parquet-hadoop:jar:1.15.1:compile
```

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
