### PR TITLE
CC-36817 Add default https scheme to endpoint url

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/storage/S3Storage.java
@@ -115,8 +115,12 @@ public class S3Storage implements Storage<S3SinkConnectorConfig, ListObjectsResp
                 ? builder.region(Region.US_EAST_1)
                 : builder.region(Region.of(region));
     } else {
+      URI endpoint = URI.create(url);
+      if (endpoint.getScheme() == null) {
+        endpoint = URI.create("https://" + url);
+      }
       builder = builder
-          .endpointOverride(URI.create(url))
+          .endpointOverride(endpoint)
           .region(Region.of(region));
     }
     log.info("S3 client created");


### PR DESCRIPTION
## Problem
The connector fails with error when the store.url does not have a uri scheme associated with it.
```
Caused by: java.lang.NullPointerException: The URI scheme of endpointOverride must not be null.
	at software.amazon.awssdk.utils.Validate.paramNotNull(Validate.java:156)
	at software.amazon.awssdk.core.internal.StaticClientEndpointProvider.<init>(StaticClientEndpointProvider.java:37)
	at software.amazon.awssdk.core.ClientEndpointProvider.forEndpointOverride(ClientEndpointProvider.java:36)
	at software.amazon.awssdk.core.client.builder.SdkDefaultClientBuilder.endpointOverride(SdkDefaultClientBuilder.java:581)
	at io.confluent.connect.s3.storage.S3Storage.newS3Client(S3Storage.java:119)
	at io.confluent.connect.s3.storage.S3Storage.<init>(S3Storage.java:91)
	at java.base/jdk.internal.reflect.DirectConstructorHandleAccessor.newInstance(DirectConstructorHandleAccessor.java:62)
	... 14 more
```

## Solution
If the uri scheme is empty, add https as the default uri scheme.


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
