### PR TITLE
Update File rotation based on a limit when FieldPartitioner is selected.

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -250,6 +250,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       + "to prefix or suffix in the s3 path after the topic name."
       + " None will not append the schema name in the s3 path.";
 
+  public static final String FIELD_PARTITIONER_FLUSH_SIZE_CONFIG = "field.partitioner.flush.size";
+  public static final int FIELD_PARTITIONER_FLUSH_SIZE_DEFAULT = -1;
+
   private static final GenericRecommender SCHEMA_PARTITION_AFFIX_TYPE_RECOMMENDER =
       new GenericRecommender();
 
@@ -913,6 +916,12 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           "Elastic buffer initial capacity"
       );
 
+      configDef.defineInternal(
+          FIELD_PARTITIONER_FLUSH_SIZE_CONFIG,
+          Type.INT,
+          FIELD_PARTITIONER_FLUSH_SIZE_DEFAULT,
+          Importance.LOW
+      );
     }
     return configDef;
   }

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -23,6 +23,7 @@ import io.confluent.connect.s3.util.FileRotationTracker;
 import io.confluent.connect.s3.util.RetryUtil;
 import io.confluent.connect.s3.util.TombstoneTimestampExtractor;
 import io.confluent.connect.storage.errors.PartitionException;
+import io.confluent.connect.storage.partitioner.FieldPartitioner;
 import io.confluent.connect.storage.schema.SchemaCompatibilityResult;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.data.Schema;
@@ -88,6 +89,7 @@ public class TopicPartitionWriter {
   private final boolean ignoreTaggingErrors;
   private int recordCount;
   private final int flushSize;
+  private final int fieldPartitionerFlushSize;
   private final long rotateIntervalMs;
   private final long rotateScheduleIntervalMs;
   private long nextScheduledRotation;
@@ -169,6 +171,8 @@ public class TopicPartitionWriter {
             S3SinkConnectorConfig.S3_OBJECT_BEHAVIOR_ON_TAGGING_ERROR_CONFIG)
             .equalsIgnoreCase(S3SinkConnectorConfig.IgnoreOrFailBehavior.IGNORE.toString());
     flushSize = connectorConfig.getInt(S3SinkConnectorConfig.FLUSH_SIZE_CONFIG);
+    fieldPartitionerFlushSize = connectorConfig.getInt(
+        S3SinkConnectorConfig.FIELD_PARTITIONER_FLUSH_SIZE_CONFIG);
     topicsDir = connectorConfig.getString(StorageCommonConfig.TOPICS_DIR_CONFIG);
     rotateIntervalMs = connectorConfig.getLong(S3SinkConnectorConfig.ROTATE_INTERVAL_MS_CONFIG);
     if (rotateIntervalMs > 0 && timestampExtractor == null) {
@@ -428,6 +432,17 @@ public class TopicPartitionWriter {
       return false;
     }
 
+    if (rotateOnFieldPartitioner()) {
+      fileRotationTracker.incrementRotationByFieldPartitionerCount(encodedPartition);
+      log.info(
+          "Starting commit and rotation for topic partition {} with start offset {}",
+          tp,
+          startOffsets
+      );
+      nextState();
+      return true;
+    }
+
     if (rotateOnSize()) {
       fileRotationTracker.incrementRotationByFlushSizeCount(encodedPartition);
       log.info(
@@ -440,6 +455,22 @@ public class TopicPartitionWriter {
     }
 
     return false;
+  }
+
+  private boolean rotateOnFieldPartitioner() {
+    if (!(partitioner instanceof FieldPartitioner) || fieldPartitionerFlushSize == -1) {
+      return false;
+    }
+
+    boolean rotate = recordCount >= fieldPartitionerFlushSize;
+    log.info("Rotate on field partitioner for topic-partition '{}': "
+            + "(count {} >= field partitioner flush size {})? {}",
+        tp,
+        recordCount,
+        fieldPartitionerFlushSize,
+        rotate
+    );
+    return rotate;
   }
 
   private void commitOnTimeIfNoData(long now) {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/FileRotationTracker.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/FileRotationTracker.java
@@ -27,6 +27,8 @@ public final class FileRotationTracker {
 
     int rotationByFlushSize = 0;
 
+    int rotationByFieldPartitioner = 0;
+
     int rotationByRotationInterval = 0;
 
     int rotationByScheduledRotationInterval = 0;
@@ -69,6 +71,10 @@ public final class FileRotationTracker {
       rotationByFlushSize++;
     }
 
+    public void incrementRotationByFieldPartitionerCount() {
+      rotationByFieldPartitioner++;
+    }
+
     public void incrementRotationByRotationIntervalCount() {
       rotationByRotationInterval++;
     }
@@ -95,6 +101,13 @@ public final class FileRotationTracker {
       metrics.put(outputPartition, new RotationMetrics());
     }
     metrics.get(outputPartition).incrementRotationByFlushSizeCount();
+  }
+
+  public void incrementRotationByFieldPartitionerCount(String outputPartition) {
+    if (!metrics.containsKey(outputPartition)) {
+      metrics.put(outputPartition, new RotationMetrics());
+    }
+    metrics.get(outputPartition).incrementRotationByFieldPartitionerCount();
   }
 
   public void incrementRotationByRotationIntervalCount(String outputPartition) {
@@ -135,6 +148,8 @@ public final class FileRotationTracker {
       sb.append(rotationMetrics.rotationByScheduledRotationInterval);
       sb.append(", RotationByFlushSize: ");
       sb.append(rotationMetrics.rotationByFlushSize);
+      sb.append(", RotationByFieldPartitioner: ");
+      sb.append(rotationMetrics.rotationByFieldPartitioner);
       sb.append(", RotationByDiffName: ");
       sb.append(rotationMetrics.rotationByDiffName);
       sb.append(", RotationByDiffSchema: ");

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/TopicPartitionWriterTest.java
@@ -99,6 +99,7 @@ import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static io.confluent.connect.s3.S3SinkConnectorConfig.FIELD_PARTITIONER_FLUSH_SIZE_CONFIG;
 import static io.confluent.connect.s3.S3SinkConnectorConfig.SCHEMA_PARTITION_AFFIX_TYPE_CONFIG;
 import static io.confluent.connect.s3.util.Utils.sinkRecordToLoggableString;
 import static io.confluent.connect.storage.StorageSinkConnectorConfig.FLUSH_SIZE_CONFIG;
@@ -656,6 +657,79 @@ public class TopicPartitionWriterTest extends TestWithMockedS3 {
     );
 
     verify(expectedFiles, 2, schema, records);
+  }
+
+  @Test
+  public void testWriteRecordFieldBasedPartitionAndRotateOnFlushSize() throws Exception {
+    localProps.put(FIELD_PARTITIONER_FLUSH_SIZE_CONFIG, "5");
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    setUp();
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new FieldPartitioner<>();
+    partitioner.configure(parsedConfig);
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 1, 5);
+
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // Test actual write
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    @SuppressWarnings("unchecked")
+    List<String> partitionFields = (List<String>) parsedConfig.get(PARTITION_FIELD_NAME_CONFIG);
+    String partitionField = partitionFields.get(0);
+    String dirPrefix1 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(16));
+
+    List<String> expectedFiles = new ArrayList<>();
+    expectedFiles.add(FileUtils.fileKeyToCommit(topicsDir, dirPrefix1, TOPIC_PARTITION, 0, extension, ZERO_PAD_FMT));
+    verify(expectedFiles, 5, schema, records);
+  }
+
+  @Test
+  public void testWriteRecordFieldBasedPartitionAndRotateOnFlushSizeWhenFlushSizeIsUnset() throws Exception {
+    localProps.put(FIELD_PARTITIONER_FLUSH_SIZE_CONFIG, "-1");
+    localProps.put(FLUSH_SIZE_CONFIG, "1000");
+    setUp();
+
+    // Define the partitioner
+    Partitioner<?> partitioner = new FieldPartitioner<>();
+    partitioner.configure(parsedConfig);
+
+    TopicPartitionWriter topicPartitionWriter = new TopicPartitionWriter(
+        TOPIC_PARTITION, storage, writerProvider, partitioner, connectorConfig, context, null);
+
+    String key = "key";
+    Schema schema = createSchema();
+    List<Struct> records = createRecordBatches(schema, 1, 5);
+
+    Collection<SinkRecord> sinkRecords = createSinkRecords(records, key, schema);
+
+    for (SinkRecord record : sinkRecords) {
+      topicPartitionWriter.buffer(record);
+    }
+
+    // Test actual write
+    topicPartitionWriter.write();
+    topicPartitionWriter.close();
+
+    @SuppressWarnings("unchecked")
+    List<String> partitionFields = (List<String>) parsedConfig.get(PARTITION_FIELD_NAME_CONFIG);
+    String partitionField = partitionFields.get(0);
+    String dirPrefix1 = partitioner.generatePartitionedPath(TOPIC, partitionField + "=" + String.valueOf(16));
+
+    List<String> expectedFiles = new ArrayList<>();
+    verify(expectedFiles, 0, schema, records);
   }
 
   @Test

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileRotationTrackerTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/FileRotationTrackerTest.java
@@ -17,13 +17,14 @@ public class FileRotationTrackerTest {
     FileRotationTracker fileRotationTracker = new FileRotationTracker();
     fileRotationTracker.incrementRotationByRotationIntervalCount(FILE_1);
     fileRotationTracker.incrementRotationByFlushSizeCount(FILE_2);
+    fileRotationTracker.incrementRotationByFieldPartitionerCount(FILE_2);
     fileRotationTracker
         .incrementRotationBySchemaChangeCount(FILE_3, SchemaIncompatibilityType.DIFFERENT_VERSION);
     fileRotationTracker.incrementRotationByFlushSizeCount(FILE_1);
     String actual = fileRotationTracker.toString();
-    String expected = "OutputPartition: file2, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0, RotationByNullSchema: 0\n"
-        + "OutputPartition: file3, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 0, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 1, RotationByDiffParams: 0, RotationByNullSchema: 0\n"
-        + "OutputPartition: file1, RotationByInterval: 1, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0, RotationByNullSchema: 0\n";
+    String expected = "OutputPartition: file2, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByFieldPartitioner: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0, RotationByNullSchema: 0\n"
+        + "OutputPartition: file3, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 0, RotationByFieldPartitioner: 0, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 1, RotationByDiffParams: 0, RotationByNullSchema: 0\n"
+        + "OutputPartition: file1, RotationByInterval: 1, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByFieldPartitioner: 0, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0, RotationByNullSchema: 0\n";
     Assert.assertEquals(expected, actual);
   }
 
@@ -32,13 +33,14 @@ public class FileRotationTrackerTest {
     FileRotationTracker fileRotationTracker = new FileRotationTracker();
     fileRotationTracker.incrementRotationByRotationIntervalCount(FILE_1);
     fileRotationTracker.incrementRotationByFlushSizeCount(FILE_2);
+    fileRotationTracker.incrementRotationByFieldPartitionerCount(FILE_3);
     fileRotationTracker
         .incrementRotationBySchemaChangeCount(FILE_3, SchemaIncompatibilityType.DIFFERENT_VERSION);
     fileRotationTracker.incrementRotationByFlushSizeCount(FILE_1);
     String actual = fileRotationTracker.toString();
-    String expected = "OutputPartition: file2, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0, RotationByNullSchema: 0\n"
-        + "OutputPartition: file3, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 0, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 1, RotationByDiffParams: 0, RotationByNullSchema: 0\n"
-        + "OutputPartition: file1, RotationByInterval: 1, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0, RotationByNullSchema: 0\n";
+    String expected = "OutputPartition: file2, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByFieldPartitioner: 0, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0, RotationByNullSchema: 0\n"
+        + "OutputPartition: file3, RotationByInterval: 0, RotationByScheduledInterval: 0, RotationByFlushSize: 0, RotationByFieldPartitioner: 1, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 1, RotationByDiffParams: 0, RotationByNullSchema: 0\n"
+        + "OutputPartition: file1, RotationByInterval: 1, RotationByScheduledInterval: 0, RotationByFlushSize: 1, RotationByFieldPartitioner: 0, RotationByDiffName: 0, RotationByDiffSchema: 0, RotationByDiffType: 0, RotationByDiffVersion: 0, RotationByDiffParams: 0, RotationByNullSchema: 0\n";
     Assert.assertEquals(expected, actual);
     fileRotationTracker.clear();
     actual = fileRotationTracker.toString();


### PR DESCRIPTION
## Problem

* When FieldPartitioner is selected, we do not want to overload the resources in Cloud and cause a failure.

JIRA: https://confluentinc.atlassian.net/browse/CC-33220

## Solution

* We're limiting Part size to 5MB, FieldPartitioner flush size to 500 files, and 1 Topic Partition per task.
* As part of this approach, we're limiting the flush size to 500 via template values in this commit.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy

* Tested by deploying the changes on devel canary-6. The limit is being applied correctly based on the configured value.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
