### PR TITLE
CC-44610: Upgrade netty-handler to 4.2.17.Final

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -129,6 +129,12 @@
             <artifactId>netty-codec</artifactId>
             <version>${netty.version}</version>
         </dependency>
+        <!--        pin version to fix CVE-2026-75595, CVE-2026-75596-->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
         <dependency>
             <groupId>io.findify</groupId>
             <artifactId>s3mock_2.12</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <zookeeper.version>3.9.5</zookeeper.version>
         <dnsjava.version>3.6.1</dnsjava.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
-        <netty.version>4.2.16.Final</netty.version>
+        <netty.version>4.2.17.Final</netty.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Summary
- Bumped `io.netty:netty-handler` from `4.2.16.Final` to `4.2.17.Final` to fix CVE-2026-75595 (CRITICAL) and CVE-2026-75596 (MEDIUM)
- `netty-handler` is pulled in transitively via `software.amazon.awssdk:netty-nio-client` (resolved through the AWS SDK BOM, not directly declared). Pinned it directly in `kafka-connect-s3/pom.xml` to `${netty.version}`, matching the existing pattern already used for `netty-codec`, `netty-codec-http`, and `netty-codec-http2`. Also bumped the shared `netty.version` property in the root `pom.xml`.

## CVE Details
- **Jira**: [CC-44610](https://confluentinc.atlassian.net/browse/CC-44610)
- **Linked CVEs**: [CVE-25747](https://confluentinc.atlassian.net/browse/CVE-25747), [CVE-25748](https://confluentinc.atlassian.net/browse/CVE-25748) (kafka-connect-s3:11.0.18)
- **Impacted versions**: `kafka-connect-s3:11.0.18`
- **Vulnerable**: `io.netty:netty-handler:4.2.16.Final` (transitive, via `netty-nio-client`)
- **Fixed**: `io.netty:netty-handler:4.2.17.Final` (pinned directly in dependency list)

## Test Results

### Trivy CVE Scan
**Command**: `trivy rootfs --scanners vuln .`

Before fix:
```
io.netty:netty-handler (netty-handler-4.2.16.Final.jar)   CVE-2026-75595   CRITICAL
io.netty:netty-handler (netty-handler-4.2.16.Final.jar)   CVE-2026-75596   MEDIUM
```

After fix — no matches for netty-handler CVEs:
```
$ grep -i "netty-handler" trivy_after.txt | grep CVE
(no output)
```
**Result: CLEAN — CVE-2026-75595 / CVE-2026-75596 no longer detected**

### Dependency Tree Verification
**Command**: `mvn -pl kafka-connect-s3 dependency:tree -Dincludes=io.netty:netty-handler`
```
[INFO] io.confluent:kafka-connect-s3:jar:11.0.19-SNAPSHOT
[INFO] \- io.netty:netty-handler:jar:4.2.17.Final:compile
```

### Unit Tests — 295 tests, 0 new failures
**Command**: `mvn test`
```
Tests run: 295, Failures: 0, Errors: 5, Skipped: 0
```
All 5 errors are pre-existing environment/local-setup issues (PowerMock internal error, missing local `AWS_REGION`, JAAS `getSubject` unsupported) — confirmed identical on the unmodified `11.0.x` base branch before this change, unrelated to the netty upgrade.
All tests pass on CI build

### KDP Sink Test
**Command**: `playground run -f ./minio-sink.sh --connector-jar /Users/subhashiyer/work/kafka-connect-storage-cloud/kafka-connect-s3/target/components/kafka-connect-s3-11.0.19-SNAPSHOT.jar --environment plaintext`
```
11:48:20 produced 10 records to topic minio_topic, took: 0min 2sec
Listing objects of bucket mybucket in Minio
[2026-09-10 06:18:20 UTC]   213B STANDARD topics/minio_topic/partition=0/minio_topic+0+0000000000.avro
[2026-09-10 06:18:20 UTC]   213B STANDARD topics/minio_topic/partition=0/minio_topic+0+0000000003.avro
[2026-09-10 06:18:20 UTC]   213B STANDARD topics/minio_topic/partition=0/minio_topic+0+0000000006.avro
minio_topic+0+0000000000.avro content:
{"f1":"value1"}
{"f1":"value2"}
{"f1":"value3"}
####################################################
RESULT: SUCCESS for minio-sink.sh (took: 1min 28sec)
####################################################
```

[CC-44610]: https://confluentinc.atlassian.net/browse/CC-44610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CVE-25747]: https://confluentinc.atlassian.net/browse/CVE-25747?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CVE-25748]: https://confluentinc.atlassian.net/browse/CVE-25748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ