### PR TITLE
CC-43150: Upgrade netty 4.2.15.Final -> 4.2.16.Final to fix CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <zookeeper.version>3.9.5</zookeeper.version>
         <dnsjava.version>3.6.1</dnsjava.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <netty.version>4.2.16.Final</netty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Summary
Upgrades the pinned `netty.version` property from `4.2.15.Final` to `4.2.16.Final`, fixing three tracked CVEs on `kafka-connect-s3`:

- [CC-43150](https://confluentinc.atlassian.net/browse/CC-43150) — `io.netty:netty-codec-compression:4.2.15.Final`
- [CC-43148](https://confluentinc.atlassian.net/browse/CC-43148) — `io.netty:netty-codec-http2:4.2.15.Final`
- [CC-43149](https://confluentinc.atlassian.net/browse/CC-43149) — `io.netty:netty-codec-http:4.2.15.Final`

`netty-codec-compression` is a transitive dependency of `netty-codec-http` (same upstream release train), so bumping the shared `netty.version` property resolves all three.

## Verification

**Dependency tree** — confirms all three now resolve to 4.2.16.Final:
```
$ mvn -pl kafka-connect-s3 dependency:tree -Dincludes=io.netty:netty-codec-http,io.netty:netty-codec-http2,io.netty:netty-codec-compression
[INFO] +- io.netty:netty-codec-http:jar:4.2.16.Final:compile
[INFO] |  \- io.netty:netty-codec-compression:jar:4.2.16.Final:compile
[INFO] \- io.netty:netty-codec-http2:jar:4.2.16.Final:compile
```

**Trivy scan** — `trivy rootfs --scanners vuln .` after `mvn clean install -DskipTests`: no netty-related CVEs remain (all netty jars report 0 vulnerabilities). Remaining findings in the repo (lz4-java, commons-lang) are unrelated to this change / these tickets.

**Unit tests** — `mvn -pl kafka-connect-s3 test`: 295 tests run, 5 pre-existing failures (confirmed to also fail on unmodified `11.0.x` base branch — AWS region provider config, PowerMock internal error, JAXB `getSubject`, type-creation issue — all unrelated to netty). No new failures introduced by this upgrade.

**Local KDP e2e** — not run: the sandbox used for this fix has no AWS credentials configured (`~/.aws/credentials`), which the `s3-sink.sh` script requires to reach real S3. The custom-built JAR was successfully swapped into the connector before that check, confirming it loads correctly.

## Test plan
- [x] `mvn dependency:tree` shows netty-codec-http/http2/compression at 4.2.16.Final
- [x] `trivy rootfs --scanners vuln .` shows no netty CVEs
- [x] `mvn test` — no new regressions vs base branch
- [ ] KDP end-to-end `s3-sink.sh` (blocked locally by missing AWS credentials; recommend running in CI or an environment with AWS access before merge)

[CC-43150]: https://confluentinc.atlassian.net/browse/CC-43150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-43148]: https://confluentinc.atlassian.net/browse/CC-43148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CC-43149]: https://confluentinc.atlassian.net/browse/CC-43149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ