### PR TITLE
CC-41520: bump commons-configuration2 to 2.15.0 (CVE-2026-45205)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -311,7 +311,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-configuration2</artifactId>
-            <version>2.10.1</version>
+            <version>2.15.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
## Problem

`CC-41520` flags `org.apache.commons:commons-configuration2:2.10.1` — **CVE-2026-45205** (MEDIUM): Apache Commons Configuration uncontrolled recursion → `StackOverflowError` on cyclic YAML input (affects 2.2 before 2.15.0), fixed in `2.15.0`. Impacted `kafka-connect-s3` versions: 10.6.15–10.6.17, 11.0.13–11.0.16, 12.1.5–12.1.8.

`commons-configuration2` is pulled transitively via the Hadoop stack, and its version is **forced by this repo's root pom `<dependencyManagement>`** (hardcoded `2.10.1`) — so a single managed bump remediates the packaged `kafka-connect-s3` artifact.

## Solution

Bump the managed `commons-configuration2` version `2.10.1 → 2.15.0` in the root pom `<dependencyManagement>`. 2.15.0 is the fixed version per the advisory and is a backward-compatible upgrade on the 2.x line.

<!--- Mark x in the box. -->
##### Does this solution apply anywhere else?
- [x] yes
- [ ] no

##### If yes, where?

Forward-merges from `10.6.x` to `11.0.x` / `12.0.x` / `12.1.x` (and up) via pint.

## Test Strategy

- Resolved graph: `commons-configuration2:2.15.0` (compile) in `kafka-connect-s3`.
- **Trivy (before):** packaged `lib/` bundled `commons-configuration2-2.10.1.jar` → `CVE-2026-45205` flagged.
- **Trivy (after):** `lib/` bundles `commons-configuration2-2.15.0.jar`; **`CVE-2026-45205` no longer reported** (only an unrelated MEDIUM remains).
  ```
  trivy --skip-files "*.zip" rootfs --scanners vuln --severity CRITICAL,HIGH,MEDIUM,LOW target/components/packages
  ```
- **Unit tests:** 248 run / 247 pass / **1 flaky failure** (Temurin 11). The single failure is `S3SinkConnectorFaultyS3Test.testErrorIsRetriedByConnectFramework` — a timing-sensitive fault-injection/retry test (60s timeout, ~70 repeats: *"Files not written to S3 bucket in time"*) that flaked under local build load. It is **unrelated to the commons-configuration2 bump** (a Hadoop config-parsing library with no path to S3 write-retry timing); CI runs it in a clean environment.
- **Integration / KDP:** the S3-sink IT and `s3-sink.sh` KDP require live AWS credentials + an S3 bucket — run in CI. `commons-configuration2` is a transitive, backward-compatible patch (Hadoop config parsing), so no connector code path changes.

<!--- Mark x in the box for all that apply. -->
##### Testing done:
- [x] Unit tests
- [ ] Integration tests
- [ ] System tests
- [x] Manual tests

## Release Plan

Merge to `10.6.x`; pint forward-merges to `11.0.x` / `12.x`. Cut new `kafka-connect-s3` releases. Build-only change (one managed version) — safe to roll back.


---

## Validation update — CI, KDP, dependency tree (2026-07-22)

**CI (Semaphore) — ✅ PASS** (after re-run: pipeline `a24973fe`).
- The initial run failed on a **transient Maven dependency-resolution race** — `java.util.ConcurrentModificationException` while collecting `io.confluent:kafka-connect-protobuf-converter:[7.7.8-0,7.7.9-0)` in the `kafka-connect-s3` child module. This is unrelated to the commons-configuration2 bump (the parent module built SUCCESS; no test ran). Re-triggering the workflow produced a clean green build.
- **Connector Kafka Docker Playground (KDP)** block: ✅ **PASSED** (job `0524cb8c`) — KDP ran on this PR commit `37e05ba` with the commons-configuration2 bump included (it passed even on the initial pipeline, since it runs independently of the unit-Test block).

**Dependency tree (after — resolved graph):**
```
\- org.apache.commons:commons-configuration2:jar:2.15.0:compile
```
Resolved to **commons-configuration2 → 2.15.0** (CC-41520 / CVE-2026-45205) across the `kafka-connect-s3` modules.


---

## Local KDP re-run — s3-sink end-to-end (2026-07-23)

Re-ran the AWS **S3 sink** KDP (`connect/connect-aws-s3-sink/s3-sink.sh`) locally on **CP 8.1.0** against the connector built from this PR — `confluentinc-kafka-connect-s3-10.6.18-SNAPSHOT.zip` (installed via `--connector-zip`). Verified the zip bundles this PR's fix:
```
lib/commons-configuration2-2.15.0.jar
```

**Result: ✅ `RESULT: SUCCESS`.**
- Connector `s3-sink` (`io.confluent.connect.s3.S3SinkConnector`, v10.6.18-SNAPSHOT) deployed; task `0:🟢 RUNNING[connect]`.
- Produced 10 records (`{"f1":"value1"}`…`{"f1":"value10"}`) to `s3_topic`; the sink wrote them to S3 as Avro (flush.size=3) — confirmed via `aws s3 ls`:
  ```
  s3_topic+0+0000000000.avro   213
  s3_topic+0+0000000003.avro   213
  s3_topic+0+0000000006.avro   213
  ```
- Read an object back from S3: schema `myrecord {f1: string}`, values `value1`…`value3` — round-trip verified (bucket `pgbucket<user>`, region `us-east-1`, acct `037803949979`).

<details>
<summary><b>KDP run log (excerpts)</b></summary>

```text
$ AWS_REGION=us-east-1 playground run -f s3-sink.sh \
    --connector-zip confluentinc-kafka-connect-s3-10.6.18-SNAPSHOT.zip

ℹ️ 💫 Using default CP version 8.1.0
Installing a component Kafka Connect S3 10.6.18-SNAPSHOT, provided by Confluent, Inc.
   from the local file: /tmp/confluentinc-kafka-connect-s3-10.6.18-SNAPSHOT.zip

# connector deployed
playground connector create-or-update --connector s3-sink
   (io.confluent.connect.s3.S3SinkConnector, version 10.6.18-SNAPSHOT)
s3-sink                        ✅ RUNNING  0:🟢 RUNNING[connect]

# produced 10 records to topic s3_topic
{"f1":"value1"} ... {"f1":"value10"}

# objects written to S3  (aws s3 ls s3://<bucket>/8.1.0/s3_topic/partition=0/)
s3_topic+0+0000000000.avro   213
s3_topic+0+0000000003.avro   213
s3_topic+0+0000000006.avro   213

# read back from S3  (playground tools read-avro-file)
avro.schema  {"type":"record","name":"myrecord","fields":[{"name":"f1","type":"string"}],
              "connect.version":1,"connect.name":"myrecord"}
{"f1":"value1"}
{"f1":"value2"}
{"f1":"value3"}

ℹ️ ✅ RESULT: SUCCESS for s3-sink.sh (took: 1min 25sec)
```
</details>

_Notes: the S3 bucket already existed in `us-east-1`, so the run used `AWS_REGION=us-east-1` to match it (a mismatched region otherwise yields an S3 `301 PermanentRedirect`, unrelated to the connector). commons-configuration2 is a Hadoop config-parsing dependency with no S3 write path, so this bump is transparent to the sink — confirmed by the clean round-trip._
