### PR TITLE
demo: do not review | CC-41637: Commit the frontier offset in the S3 sink to clear phantom lag and restart re-reads

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkConnectorConfig.java
@@ -200,6 +200,20 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
       + " is configured";
   public static final boolean ROTATE_FILE_ON_PARTITION_CHANGE_DEFAULT = true;
 
+  public static final String COMMIT_FRONTIER_OFFSET_CONFIG = "commit.frontier.offset.enable";
+  public static final boolean COMMIT_FRONTIER_OFFSET_DEFAULT = false;
+  public static final String COMMIT_FRONTIER_OFFSET_DOC =
+      "When enabled, preCommit reports the frontier offset per partition instead of only the offset"
+      + " of the last uploaded file. The frontier is the lowest Kafka offset of a record that is"
+      + " buffered but not yet uploaded to S3, or the consumed high-water mark when nothing is"
+      + " buffered. Everything below the frontier is decided (already uploaded, or dropped or"
+      + " filtered), so committing it clears the phantom lag that a partition otherwise shows when"
+      + " records are consumed but no file has rotated yet (idle partitions, runs of filtered or"
+      + " null-valued records, or buffers still under the flush size). Because S3 resumes from the"
+      + " committed Kafka offset on restart, committing the frontier never steps over a record that"
+      + " is still in flight. Defaults to false, which preserves the existing behavior.";
+  public static final String COMMIT_FRONTIER_OFFSET_DISPLAY = "Commit Frontier Offset";
+
   /**
    * Maximum back-off time when retrying failed requests.
    */
@@ -757,6 +771,18 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
           ++orderInGroup,
           Width.SHORT,
           "Rotate files on partition change"
+      );
+
+      configDef.define(
+          COMMIT_FRONTIER_OFFSET_CONFIG,
+          Type.BOOLEAN,
+          COMMIT_FRONTIER_OFFSET_DEFAULT,
+          Importance.LOW,
+          COMMIT_FRONTIER_OFFSET_DOC,
+          group,
+          ++orderInGroup,
+          Width.SHORT,
+          COMMIT_FRONTIER_OFFSET_DISPLAY
       );
 
       // This is done to avoid aggressive schema based rotations resulting out of interleaving
@@ -1416,6 +1442,10 @@ public class S3SinkConnectorConfig extends StorageSinkConnectorConfig {
 
   public boolean shouldRotateOnPartitionChange() {
     return getBoolean(ROTATE_FILE_ON_PARTITION_CHANGE);
+  }
+
+  public boolean isCommitFrontierOffsetEnabled() {
+    return getBoolean(COMMIT_FRONTIER_OFFSET_CONFIG);
   }
 
   public enum IgnoreOrFailBehavior {

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -352,12 +352,46 @@ public class S3SinkTask extends SinkTask {
   public Map<TopicPartition, OffsetAndMetadata> preCommit(
       Map<TopicPartition, OffsetAndMetadata> offsets
   ) {
+    if (connectorConfig.isCommitFrontierOffsetEnabled()) {
+      return preCommitFrontier(offsets);
+    }
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>();
     for (TopicPartition tp : topicPartitionWriters.keySet()) {
       Long offset = topicPartitionWriters.get(tp).getOffsetToCommitAndReset();
       if (offset != null) {
         log.trace("Forwarding to framework request to commit offset: {} for {}", offset, tp);
         offsetsToCommit.put(tp, new OffsetAndMetadata(offset));
+      }
+    }
+    return offsetsToCommit;
+  }
+
+  /**
+   * Computes the offset to commit per partition as the frontier rather than the offset of the last
+   * uploaded file. The frontier is the lowest Kafka offset of a record that is buffered but not
+   * yet uploaded to S3, or the consumed high-water mark from the {@code offsets} argument when
+   * nothing is buffered. Everything below the frontier is decided, so committing it clears the
+   * phantom lag that a partition otherwise carries when records are consumed but no file has
+   * rotated (idle partitions, runs of filtered or null-valued records, or buffers still under the
+   * flush size). Because S3 resumes from the committed Kafka offset on restart, committing the
+   * frontier never steps over an in-flight record.
+   */
+  private Map<TopicPartition, OffsetAndMetadata> preCommitFrontier(
+      Map<TopicPartition, OffsetAndMetadata> offsets
+  ) {
+    Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = new HashMap<>();
+    for (TopicPartition tp : topicPartitionWriters.keySet()) {
+      // The framework's consumed position includes offsets that never reached put(), such as
+      // SMT-filtered records, so it is the correct upper bound for a partition with nothing
+      // buffered. It may be absent for a partition the framework has not reported yet.
+      OffsetAndMetadata consumed = offsets.get(tp);
+      Long consumedHighWaterMark = consumed != null ? consumed.offset() : null;
+      Long frontier =
+          topicPartitionWriters.get(tp).getFrontierOffset(consumedHighWaterMark);
+      if (frontier != null) {
+        log.trace("Forwarding to framework request to commit frontier offset: {} for {}",
+            frontier, tp);
+        offsetsToCommit.put(tp, new OffsetAndMetadata(frontier));
       }
     }
     return offsetsToCommit;

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/TopicPartitionWriter.java
@@ -53,6 +53,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.TreeSet;
 
 import io.confluent.common.utils.SystemTime;
 import io.confluent.common.utils.Time;
@@ -103,6 +104,13 @@ public class TopicPartitionWriter {
   private Long baseRecordTimestamp;
   private Long offsetToCommit;
   private final RecordWriterProvider<S3SinkConnectorConfig> writerProvider;
+
+  // The set P of pending offsets: records that have been buffered for this partition but are not
+  // yet durable in S3. An offset is added when the record is buffered and removed once the file
+  // holding it has been committed. The frontier is min(P) when P is non-empty, so this stays
+  // ordered for a cheap first() lookup.
+  private final boolean commitFrontierOffset;
+  private final TreeSet<Long> pendingOffsets = new TreeSet<>();
 
   // VisibleForTesting
   Map<Long, String> offsetToFilenameMap;
@@ -204,6 +212,7 @@ public class TopicPartitionWriter {
         connectorConfig.getString(StorageSinkConnectorConfig.SCHEMA_COMPATIBILITY_CONFIG));
 
     buffer = new LinkedList<>();
+    commitFrontierOffset = connectorConfig.isCommitFrontierOffsetEnabled();
     commitFiles = new LinkedHashMap<>();
     writers = new HashMap<>();
     currentSchemas = new HashMap<>();
@@ -302,7 +311,9 @@ public class TopicPartitionWriter {
         throw new ConnectException(e);
       } catch (SchemaProjectorException e) {
         if (reporter != null) {
-          reporter.report(buffer.poll(), e);
+          SinkRecord errantRecord = buffer.poll();
+          markDecidedOffset(errantRecord);
+          reporter.report(errantRecord, e);
           log.warn("Errant record written to DLQ due to: {}", e.getMessage());
         } else {
           throw e;
@@ -366,7 +377,7 @@ public class TopicPartitionWriter {
         } catch (PartitionException e) {
           if (reporter != null) {
             reporter.report(record, e);
-            buffer.poll();
+            markDecidedOffset(buffer.poll());
             break;
           } else {
             throw e;
@@ -504,8 +515,11 @@ public class TopicPartitionWriter {
 
     SinkRecord projectedRecord = compatibility.project(record, null, currentValueSchema);
     boolean validRecord = writeRecord(projectedRecord, encodedPartition, record);
-    buffer.poll();
+    SinkRecord bufferedRecord = buffer.poll();
     if (!validRecord) {
+      // The record was faulty and went to the DLQ, so it is decided and leaves the pending set.
+      // It stays in the set on the valid path until the file holding it is committed.
+      markDecidedOffset(bufferedRecord);
       // skip the faulty record and don't rotate
       return false;
     }
@@ -585,12 +599,46 @@ public class TopicPartitionWriter {
 
   public void buffer(SinkRecord sinkRecord) {
     buffer.add(sinkRecord);
+    if (commitFrontierOffset) {
+      // Record the offset in the pending set the moment it is buffered, and before put() returns
+      // to the framework. This is the single place a record enters P, so no code path can accept a
+      // record without it becoming visible to the frontier computation.
+      pendingOffsets.add(sinkRecord.kafkaOffset());
+    }
+  }
+
+  /**
+   * Marks a buffered record as decided without uploading it, which happens when it is sent to the
+   * dead-letter queue or dropped by a partition error. The record will never be uploaded, so it
+   * leaves the pending set and stops holding the frontier back.
+   */
+  private void markDecidedOffset(SinkRecord sinkRecord) {
+    if (commitFrontierOffset && sinkRecord != null) {
+      pendingOffsets.remove(sinkRecord.kafkaOffset());
+    }
   }
 
   public Long getOffsetToCommitAndReset() {
     Long latest = offsetToCommit;
     offsetToCommit = null;
     return latest;
+  }
+
+  /**
+   * Returns the frontier offset to commit for this partition: the lowest offset of a record that
+   * is buffered but not yet uploaded, or the consumed high-water mark when nothing is buffered.
+   * Every offset below the frontier is decided, either already uploaded to S3, or dropped or
+   * filtered before it could be buffered, so committing it never steps over an in-flight record.
+   *
+   * @param consumedHighWaterMark the offset one past the last record the framework has handed to
+   *                              put() for this partition, as supplied by preCommit
+   * @return the frontier offset, or null when this partition has no consumed position to report
+   */
+  public Long getFrontierOffset(Long consumedHighWaterMark) {
+    if (!pendingOffsets.isEmpty()) {
+      return pendingOffsets.first();
+    }
+    return consumedHighWaterMark;
   }
 
   public Long currentStartOffset() {
@@ -976,6 +1024,12 @@ public class TopicPartitionWriter {
     }
 
     offsetToCommit = currentOffset + 1;
+    if (commitFrontierOffset) {
+      // Every offset at or below currentOffset has now been uploaded to S3 and is durable, so it
+      // leaves the pending set. The frontier then advances to the next record still in flight, or
+      // to the consumed high-water mark once nothing is left buffered.
+      pendingOffsets.headSet(currentOffset, true).clear();
+    }
     commitFiles.clear();
     currentSchemas.clear();
     offsetToFilenameMap.clear();


### PR DESCRIPTION
> Demonstration PR. Please do not review or merge. It exists to illustrate the decided-frontier approach for CC-41637.

## Summary

The S3 sink currently advances the committed Kafka offset only when a file rotates and is uploaded to S3.
When records are consumed but no file is uploaded, the committed offset freezes, and monitoring shows lag that never drains even though the connector is healthy.
This change adds an opt-in mode, controlled by a new config flag `commit.frontier.offset.enable` that defaults to false, in which `preCommit` reports the frontier offset per partition instead of only the offset of the last uploaded file.
The frontier is the lowest Kafka offset of a record that has been buffered but not yet uploaded, or the consumed high-water mark when nothing is buffered.
Everything below the frontier is decided, so committing it clears the phantom lag without ever committing past a record that is still in flight.

## The bug as it manifests in S3

The S3 sink buffers records in `put()` and only makes them durable when a file rotates and its upload commits.
The committable offset is derived from that rotation: `TopicPartitionWriter.commitFiles()` sets `offsetToCommit = currentOffset + 1`, where `currentOffset` is the highest offset written into the file that was just uploaded, and `preCommit` forwards that value through `getOffsetToCommitAndReset()`.
Nothing else advances the committed offset.

That leaves several ordinary situations where offsets are consumed but the committed offset does not move, so the partition carries a lag that never drains on its own.

- An idle partition that receives no new records never rotates a file, so its committed offset stays wherever the last upload left it, even though the consumer has caught up to the log end.
- A run of records dropped inside `put()` because their value is null and `behavior.on.null.values` is `ignore` never enters a file, so it never contributes to a rotation.
- Records removed by a Filter transform upstream never reach `put()` at all, so the connector cannot even name those offsets, yet the framework counts them as consumed.
- A buffer that is still below the flush size, and whose partition sees no time-based or scheduled rotation, holds real records that are consumed but not yet uploaded, so their offsets are neither committed nor lost, just stuck.

In every one of these cases the consumer group has moved forward but the committed offset has not, and the difference shows up as lag that looks like a stall.

For the S3 sink there is a second consequence that matters even more than the misleading metric.
On restart the S3 sink resumes from the committed Kafka offset.
Because the committed offset froze, a restart re-reads from the frozen position and reprocesses everything above it, including the records it already dropped or filtered, which is wasted work and, for a null-drop run, a repeat of the same decision.

## The frontier mechanism, mapped to S3

The fix rests on a single rule.
Never commit past a record that the connector intends to write to the end system and has not yet made durable.
Every offset at or below the committed offset must be decided, and decided means one of two things: the record was durably written, or the connector deliberately decided it will never be written, whether by dropping a null value, sending a record to the dead-letter queue, or having a Filter transform remove it before it arrived.

Rather than trying to enumerate every reason an offset became safe, which is impossible because filtered records never reach the connector, the rule is stated as a negative.
The only offsets that are not safe to commit are those whose records the connector intends to write and has not yet made durable.
Call that set of pending offsets P.
The frontier is then defined as:

    frontier = P.isEmpty() ? consumedHighWaterMark : min(P)

When a record is still in flight, the frontier is the lowest such offset, and everything below it is decided.
When nothing is in flight, the frontier is the consumed high-water mark, the farthest offset the connector could safely commit.
The frontier is committed as is, not `min(P) - 1`, because a committed offset names the next record to consume, so committing `min(P)` makes the lowest pending record be re-read after a restart, which is exactly the intended recovery point.

Mapping the abstract terms to the real S3 code:

- "durable" means a record written into a file that has been uploaded and committed to S3, which is the moment `commitFiles()` runs and sets `offsetToCommit`.
- "pending", the set P, means offsets of records that have been buffered but not yet uploaded, whether they are still sitting in the in-memory buffer or have already been written into an open file that has not yet rotated.

The implementation tracks P per `TopicPartitionWriter` in an ordered set.
An offset enters the set in `buffer(SinkRecord)`, which is the single place a record is accepted, so no code path can buffer a record without it becoming visible to the frontier computation.
An offset leaves the set in two ways.
When `commitFiles()` uploads files, every offset at or below the newly durable `currentOffset` is removed, because those records are now durable.
When a buffered record is instead sent to the dead-letter queue or dropped by a partition error, it is removed as well, because a drop is itself a decision and the record will never be uploaded, so it must not hold the frontier back.
The minimum of the set is then a cheap `first()` lookup, and `preCommit` uses it, falling back to the consumed high-water mark from its own argument when the set is empty.

Because the frontier is computed only from whether an offset was buffered and not yet made durable, the invisible filtered offsets and the dropped null offsets between the durable position and the frontier are stepped over without the connector ever having to name them.
If one of those offsets had actually been a real record still pending, it would be in P, and being lower than the current minimum it would have pulled the frontier down to itself, which is a contradiction, so every offset below the frontier is provably decided.

## Why S3 needs strictly less than a re-seek sink

This is the point of demonstrating the frontier idea on S3 specifically.
Sinks fall into two groups by how they recover on restart.

A re-seek sink, such as Snowflake, does not resume from the committed Kafka offset.
It resumes from its own external durable state, for example a channel offset token, and it re-seeks to that token plus one, ignoring the committed Kafka offset.
For such a sink, committing the frontier fixes the phantom lag in monitoring, but it does nothing for restart on its own, because restart consults the external token rather than the committed offset.
To make restart land on the frontier, a re-seek sink has to persist the frontier alongside the commit, in the offset metadata, and read it back on restart to seek to the maximum of the durable token and that recovery floor.
That requires extra recovery machinery: a metadata floor written on every commit, and an `open()`-time read and re-seek that consults it.

S3 is a non-re-seek sink.
On restart it resumes directly from the committed Kafka offset.
So the moment `preCommit` commits the frontier, both problems are solved at once.
The lag in monitoring reflects only genuine in-flight work, and a restart resumes from the committed offset, which is already the frontier, so it re-reads the lowest pending record and skips nothing that was not already decided.
There is no metadata floor to write, no `open()`-time read, and no re-seek to implement.
The single change in `preCommit` is the entire mechanism, and the connector runs on a stock Connect runtime.
This is the contrast worth stating plainly: the same frontier idea, but S3 needs strictly less than Snowflake because it recovers from the committed offset that the frontier already produces.

## Why it is data-loss-safe

Everything rests on one invariant: every consumed real record is, at every commit, either already durable in S3 or currently in the pending set P, never neither.

This holds from the order of operations in Connect and from where the pending set is populated.
The framework hands a batch to `put()`.
`put()` buffers each record it accepts, and buffering is exactly where the offset enters P, before `put()` returns.
Only after `put()` returns does the framework advance the consumed position that `preCommit` later reads.
So by the time any commit reads the consumed high-water mark, every real record below it that the connector accepted is already in P or already uploaded.
There is no window in which a consumed real record is missing from both, and that window is precisely what a data-loss bug would require.
The frontier, being the minimum of P or the consumed edge when P is empty, therefore never names an offset above a pending real record, so committing it can never step over a record that still needs to be written.

The drop paths preserve the invariant rather than breaking it.
A record removed to the dead-letter queue or dropped by a partition error is a decision, so it correctly leaves P, and because it will never be uploaded, leaving it in P would only pin the frontier and reintroduce a stall, never cause a loss.
A record written into an open file that has not yet rotated stays in P until `commitFiles()` makes it durable, so a crash before rotation leaves the committed offset at or below that record and it is re-read after restart.
On a retriable write error the sink discards the writer and rebuilds it, and the framework re-seeks and re-buffers, which repopulates P from the re-read, so the pending set is self-healing.

## Config flag and default-off safety

The behavior is gated by a new boolean config, `commit.frontier.offset.enable`, in the S3 config group, defaulting to false.
When it is false, the code path is byte-for-byte the existing one: `preCommit` calls `getOffsetToCommitAndReset()` per writer exactly as before, the pending set is never populated, and there is no behavioral or performance change.
When it is true, `preCommit` computes the frontier per partition as described.
Because the default is off, this change is inert for every existing connector until an operator opts in, which keeps the rollout safe and reversible by a single config edit.

## Test plan

- Unit tests on `TopicPartitionWriter` for the pending-set lifecycle: an offset enters the set on `buffer`, leaves on `commitFiles` for everything at or below the new durable offset, and leaves on a dead-letter or partition-error drop, so that `getFrontierOffset` returns `min(P)` when records are in flight and the supplied consumed high-water mark when the set is empty.
- Unit test on `S3SinkTask.preCommit` that with the flag off the committed offsets are identical to the current behavior, and with the flag on the committed offset for an idle or fully drained partition advances to the consumed high-water mark from the `preCommit` argument, while a partition with buffered-but-not-uploaded records commits `min(P)`.
- The worked scenario from the design note, driven end to end against a real bucket: a partition with a mix of uploaded records, null drops, filtered records, and buffered-not-uploaded records, asserting that the committed offset sits on the lowest buffered offset and ratchets forward as files rotate, reaching the consumed edge once the last buffered record is uploaded, with the stock connector visibly stuck by contrast.
- A restart test that exercises the non-re-seek recovery: with the flag on, kill the task while records are buffered but not uploaded, restart, and confirm the task resumes from the frontier, re-reads exactly the pending records, and does not reprocess the already-uploaded or already-dropped offsets below the frontier, and confirm no record is lost.
- A regression pass of the existing S3 sink test suite with the flag off to confirm the default path is unchanged.

## Where the code lives

The change is three files in `kafka-connect-s3`.

- `io/confluent/connect/s3/S3SinkConnectorConfig.java`: the new `commit.frontier.offset.enable` config key, its `ConfigDef` definition in the S3 group, and the `isCommitFrontierOffsetEnabled()` accessor.
- `io/confluent/connect/s3/TopicPartitionWriter.java`: the per-partition pending set P, populated in `buffer`, pruned in `commitFiles`, and pruned on the dead-letter and partition-error drop paths, plus `getFrontierOffset(consumedHighWaterMark)`.
- `io/confluent/connect/s3/S3SinkTask.java`: `preCommit` branches to `preCommitFrontier` when the flag is on, computing the frontier per partition from the pending set and the consumed position carried in its own argument.

## Build status

The `kafka-connect-s3` module compiles cleanly under JDK 11, including checkstyle validation.
