### PR TITLE
[Common BOM] Remove explicit easymock.version override, inherit from parent chain

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -419,7 +419,6 @@
         <dependency>
             <groupId>org.easymock</groupId>
             <artifactId>easymock</artifactId>
-            <version>${easymock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Removes the explicit `<version>${easymock.version}</version>` override on `org.easymock:easymock` (plain `<dependencies>`, not `dependencyManagement`), letting it resolve from the parent chain instead.

## Not BOM-backed, and why that's OK here
Unlike most repos in this cleanup, this one's parent chain doesn't reach `confluent-common-bom`. `kafka-connect-storage-cloud` parents off `kafka-connect-storage-common-parent` (`12.0.12`), which itself pins `common [7.7.11, 7.7.12)` — a release that predates `confluent-common-bom`'s adoption entirely. Checked the latest published `kafka-connect-storage-common-parent` (`12.0.13`, one patch ahead of what this repo pins) — it's still on `common [7.7.11, 7.7.12)`, so this isn't a stale-branch issue on this repo's side (`master` is its only branch); the whole `kafka-connect-storage-common-parent` lineage hasn't been bumped to track `common`'s `8.x` line yet.

The removal is still a safe no-op — `common`'s own `dependencyManagement` at that version supplies the same `5.2.0` value either way, verified below.

## Verification
- `mvn -N validate` passes locally
- `mvn help:effective-pom` confirms `easymock` still resolves to `5.2.0`

## Tracking
Part of the `easymock.version` cleanup step in the [Common Inheritance Map — Cleanup Plan](https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82) audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)