### PR TITLE
Upgraded netty-codec-http2 version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,6 +100,11 @@
                 <artifactId>jose4j</artifactId>
                 <version>0.9.4</version>
             </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http2</artifactId>
+                <version>4.1.124.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Problem
Bump `netty-codec-http2` version : https://confluentinc.atlassian.net/browse/CC-36369 

## Solution
Added a dependency in `dependencyManagement` section with updated version of `netty-codec-http2`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy
Playground tests.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
