### PR TITLE
CC-41910: Bumped io.netty version to 4.2.15.Final (#937)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <zookeeper.version>3.9.5</zookeeper.version>
         <dnsjava.version>3.6.1</dnsjava.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Problem
https://confluentinc.atlassian.net/browse/CC-41910
CVE in `io.netty:netty-handler:4.2.13.Final`

## Solution

Update netty.version to `4.2.15.Final`

```
> mvn dependency:tree -Dincludes=io.netty:netty-handler
[INFO] 
[INFO] --- dependency:3.3.0:tree (default-cli) @ kafka-connect-s3 ---
[INFO] io.confluent:kafka-connect-s3:jar:11.0.14-SNAPSHOT
[INFO] \- software.amazon.awssdk:netty-nio-client:jar:2.28.23:compile
[INFO]    \- io.netty:netty-handler:jar:4.2.15.Final:compile
```

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests
- [x] KDP ran in CI

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
