### PR TITLE
CC-35444 - Upgrade commons-lang3 version to 3.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,11 +100,6 @@
                 <artifactId>jose4j</artifactId>
                 <version>0.9.4</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>3.18.0</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
## Problem
[CVE](https://confluentinc.atlassian.net/browse/CC-35444?atlOrigin=eyJpIjoiOTg1MjlmMTgyMzhjNDEwMzk3NGVjY2IyNTIxNzY3YTMiLCJwIjoiamlyYS1zbGFjay1pbnQifQ) - Upgrade `commons-lang3` version to `3.18.0`

## Solution
To resolve the CVE, we explicitly added an upgraded dependency on `commons-lang3` in the `dependencies` section of the `pom.xml`. We chose this approach rather than updating the parent dependency (`hadoop-common`), because even the latest available version of `hadoop-common` remains affected by the vulnerability. For reference, [hadoop-common 3.4.2](https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-common/3.4.2) still lists `CVE-2025-48924` in its vulnerabilities section. By directly specifying the safe version of `commons-lang3`, we ensure that our project is protected against the CVE, regardless of the transitive dependencies brought in by `hadoop-common`.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?
This solution is applicable in scenarios where the `commons-lang3` library must be upgraded to version `3.18.0` to address a CVE, but upgrading its parent dependency is not feasible or does not resolve the vulnerability. By directly specifying the desired version of `commons-lang3` in your project dependencies, you can effectively mitigate the CVE without relying on changes to the parent library.

## Test Strategy
Playground tests, CI - build-test-release

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
Hub release was done on 1 Oct, 2025.
