### PR TITLE
[Common BOM] Remove avro.version property override

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -491,7 +491,6 @@
         <dependency>
             <groupId>org.apache.avro</groupId>
             <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
         </dependency>
         <dependency>
             <groupId>dnsjava</groupId>


### PR DESCRIPTION
## Summary
- Removes the `avro.version` override for `org.apache.avro:avro` (a plain `<dependency>`, so only the `<version>` line needed to go — it inherits from the parent chain).
- Note: like the earlier `easymock.version`/`powermock.version` cleanups on this repo (#956, #957), this is NOT actually BOM-backed end-to-end — `kafka-connect-storage-common-parent` (this repo's parent) is stuck pinning a pre-BOM `common` release, a structural gap unrelated to this change. The version still resolves correctly through the parent chain's own property.
- Verified locally via `mvn -N validate` and `mvn help:effective-pom` (resolves to `1.11.5`, unchanged).

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn help:effective-pom` confirms `avro` resolves to `1.11.5` (unchanged)
- [ ] CI green