### PR TITLE
CC-42057: bump kafka-connect-storage-common parent to 12.0.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-common-parent</artifactId>
-        <version>12.0.12</version>
+        <version>12.0.14</version>
     </parent>
 
     <groupId>io.confluent</groupId>


### PR DESCRIPTION
Bump the `kafka-connect-storage-common-parent` from `12.0.12` → `12.0.14` to pick up the CP 8.4 fix.

**Why:** on Apache Kafka 4.x, `org.apache.kafka.common.utils.AppInfoParser` moved to `...utils.internals.AppInfoParser` and the old path was removed, so `SchemaSourceConnector.version()` threw `NoClassDefFoundError` during Connect's plugin scan on CP 8.4 workers. storage-common [#492](https://github.com/confluentinc/kafka-connect-storage-common/pull/492) fixed this by reading `/kafka/kafka-version.properties` as a classpath resource instead, referencing no Kafka class — so a single jar works on both 8.3 and 8.4. Released as `v12.0.14`.


Supersedes [#960](https://github.com/confluentinc/kafka-connect-storage-cloud/pull/960), which made the same change directly against `master`.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
