### PR TITLE
Fix CVE : commons-lang3

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -49,6 +49,11 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons.lang3.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
                 <version>${aws.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons.lang3.version}</version>
+            </dependency>
             <!-- band aid until connector catches up with the updated schema registry -->
             <dependency>
                 <groupId>org.yaml</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,10 @@
             <version>${hadoop.version}</version>
             <exclusions>
                 <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>
                 </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
         <guava.version>32.1.2-jre</guava.version>
         <zookeeper.version>3.8.4</zookeeper.version>
         <dnsjava.version>3.6.1</dnsjava.version>
+        <commons.lang3.version>3.18.0</commons.lang3.version>
     </properties>
 
     <repositories>
@@ -104,11 +105,6 @@
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.18.0</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
@@ -196,10 +192,6 @@
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
             <exclusions>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-lang3</artifactId>
-                </exclusion>
                 <exclusion>
                     <groupId>org.apache.avro</groupId>
                     <artifactId>avro</artifactId>


### PR DESCRIPTION
## Problem
The vulnerability identified in [CC-35444](https://confluentinc.atlassian.net/browse/CC-35444) persists because 'commons-lang3' is still included transitively through the 'hadoop-common' dependency, even after the partial resolution in [PR #879](https://github.com/confluentinc/kafka-connect-storage-cloud/pull/879). 

## Solution
To fully address this issue, we pinned the version in the 'dependencyManagement' in the 'pom' files.
<img width="720" height="717" alt="image" src="https://github.com/user-attachments/assets/7af99185-853d-412d-af69-a02c8a43961e" />
<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [x] no

##### If yes, where?


## Test Strategy
kdp
<img width="692" height="342" alt="image" src="https://github.com/user-attachments/assets/fab68e74-ad8e-4957-9af6-50b1f75112a7" />

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 


[CC-35444]: https://confluentinc.atlassian.net/browse/CC-35444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ