### PR TITLE
Close only revoked partition writers in S3 sink task (10.6.x backport for Databricks Delta Lake)

### DIFF
--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -15,7 +15,7 @@
 
 package io.confluent.connect.s3;
 
-3import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonClientException;
 import io.confluent.connect.s3.S3SinkConnectorConfig.OutputWriteBehavior;
 import io.confluent.connect.s3.util.TombstoneSupportedPartitioner;
 import io.confluent.connect.s3.util.SchemaPartitioner;
@@ -276,9 +276,8 @@ public class S3SinkTask extends SinkTask {
   }
 
   /**
-   * Retrieves the TopicPartitionWriter for the given TopicPartition.
-   * If no writer is found, it indicates a mismatch between the record's topic partition
-   * and the assigned partitions.
+   * Retrieves the TopicPartitionWriter for the given TopicPartition, lazily creating one if the
+   * partition is currently assigned to this task but its writer was not created yet.
    *
    * @param tp the TopicPartition to get the writer for
    * @return the TopicPartitionWriter

--- a/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
+++ b/kafka-connect-s3/src/main/java/io/confluent/connect/s3/S3SinkTask.java
@@ -15,7 +15,7 @@
 
 package io.confluent.connect.s3;
 
-import com.amazonaws.AmazonClientException;
+3import com.amazonaws.AmazonClientException;
 import io.confluent.connect.s3.S3SinkConnectorConfig.OutputWriteBehavior;
 import io.confluent.connect.s3.util.TombstoneSupportedPartitioner;
 import io.confluent.connect.s3.util.SchemaPartitioner;
@@ -282,11 +282,18 @@ public class S3SinkTask extends SinkTask {
    *
    * @param tp the TopicPartition to get the writer for
    * @return the TopicPartitionWriter
-   * @throws ConnectException if no writer is found
+   * @throws ConnectException if the partition is not currently assigned to this task
    */
   private TopicPartitionWriter getTopicPartitionWriterOrThrow(TopicPartition tp)
       throws ConnectException {
     TopicPartitionWriter writer = topicPartitionWriters.get(tp);
+    if (writer == null && context.assignment().contains(tp)) {
+      // Assignment can be applied before this task's writer map catches up; create the
+      // missing writer instead of failing on an otherwise valid, currently-assigned partition.
+      log.warn("No writer yet for newly assigned topic partition {}. Creating one now.", tp);
+      writer = newTopicPartitionWriter(tp);
+      topicPartitionWriters.put(tp, writer);
+    }
     if (writer == null) {
       String errorMsg = String.format(
           "No writer found for topic partition %s. "
@@ -365,14 +372,18 @@ public class S3SinkTask extends SinkTask {
 
   @Override
   public void close(Collection<TopicPartition> partitions) {
-    for (TopicPartition tp : topicPartitionWriters.keySet()) {
-      try {
-        topicPartitionWriters.get(tp).close();
-      } catch (ConnectException e) {
-        log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
+    // Only close writers for the partitions actually being revoked; revocation can be partial
+    // and the retained partitions keep receiving records without a fresh open().
+    for (TopicPartition tp : partitions) {
+      TopicPartitionWriter writer = topicPartitionWriters.remove(tp);
+      if (writer != null) {
+        try {
+          writer.close();
+        } catch (ConnectException e) {
+          log.error("Error closing writer for {}. Error: {}", tp, e.getMessage());
+        }
       }
     }
-    topicPartitionWriters.clear();
   }
 
   @Override

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -38,8 +38,10 @@ import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import io.confluent.connect.s3.format.avro.AvroUtils;
 import io.confluent.connect.s3.storage.S3Storage;
@@ -49,6 +51,7 @@ import io.confluent.connect.storage.partitioner.DefaultPartitioner;
 import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -299,6 +302,33 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
     }
   }
 
+  @Test
+  public void testPutRecordForPartitionInAssignmentButNotYetOpenedCreatesWriter()
+      throws Exception {
+    setUp();
+    replayAll();
+    task = new S3SinkTask();
+    task.initialize(context);
+    task.start(properties);
+    verifyAll();
 
+    // Simulate the assignment already including a new partition before task.open() has run
+    // for it, without going through task.open() itself.
+    Set<TopicPartition> expandedAssignment = new HashSet<>(context.assignment());
+    expandedAssignment.add(TOPIC_PARTITION3);
+    context.setAssignment(expandedAssignment);
+
+    List<SinkRecord> sinkRecords =
+        createRecordsWithPrimitive(3, 0, Collections.singleton(TOPIC_PARTITION3));
+    task.put(sinkRecords);
+
+    assertNotNull(task.getTopicPartitionWriter(TOPIC_PARTITION3));
+
+    task.close(context.assignment());
+    task.stop();
+
+    long[] validOffsets = {0, 3};
+    verify(sinkRecords, validOffsets, Collections.singleton(TOPIC_PARTITION3), true);
+  }
 }
 

--- a/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
+++ b/kafka-connect-s3/src/test/java/io/confluent/connect/s3/S3SinkTaskTest.java
@@ -37,6 +37,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.ByteArrayInputStream;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -52,6 +53,7 @@ import io.confluent.connect.storage.partitioner.PartitionerConfig;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -329,6 +331,54 @@ public class S3SinkTaskTest extends DataWriterAvroTest {
 
     long[] validOffsets = {0, 3};
     verify(sinkRecords, validOffsets, Collections.singleton(TOPIC_PARTITION3), true);
+  }
+
+  /**
+   * close() may revoke only a subset of the assigned partitions; the retained partitions must
+   * keep their writers and buffered state since they never go through open() again.
+   */
+  @Test
+  public void testPartialRevocationPreservesRetainedPartitionState() throws Exception {
+    setUp();
+    task = new S3SinkTask(connectorConfig, context, storage, partitioner, format, SYSTEM_TIME);
+
+    // Default assignment (from the test harness) is {TOPIC_PARTITION, TOPIC_PARTITION2}.
+    Set<TopicPartition> originalAssignment = new HashSet<>(context.assignment());
+    assertTrue(originalAssignment.contains(TOPIC_PARTITION));
+    assertTrue(originalAssignment.contains(TOPIC_PARTITION2));
+
+    // Buffer 2 records into TOPIC_PARTITION2, one below its flush size (3), so its writer is
+    // left holding an open, uncommitted file.
+    List<SinkRecord> tp2RecordsPart1 =
+        createRecordsWithPrimitive(2, 0, Collections.singleton(TOPIC_PARTITION2));
+    task.put(tp2RecordsPart1);
+
+    TopicPartitionWriter tp2WriterBeforeClose = task.getTopicPartitionWriter(TOPIC_PARTITION2);
+    assertNotNull(tp2WriterBeforeClose);
+
+    // Partial revocation: only TOPIC_PARTITION is revoked, TOPIC_PARTITION2 stays assigned.
+    task.close(Collections.singleton(TOPIC_PARTITION));
+
+    // The retained partition's writer must survive a close() call that didn't name it.
+    assertSame(
+        "close() must not tear down writers for partitions that were not actually revoked",
+        tp2WriterBeforeClose,
+        task.getTopicPartitionWriter(TOPIC_PARTITION2)
+    );
+
+    // All 3 records must land in one file starting at offset 0; a wiped writer would have
+    // started a fresh file at offset 2 with only 1 record.
+    List<SinkRecord> tp2RecordsPart2 =
+        createRecordsWithPrimitive(1, 2, Collections.singleton(TOPIC_PARTITION2));
+    task.put(tp2RecordsPart2);
+
+    task.close(Collections.singleton(TOPIC_PARTITION2));
+    task.stop();
+
+    List<SinkRecord> tp2AllRecords = new ArrayList<>(tp2RecordsPart1);
+    tp2AllRecords.addAll(tp2RecordsPart2);
+    long[] validOffsets = {0, 3};
+    verify(tp2AllRecords, validOffsets, Collections.singleton(TOPIC_PARTITION2), true);
   }
 }
 


### PR DESCRIPTION
## Summary
- Backport of the fix in #950 onto the `10.6.x` line (AWS SDK v1), since the Databricks Delta Lake connector pins `kafka-connect-s3` here and its own code depends directly on `com.amazonaws.*` classes that #950's `12.1.x` base no longer has.
- `close()` used to clear every writer regardless of which partitions were actually revoked. Under KIP-848's new consumer protocol, revocation can be partial, so this wiped out writers for partitions the task still owned.
- Also makes `getTopicPartitionWriterOrThrow` create a writer lazily if a record arrives for a partition that's already assigned but not yet opened, instead of failing the task.

## Test plan
- [x] `mvn test-compile` passes
- [x] Compiles and passes all tests when consumed by `kafka-connect-databricks-delta-lake` on its own partial-revocation fix branch