### PR TITLE
CC-42312: Bump storage-common-parent to 11.2.36 to fix jackson-databind CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>11.2.35</version>
+        <version>11.2.36</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION

## Problem

kafka-connect-storage-common-parent 11.2.35 pins jackson-databind to 2.18.6, flagged by CVE tracked in CC-42312. 

## Solution

Bumping to 11.2.36 pulls in jackson-databind 2.21.4 


<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [ ] yes
- [ ] no

##### If yes, where?


## Test Strategy


<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [ ] Unit tests
- [ ] Integration tests
- [ ] System tests
- [ ] Manual tests

## Release Plan
<!--- Describe the release plan for this feature. -->
<!-- Are you backporting or merging to master? -->
<!-- If you are reverting or rolling back, is it safe? --> 
