### PR TITLE
CC-40256 Fix CVE in io.netty:netty-codec-http2 by upgrading to 4.2.11.Final

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -107,7 +107,7 @@
                 </exclusion>
                 <exclusion>
                     <groupId>io.netty</groupId>
-                    <artifactId>netty-codec-http-2</artifactId>
+                    <artifactId>netty-codec-http2</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -115,19 +115,19 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>4.2.10.Final</version>
+            <version>${netty.version}</version>
         </dependency>
         <!--        pin version to fix CVE-2025-5516-->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>4.2.5.Final</version>
+            <version>${netty.version}</version>
         </dependency>
-        <!--        pin version to fixCVE-2025-58057-->
+        <!--        pin version to fix CVE-2025-58057-->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec</artifactId>
-            <version>4.2.5.Final</version>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,7 @@
         <zookeeper.version>3.9.5</zookeeper.version>
         <dnsjava.version>3.6.1</dnsjava.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
+        <netty.version>4.2.11.Final</netty.version>
     </properties>
 
     <repositories>
@@ -109,7 +110,7 @@
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-codec-http2</artifactId>
-                <version>4.2.5.Final</version>
+                <version>${netty.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -118,7 +119,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http2</artifactId>
-            <version>4.2.5.Final</version>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>


### PR DESCRIPTION
## Problem

CVE-2026-33871: Fix vulnerability in netty-codec-http2  dependency

## Solution
 Bump netty-codec-http2 version to 4.2.11.Final.
Addititionally, it also bumps some other netty dependencies to keep the versions aligned

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [x] Integration tests
- [ ] System tests
- [x] Manual tests - KDP test - 
[s3-sink-kdp.txt](https://github.com/user-attachments/files/26623284/s3-sink-kdp.txt)


## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
