### PR TITLE
Document limitation of proxy config not working with assume role credentials provider.

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -417,8 +417,9 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           "Credentials provider or provider chain to use for authentication to AWS. By default "
               + "the connector uses ``"
               + DefaultAWSCredentialsProviderChain.class.getSimpleName()
-              + "``.",
-
+              + "``."
+              + " If you are using a assume role in the credentials provider, a proxy configuration will not work."
+              + " This is a limitation of the underlying AWS SDK client.",
           group,
           ++orderInGroup,
           Width.LONG,

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -418,7 +418,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
               + "the connector uses ``"
               + DefaultAWSCredentialsProviderChain.class.getSimpleName()
               + "``."
-              + " If you are using a assume role in the credentials provider, a proxy configuration will not work."
+              + " If you are using a assume role in the credentials provider,"
+              + " a proxy configuration will not work."
               + " This is a limitation of the underlying AWS SDK client.",
           group,
           ++orderInGroup,


### PR DESCRIPTION

## Problem
https://confluentinc.atlassian.net/browse/CC-33745.
There is a bug with aws client sdk, that it does not support proxy configuration with assume role credentials ref- https://github.com/aws/aws-sdk-java/issues/2558. So if a customer is using the config "s3.credentials.provider.class" and the credentials provider class is using a AssumeRole, they won't be able to use a proxy configuration with this.

## Solution
Documented the limitation in the config doc  for - "s3.credentials.provider.class"

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
