### PR TITLE
Bumping `netty-codec-http2` version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>4.1.124.Final</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${httpclient.version}</version>


### PR DESCRIPTION
## Problem
Bump `netty-codec-http2` version : https://confluentinc.atlassian.net/browse/CC-36369 

## Solution
Added a dependency in `dependencyManagement` section with updated version of `netty-codec-http2`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
Playground tests.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
