### PR TITLE
[Common BOM] Remove powermock.version property override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,7 +425,6 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-module-junit4</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -436,7 +435,6 @@
         <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-api-mockito2</artifactId>
-            <version>${powermock.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Removes the `powermock.version` override for `org.powermock:powermock-module-junit4` and `org.powermock:powermock-api-mockito2` (both plain `<dependency>` entries, so only the `<version>` lines needed to go — they inherit from the parent chain).
- `common`'s own `dependencyManagement` pins both at `${powermock.version}` = `2.0.9`, matching `confluent-common-bom`'s managed value exactly, so this is a no-op version change.
- Note: like the earlier `easymock.version` cleanup on this repo (#956), this is NOT actually BOM-backed end-to-end — `kafka-connect-storage-common-parent` (this repo's parent) is stuck pinning `common [7.7.11, 7.7.12)`, a structural gap unrelated to this change. The version still resolves correctly through `common`'s own `dependencyManagement`.
- Verified locally via `mvn -N validate` and `mvn help:effective-pom` (both resolve to `2.0.9`, unchanged).

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn help:effective-pom` confirms `powermock-module-junit4`/`powermock-api-mockito2` resolve to `2.0.9` (unchanged)
- [ ] CI green