### PR TITLE
CC-41245: Remove redundant netty CVE pins on 11.0.x

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -94,40 +94,6 @@
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>netty-nio-client</artifactId>
-<!--            exclude netty dependecies as the latest version still has CVE-2025-55163, CVE-2025-58056,-->
-<!--            CVE-2025-58057-->
-            <exclusions>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec-http</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-codec-http2</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <!--    pin version to fix CVE-2025-58056, CVE-2025-67721, CVE-2025-67735-->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <!--        pin version to fix CVE-2025-5516-->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <!--        pin version to fix CVE-2025-58057-->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.findify</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -114,20 +114,10 @@
                 <artifactId>bcprov-jdk18on</artifactId>
                 <version>1.84</version>
             </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-codec-http2</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-codec-http2</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>


### PR DESCRIPTION
## Summary

Removes explicit netty CVE pins that are now redundant on 11.0.x. After [CC-41245 / PR #931](https://github.com/confluentinc/kafka-connect-storage-cloud/pull/931) bumped `kafka-connect-storage-common-parent` from `11.2.34` → `11.2.35` and set `<netty.version>4.2.13.Final</netty.version>`, the parent BOM already manages every netty 4.2.x artifact via that property — so the layered pins from earlier remediation PRs no longer do anything.

Removed (all redundant):
- Top-level `pom.xml`: `<dependencyManagement>` and `<dependencies>` entries for `io.netty:netty-codec-http2` (added by PR #929).
- `kafka-connect-s3/pom.xml`: `<exclusions>` block on `software.amazon.awssdk:netty-nio-client` for `netty-codec`, `netty-codec-http`, `netty-codec-http2`.
- `kafka-connect-s3/pom.xml`: direct `<dependency>` declarations for `netty-codec-http`, `netty-codec-http2`, `netty-codec` (pinned earlier for CVE-2025-58056, CVE-2025-67721, CVE-2025-67735, CVE-2025-5516, CVE-2025-58057).

Kept: `<netty.version>4.2.13.Final</netty.version>` — single source of truth driving the parent BOM.

- JIRA: https://confluentinc.atlassian.net/browse/CC-41245
- JIRA: https://confluentinc.atlassian.net/browse/CC-41154
- JIRA: https://confluentinc.atlassian.net/browse/CC-41244

## Testing details

### `mvn dependency:tree` (post-cleanup)

All netty-codec artifacts continue to resolve to `4.2.13.Final:compile`, identical to pre-cleanup:

```
io.netty:netty-codec:jar:4.2.13.Final:compile
io.netty:netty-codec-http:jar:4.2.13.Final:compile
io.netty:netty-codec-http2:jar:4.2.13.Final:compile
io.netty:netty-codec-compression:jar:4.2.13.Final:compile
```

### Built connector zip — netty + bcprov jars

```
bcprov-jdk18on-1.84.jar
netty-buffer-4.2.13.Final.jar
netty-codec-4.2.13.Final.jar
netty-codec-base-4.2.13.Final.jar
netty-codec-compression-4.2.13.Final.jar
netty-codec-http-4.2.13.Final.jar
netty-codec-http2-4.2.13.Final.jar
netty-codec-marshalling-4.2.13.Final.jar
netty-codec-protobuf-4.2.13.Final.jar
netty-common-4.2.13.Final.jar
netty-handler-4.2.13.Final.jar
netty-resolver-4.2.13.Final.jar
netty-transport-4.2.13.Final.jar
netty-transport-classes-epoll-4.2.13.Final.jar
netty-transport-native-unix-common-4.2.13.Final.jar
```

### Trivy scan

`trivy rootfs --severity HIGH,CRITICAL --ignore-unfixed` against the built package: **0 findings**. No netty / bcprov CVE regressions.

## Test plan

- [x] `mvn -Dcloud -pl kafka-connect-s3 -am dependency:tree` — netty artifacts resolve to 4.2.13.Final
- [x] `mvn -Dcloud -DskipTests package` builds cleanly
- [x] `trivy rootfs --severity HIGH,CRITICAL` reports 0 findings
- [ ] CI green
- [ ] KDP sanity test