### PR TITLE
Resolve merge conflict in PR #965 (12.1.x -> master)

### DIFF
--- a/kafka-connect-s3/pom.xml
+++ b/kafka-connect-s3/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.confluent</groupId>
         <artifactId>kafka-connect-storage-cloud</artifactId>
-        <version>12.0.0-SNAPSHOT</version>
+        <version>12.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kafka-connect-s3</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <groupId>io.confluent</groupId>
     <artifactId>kafka-connect-storage-cloud</artifactId>
     <packaging>pom</packaging>
-    <version>12.0.0-SNAPSHOT</version>
+    <version>12.2.0-SNAPSHOT</version>
     <name>kafka-connect-storage-cloud</name>
     <organization>
         <name>Confluent, Inc.</name>
@@ -50,7 +50,7 @@
         <connection>scm:git:git://github.com/confluentinc/kafka-connect-storage-cloud.git</connection>
         <developerConnection>scm:git:git@github.com:confluentinc/kafka-connect-storage-cloud.git</developerConnection>
         <url>https://github.com/confluentinc/kafka-connect-storage-cloud</url>
-        <tag>12.1.x</tag>
+        <tag>12.0.x</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <zookeeper.version>3.9.5</zookeeper.version>
         <dnsjava.version>3.6.1</dnsjava.version>
         <commons.lang3.version>3.18.0</commons.lang3.version>
-        <netty.version>4.2.13.Final</netty.version>
+        <netty.version>4.2.15.Final</netty.version>
     </properties>
 
     <repositories>

--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 name: kafka-connect-storage-cloud
 lang: java
-lang_version: 8
+lang_version: "8"
 git:
   enable: true
 codeowners:
@@ -9,7 +9,6 @@ semaphore:
   enable: true
   pipeline_type: cp
   trivy_scan: true
-
   extra_deploy_args: "-Dcloud -Pjenkins"
   extra_build_args: "-Dcloud -Pjenkins"
   run_pint_merge: true


### PR DESCRIPTION
## Summary
- Merges master into `pr_merge_from_12_1_x_to_master` to resolve the version conflict blocking #965.
- Both `pom.xml` and `kafka-connect-s3/pom.xml` conflicted on the module version (`12.1.11-SNAPSHOT` from 12.1.x vs `12.2.0-SNAPSHOT` from master); resolved by keeping master's `12.2.0-SNAPSHOT`.

## Test plan
- [x] `mvn -N validate` passes
- [x] `mvn -pl kafka-connect-s3 -am compile` passes