### PR TITLE
feat: allow null and empty headers configuration option

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -1443,7 +1443,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     return getBoolean(ROTATE_FILE_ON_PARTITION_CHANGE);
   }
 
-  public Boolean allowNullAndEmptyHeaders() {
+  public boolean allowNullAndEmptyHeaders() {
     return getBoolean(IGNORE_NULL_OR_EMPTY_HEADERS_CONFIG);
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -1443,7 +1443,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
     return getBoolean(ROTATE_FILE_ON_PARTITION_CHANGE);
   }
 
-  public boolean allowNullAndEmptyHeaders() {
+  public boolean ignoreNullOrEmptyHeaders() {
     return getBoolean(IGNORE_NULL_OR_EMPTY_HEADERS_CONFIG);
   }
 

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -178,8 +178,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
   public static final String BEHAVIOR_ON_NULL_VALUES_DEFAULT = OutputWriteBehavior.FAIL.toString();
-  public static final String ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG = "allow.null.and.empty.headers";
-  public static final Boolean ALLOW_NULL_AND_EMPTY_HEADERS_DEFAULT = false;
+  public static final String IGNORE_NULL_OR_EMPTY_HEADERS_CONFIG = "ignore.null.or.empty.headers";
+  public static final Boolean IGNORE_NULL_OR_EMPTY_HEADERS_DEFAULT = false;
 
   public static final String REPORT_NULL_RECORDS_TO_DLQ = "report.null.values.to.dlq";
   public static final boolean REPORT_NULL_RECORDS_TO_DLQ_DEFAULT = true;
@@ -727,15 +727,20 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       );
 
       configDef.define(
-              ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG,
+              IGNORE_NULL_OR_EMPTY_HEADERS_CONFIG,
               Type.BOOLEAN,
-              ALLOW_NULL_AND_EMPTY_HEADERS_DEFAULT,
+              IGNORE_NULL_OR_EMPTY_HEADERS_DEFAULT,
               Importance.LOW,
-              "Whether to allow null and empty headers when writing headers is enabled.",
+              "How to handle records with a null or empty headers when store headers is enabled."
+              + " If true, the message will be saved even if headers are missing and store "
+              + " headers is enabled."
+              + " Else, an exception will be thrown if headers are missing and store headers is"
+              + " enabled."
+              + " This option has no effect if store headers is disabled.",
               group,
               ++orderInGroup,
               Width.SHORT,
-              "Whether to allow null and empty headers when writing headers is enabled."
+              "Whether to ignore null or empty headers when storing message headers is enabled."
       );
 
       configDef.define(
@@ -1439,7 +1444,7 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
   }
 
   public Boolean allowNullAndEmptyHeaders() {
-    return getBoolean(ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG);
+    return getBoolean(IGNORE_NULL_OR_EMPTY_HEADERS_CONFIG);
   }
 
   public enum IgnoreOrFailBehavior {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -178,6 +178,8 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public static final String BEHAVIOR_ON_NULL_VALUES_CONFIG = "behavior.on.null.values";
   public static final String BEHAVIOR_ON_NULL_VALUES_DEFAULT = OutputWriteBehavior.FAIL.toString();
+  public static final String ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG = "allow.null.and.empty.headers";
+  public static final Boolean ALLOW_NULL_AND_EMPTY_HEADERS_DEFAULT = false;
 
   public static final String REPORT_NULL_RECORDS_TO_DLQ = "report.null.values.to.dlq";
   public static final boolean REPORT_NULL_RECORDS_TO_DLQ_DEFAULT = true;
@@ -722,6 +724,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.SHORT,
           "Behavior for null-valued records"
+      );
+
+      configDef.define(
+              ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG,
+              Type.BOOLEAN,
+              ALLOW_NULL_AND_EMPTY_HEADERS_DEFAULT,
+              Importance.LOW,
+              "Whether to allow null and empty headers when writing headers is enabled.",
+              group,
+              ++orderInGroup,
+              Width.SHORT,
+              "Whether to allow null and empty headers when writing headers is enabled."
       );
 
       configDef.define(
@@ -1422,6 +1436,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public boolean shouldRotateOnPartitionChange() {
     return getBoolean(ROTATE_FILE_ON_PARTITION_CHANGE);
+  }
+
+  public Boolean allowNullAndEmptyHeaders() {
+    return getBoolean(ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG);
   }
 
   public enum IgnoreOrFailBehavior {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -103,6 +103,7 @@ public class KeyValueHeaderRecordWriterProvider
 
         // headerWriter != null means writing headers is turned on
         if (headerWriter.isPresent()
+            && !conf.allowNullAndEmptyHeaders()
             && (sinkRecord.headers() == null || sinkRecord.headers().isEmpty())) {
           throw new DataException(
               String.format("Headers cannot be null for SinkRecord: %s",

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/format/KeyValueHeaderRecordWriterProvider.java
@@ -103,7 +103,7 @@ public class KeyValueHeaderRecordWriterProvider
 
         // headerWriter != null means writing headers is turned on
         if (headerWriter.isPresent()
-            && !conf.allowNullAndEmptyHeaders()
+            && !conf.ignoreNullOrEmptyHeaders()
             && (sinkRecord.headers() == null || sinkRecord.headers().isEmpty())) {
           throw new DataException(
               String.format("Headers cannot be null for SinkRecord: %s",

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/DataWriterAvroTest.java
@@ -972,19 +972,7 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
       verifyFileListing(validOffsets, partitions, EXTENSION);
     }
 
-    for (TopicPartition tp : partitions) {
-      for (int i = 1, j = 0; i < validOffsets.length; ++i) {
-        long startOffset = validOffsets[i - 1];
-        long size = validOffsets[i] - startOffset;
-
-        FileUtils.fileKeyToCommit(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset, EXTENSION, ZERO_PAD_FMT);
-        Collection<Object> records = readRecords(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset,
-                                                 EXTENSION, ZERO_PAD_FMT, S3_TEST_BUCKET_NAME, s3);
-        assertEquals(size, records.size());
-        verifyContents(sinkRecords, j, records);
-        j += size;
-      }
-    }
+    verifyFileContents(partitions, validOffsets, sinkRecords);
   }
 
   protected void verifyOffsets(
@@ -1020,5 +1008,20 @@ public class DataWriterAvroTest extends DataWriterTestBase<AvroFormat> {
     }
     assertEquals(actualOffsets, expectedOffsets);
   }
-}
 
+  protected void verifyFileContents(Set<TopicPartition> partitions, long[] validOffsets, List<SinkRecord> sinkRecords) throws IOException {
+    for (TopicPartition tp : partitions) {
+      for (int i = 1, j = 0; i < validOffsets.length; ++i) {
+        long startOffset = validOffsets[i - 1];
+        long size = validOffsets[i] - startOffset;
+
+        FileUtils.fileKeyToCommit(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset, EXTENSION, ZERO_PAD_FMT);
+        Collection<Object> records = readRecords(topicsDir, getDirectory(tp.topic(), tp.partition()), tp, startOffset,
+            EXTENSION, ZERO_PAD_FMT, S3_TEST_BUCKET_NAME, s3);
+        assertEquals(size, records.size());
+        verifyContents(sinkRecords, j, records);
+        j += size;
+      }
+    }
+  }
+}

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -146,18 +146,18 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
   }
 
   @Test
-  public void testAllowNullAndEmptyHeaders() throws Exception {
+  public void testIgnoreNullAndEmptyHeaders() throws Exception {
     setUp();
     replayAll();
     task = new S3SinkTask();
     task.initialize(context);
-    properties.put(S3SinkConnectorConfig.ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG, "true");
+    properties.put(S3SinkConnectorConfig.IGNORE_NULL_OR_EMPTY_HEADERS_CONFIG, "true");
     task.start(properties);
     verifyAll();
 
     List<SinkRecord> sinkRecords = createRecords(7);
-    SinkRecord recordWithNullHeaders = new SinkRecord(TOPIC, PARTITION, null, null, null, null, 1, null, null, Collections.emptyList());
-    SinkRecord recordWithEmptyHeaders = new SinkRecord(TOPIC, PARTITION, null, null, null, null, 1, null, null, null);
+    SinkRecord recordWithNullHeaders = new SinkRecord(TOPIC, PARTITION, null, null, null, null, 1, null, null, null);
+    SinkRecord recordWithEmptyHeaders = new SinkRecord(TOPIC, PARTITION, null, null, null, null, 1, null, null, Collections.emptyList());
 
     sinkRecords.add(recordWithNullHeaders);
     sinkRecords.add(recordWithEmptyHeaders);
@@ -289,4 +289,3 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
   }
 
 }
-

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -146,6 +146,33 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
   }
 
   @Test
+  public void testAllowNullAndEmptyHeaders() throws Exception {
+    setUp();
+    replayAll();
+    task = new S3SinkTask();
+    task.initialize(context);
+    properties.put(S3SinkConnectorConfig.ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG, "true");
+    task.start(properties);
+    verifyAll();
+
+    List<SinkRecord> sinkRecords = createRecords(7);
+    SinkRecord recordWithNullHeaders = new SinkRecord(TOPIC, PARTITION, null, null, null, null, 1, null, null, Collections.emptyList());
+    SinkRecord recordWithEmptyHeaders = new SinkRecord(TOPIC, PARTITION, null, null, null, null, 1, null, null, null);
+
+    sinkRecords.add(recordWithNullHeaders);
+    sinkRecords.add(recordWithEmptyHeaders);
+
+    task.put(sinkRecords);
+
+    task.close(context.assignment());
+    task.stop();
+
+    long[] validOffsets = {0, 3, 6};
+
+    verify(sinkRecords, validOffsets);
+  }
+
+  @Test
   public void testWriteRecordWithPrimitives() throws Exception {
     setUp();
     replayAll();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -146,7 +146,7 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
   }
 
   @Test
-  public void testIgnoreNullAndEmptyHeaders() throws Exception {
+  public void testIgnoreNullOrEmptyHeaders() throws Exception {
     setUp();
     replayAll();
     task = new S3SinkTask();

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -151,7 +151,7 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
 
   @Test
   public void testAllowNullAndEmptyHeaders() throws Exception {
-    localProps.put(S3SinkConnectorConfig.ALLOW_NULL_AND_EMPTY_HEADERS_CONFIG, "true");
+    localProps.put(S3SinkConnectorConfig.IGNORE_NULL_OR_EMPTY_HEADERS_CONFIG, "true");
     localProps.put(S3SinkConnectorConfig.STORE_KAFKA_HEADERS_CONFIG, "true");
     setUp();
 


### PR DESCRIPTION
## Problem

S3 Sink Connector will throw an error when processing a message with missing/empty headers when write headers is enabled.

In certain cases, users may wish to process topics that have a mix of messages with and without headers, and to save the headers where they exist.

For example: 
https://github.com/confluentinc/kafka-connect-storage-cloud/issues/602

## Solution

Provide a configuration option to allowmessages with missing headers, even when write headers is enabled.

The expected behaviour is that the connector will simply not write the header if it is empty or missing.

The default behaviour state of the setting will be `false`, to maintain current behaviour of throwing an exception.

##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

## Test Strategy

Manual testing on developer device.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan