### PR TITLE
SUP-228: Add logs to show connector's file rotation

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -126,7 +126,7 @@ public class TopicPartitionWriter {
   private final FileRotationTracker fileRotationTracker;
   
   // Diagnostic logging variables
-  private static final long DIAGNOSTIC_LOG_INTERVAL_MS = 60000; // 60 seconds
+  private static final long DIAGNOSTIC_LOG_INTERVAL_MS = 300000; // 5 minutes
   private long lastDiagnosticLogTime = 0;
 
   public TopicPartitionWriter(TopicPartition tp,


### PR DESCRIPTION
## Problem
- Customer wasn't aware of the file rotation frequency which resulted in smaller files.

## Solution
- Add logs to show connector's file rotation
- JIRA: https://confluentinc.atlassian.net/browse/SUP-228

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
- Object store sink connectors (GCS, Azure blob store sink)

## Test Strategy
- Dirty image testing on devel canary

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
