### PR TITLE
[Common BOM] Remove jetty.version overrides

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,37 +335,31 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-http</artifactId>
-            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-io</artifactId>
-            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-client</artifactId>
-            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-util</artifactId>
-            <version>${jetty.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Summary
- Removes the `jetty.version` override for 6 plain `<dependency>` entries (`jetty-http`, `jetty-io`, `jetty-servlet`, `jetty-server`, `jetty-client`, `jetty-util`, all test-scoped).
- Note: like the earlier `easymock.version`/`powermock.version`/`avro.version` cleanups on this repo (#956, #957, #958), this is NOT actually BOM-backed end-to-end — `kafka-connect-storage-common-parent` (this repo's parent) is stuck pinning a pre-BOM `common` release, a structural gap unrelated to this change. The version still resolves correctly through the parent chain's own property.
- Verified locally via `mvn -N validate` and `mvn help:effective-pom` (all 6 resolve to `9.4.59`, unchanged).

## Tracking
Part of the `common` dependency-property cleanup effort: https://claude.ai/code/artifact/854856e4-47a3-4455-9e22-326715a12c82

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn help:effective-pom` confirms all 6 jetty artifacts resolve to `9.4.59` (unchanged)
- [ ] CI green