### PR TITLE
CC-40908: Pin bcprov-jdk18on to 1.84 on 10.6.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.34</version>
+        <version>11.2.35</version>
     </parent>
 
     <groupId>io.confluent</groupId>
@@ -105,6 +105,13 @@
                 <groupId>org.bitbucket.b_c</groupId>
                 <artifactId>jose4j</artifactId>
                 <version>0.9.6</version>
+            </dependency>
+            <!-- CC-40908: pin bouncycastle to 1.84 to address CVE-2026-5598
+                 (Hadoop transitive brings in 1.82). -->
+            <dependency>
+                <groupId>org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>1.84</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Summary

Pins `org.bouncycastle:bcprov-jdk18on` to `1.84` in `<dependencyManagement>` to address CVE-2026-5598 (private key leakage via non-constant time comparisons). The vulnerable `1.82` is brought in transitively via Hadoop. Also bumps `kafka-connect-storage-common-parent` from `11.2.34` to `11.2.35` for routine alignment.

- JIRA: https://confluentinc.atlassian.net/browse/CC-40908

## Testing details

### `mvn dependency:tree` (post-bump)

```
io.confluent:kafka-connect-s3:jar:10.6.15-SNAPSHOT
 \- org.bouncycastle:bcprov-jdk18on:jar:1.84:compile
```

`bcprov-jdk18on` now resolves to `1.84` everywhere in the tree.

### Trivy scan

`trivy rootfs --severity HIGH,CRITICAL` against the built connector package reports **0 HIGH/CRITICAL findings**. The previously flagged `CVE-2026-5598` against `bcprov-jdk18on:1.82` is gone.

### KDP sanity test

_To be appended after the playground run completes._

Bucket: `s3://mahmed-caas-dev/` (`us-west-2`). Playground env: plaintext (CP 8.2.0). Connector built from this PR's HEAD as `confluentinc-kafka-connect-s3-10.6.15-SNAPSHOT.zip`.

Last lines of `playground run -f s3-sink.sh` output:

```
[INFO] 💯 Listing last 5 versions for connector plugin confluentinc/kafka-connect-s3
🔢 v12.1.4 - 📅 release date: 2026-04-13
[INFO] Current
🔢 v10.6.15-SNAPSHOT - 📅 release date: 2026-05-12
[INFO] 🧩 Displaying status for onprem connector s3-sink
Name                           Status       Tasks
---------------------------------------------------------------
s3-sink                        ✅ RUNNING  0:🟢 RUNNING
---------------------------------------------------------------
```

Connector loaded with bcprov-jdk18on 1.84 pinned, task transitioned to RUNNING, no errors in the playground run.
