### PR TITLE
Fix bucket exists check to handle 403 errors

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/S3FileUtils.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/util/S3FileUtils.java
@@ -46,7 +46,7 @@ public class S3FileUtils {
       // A redirect error or an AccessDenied exception means the bucket exists but it's not in
       // this region or we don't have permissions to it.
       if ((ase.statusCode() == HttpStatusCode.MOVED_PERMANENTLY)
-          || "AccessDenied".equals(ase.awsErrorDetails().errorCode())) {
+          || ase.statusCode() == HttpStatusCode.FORBIDDEN) {
         log.info("Bucket {} exists, but not in this region or we don't have permissions to it.",
             bucketName);
         return true;

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/S3FileUtilsTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/util/S3FileUtilsTest.java
@@ -115,8 +115,8 @@ public class S3FileUtilsTest {
     // Given
     String bucketName = "access-denied-bucket";
     AwsErrorDetails errorDetails = AwsErrorDetails.builder()
-        .errorCode("AccessDenied")
-        .errorMessage("Access Denied")
+        .errorCode("Forbidden")
+        .errorMessage("Forbidden")
         .build();
     AwsServiceException accessDeniedException = AwsServiceException.builder()
         .statusCode(HttpStatusCode.FORBIDDEN)


### PR DESCRIPTION
## Problem
When the IAM user does not have permissions to ListBucket, it fails with error
```
software.amazon.awssdk.services.s3.model.S3Exception: Forbidden (Service: S3, Status Code: 403, Request ID: 4N4NV95674Y4J2MF, Extended Request ID: OoAXGw5Yj01ZsVLGY7ag7zvE7BDTFjPEJwoaIWQ4oEKkIa0k5QKEkTXy8TbLnmo4XMes4bKXGIA=)
```

The existing code for bucket exists was looking for a wrong condition and hence, it was failing with 403 error.

## Solution
Fixes the right condition to check for 403 status code

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
