### PR TITLE
CC-41245: Bump netty.version to 4.2.13.Final on 11.0.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.34</version>
+        <version>11.2.35</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -72,7 +72,7 @@
         <zookeeper.version>3.9.5</zookeeper.version>
         <dnsjava.version>3.6.1</dnsjava.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
-        <netty.version>4.2.11.Final</netty.version>
+        <netty.version>4.2.13.Final</netty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Summary

Bumps the managed `<netty.version>` in `kafka-connect-storage-cloud` from `4.2.11.Final` to `4.2.13.Final` to address Netty CVEs flagged across `netty-codec-compression`, `netty-codec-http`, and `netty-codec-http2`. Also bumps `kafka-connect-storage-common-parent` from `11.2.34` to `11.2.35` for routine alignment.

- JIRA: https://confluentinc.atlassian.net/browse/CC-41245
- JIRA: https://confluentinc.atlassian.net/browse/CC-41154
- JIRA: https://confluentinc.atlassian.net/browse/CC-41244

## Testing details

### `mvn dependency:tree` (post-bump)

All Netty 4.2.x artifacts now resolve to `4.2.13.Final`:

```
io.confluent:kafka-connect-s3:jar:11.0.13-SNAPSHOT
 +- io.netty:netty-transport:jar:4.2.13.Final:compile
 +- io.netty:netty-common:jar:4.2.13.Final:compile
 +- io.netty:netty-buffer:jar:4.2.13.Final:compile
 +- io.netty:netty-handler:jar:4.2.13.Final:compile
 +- io.netty:netty-transport-classes-epoll:jar:4.2.13.Final:compile
 +- io.netty:netty-resolver:jar:4.2.13.Final:compile
 +- io.netty:netty-codec-http:jar:4.2.13.Final:compile
 |  +- io.netty:netty-codec-base:jar:4.2.13.Final:compile
 |  \- io.netty:netty-codec-compression:jar:4.2.13.Final:compile
 +- io.netty:netty-codec-http2:jar:4.2.13.Final:compile
 +- io.netty:netty-codec:jar:4.2.13.Final:compile
 |  +- io.netty:netty-codec-protobuf:jar:4.2.13.Final:compile
 |  \- io.netty:netty-codec-marshalling:jar:4.2.13.Final:compile
```

No leftover lower-version Netty 4.2.x artifacts remain.

### Trivy scan

`trivy rootfs --severity HIGH,CRITICAL` against the built connector package reports **0 Netty CVEs**. Remaining `bcprov-jdk18on:1.82` finding is tracked under CC-40908 in a separate PR.

### KDP sanity test

_To be appended after the playground run completes._

Bucket: `s3://mahmed-caas-dev/` (`us-west-2`). Playground env: plaintext (CP 8.2.0). Connector built from this PR's HEAD as `confluentinc-kafka-connect-s3-11.0.13-SNAPSHOT.zip`.

Last lines of `playground run -f s3-sink.sh` output:

```
[INFO] 💯 Listing last 5 versions for connector plugin confluentinc/kafka-connect-s3
🔢 v12.1.4 - 📅 release date: 2026-04-13 (29 days ago)
[INFO] Current
🔢 v11.0.13-SNAPSHOT - 📅 release date: 2026-05-12
[INFO] 🧩 Displaying status for onprem connector s3-sink
Name                           Status       Tasks
---------------------------------------------------------------
s3-sink                        ✅ RUNNING  0:🟢 RUNNING
---------------------------------------------------------------
```

Connector loaded with the bumped Netty 4.2.13.Final, task transitioned to RUNNING, no errors in the playground run.
